### PR TITLE
Adjust CSS to fix bug where last element became unaligned

### DIFF
--- a/src/app/components/header-stats/header-stats.component.css
+++ b/src/app/components/header-stats/header-stats.component.css
@@ -57,14 +57,14 @@ mat-card-subtitle {
 
 
 section {
-  display: flex;
-  flex-wrap: wrap;
-  flex-direction: row;
+  padding: 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 160px);
+  justify-content: space-around;
 }
 
-
-section::after {
-  content: '';
-  width: 25%;
-  flex: auto;
+@media only screen and (min-width: 768px) {
+  section {
+    grid-gap: 1rem 6rem;
+  }
 }

--- a/src/app/components/header-stats/header-stats.component.html
+++ b/src/app/components/header-stats/header-stats.component.html
@@ -16,8 +16,6 @@
             {{stat.getDisplayValue()}} {{stat.getDisplayUnit()}}
           </mat-card-title>
         </mat-card-header>
-        <section>
-        </section>
       </mat-card>
     </section>
   </mat-card-subtitle>


### PR DESCRIPTION
Activity details such as "Duration", "Moving time", "Distance", etc. currently have a minor bug where, in certain circumstances, the last element is not positioned correctly. For my user I'm able to reproduce this error by viewing "Hiking" activities (possibly others as well). Se "Total training effect" in images below for example. 

![current-offset](https://user-images.githubusercontent.com/22277624/110486315-d2ab2200-80ec-11eb-9bd8-d42d9e37c1b0.png)
_

![current-offsett-small](https://user-images.githubusercontent.com/22277624/110486321-d474e580-80ec-11eb-8e16-49ddd9f30276.png)

Link to a public activity which has this issue: 
https://quantified-self.io/user/DUrrVK0qMVZO5TtAP0r6Ox2HVLD2/event/21715c3d0b84c115946ea0106f12ddd0f5c799310121b6a12e65d5b600bf5d88

In this PR I'm suggesting changes to the CSS to resolve this issue. Instead of using flex, I've changed it to use a grid based layout. Some minor changes to the appearance as a result. Bellow are two examples of how it looks after the change. 

![new](https://user-images.githubusercontent.com/22277624/110486398-e6ef1f00-80ec-11eb-87a0-ea7915b073c0.png)

_

![new-small](https://user-images.githubusercontent.com/22277624/110486401-e8b8e280-80ec-11eb-86bd-9983bf4d1a0e.png)


I also removed an empty section tag from this view. As far as I could tell, it didn't serve any purpose.

Hope these changes are welcome :)