### PR TITLE
refactor: consolidates workout queues to a single queue

### DIFF
--- a/functions/src/history.spec.ts
+++ b/functions/src/history.spec.ts
@@ -34,7 +34,10 @@ vi.mock('firebase-admin', () => {
             collection: collectionMock,
             batch: batchMock
         }), {
-            batch: batchMock
+            batch: batchMock,
+            Timestamp: {
+                fromDate: vi.fn((date) => date)
+            }
         })
     };
 });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -77,7 +77,6 @@ export {
 } from './coros/queue';
 
 export {
-  parseCOROSAPIHistoryImportWorkoutQueue,
   parseCOROSAPIWorkoutQueue,
 } from './queue';
 
@@ -93,7 +92,6 @@ export {
 
 export {
   parseSuuntoAppActivityQueue,
-  parseSuuntoAppHistoryImportActivityQueue,
 } from './queue';
 
 

--- a/functions/src/queue.ts
+++ b/functions/src/queue.ts
@@ -27,12 +27,12 @@ import { COROSAPIEventMetaData, SuuntoAppEventMetaData } from '@sports-alliance/
 
 
 
-export async function parseQueueItems(serviceName: ServiceNames, fromHistoryQueue = false) {
+export async function parseQueueItems(serviceName: ServiceNames) {
   const RETRY_COUNT = MAX_RETRY_COUNT;
   const LIMIT = 200;
   // @todo add queue item sort date for creation
   const querySnapshot = await admin.firestore()
-    .collection(getServiceWorkoutQueueName(serviceName, fromHistoryQueue))
+    .collection(getServiceWorkoutQueueName(serviceName))
     .where('processed', '==', false)
     .where('retryCount', '<', RETRY_COUNT)
     .limit(LIMIT).get(); // Max 10 retries
@@ -109,28 +109,12 @@ export const parseCOROSAPIWorkoutQueue = functions.region('europe-west2').runWit
   await parseQueueItems(ServiceNames.COROSAPI);
 });
 
-export const parseCOROSAPIHistoryImportWorkoutQueue = functions.region('europe-west2').runWith({
-  timeoutSeconds: TIMEOUT_DEFAULT,
-  memory: MEMORY_DEFAULT,
-  maxInstances: 1,
-}).pubsub.schedule(QUEUE_SCHEDULE).onRun(async () => {
-  await parseQueueItems(ServiceNames.COROSAPI, true);
-});
-
 export const parseSuuntoAppActivityQueue = functions.region('europe-west2').runWith({
   timeoutSeconds: TIMEOUT_HIGH,
   memory: MEMORY_HIGH,
   maxInstances: 1,
 }).pubsub.schedule(QUEUE_SCHEDULE).onRun(async () => {
   await parseQueueItems(ServiceNames.SuuntoApp);
-});
-
-export const parseSuuntoAppHistoryImportActivityQueue = functions.region('europe-west2').runWith({
-  timeoutSeconds: TIMEOUT_HIGH,
-  memory: MEMORY_HIGH,
-  maxInstances: 1,
-}).pubsub.schedule(QUEUE_SCHEDULE).onRun(async () => {
-  await parseQueueItems(ServiceNames.SuuntoApp, true);
 });
 
 

--- a/functions/src/shared/queue-names.ts
+++ b/functions/src/shared/queue-names.ts
@@ -1,23 +1,9 @@
 import { ServiceNames } from '@sports-alliance/sports-lib';
-import { SUUNTOAPP_HISTORY_IMPORT_WORKOUT_QUEUE_COLLECTION_NAME, SUUNTOAPP_WORKOUT_QUEUE_COLLECTION_NAME } from '../suunto/constants';
-import { COROSAPI_HISTORY_IMPORT_WORKOUT_QUEUE_COLLECTION_NAME, COROSAPI_WORKOUT_QUEUE_COLLECTION_NAME } from '../coros/constants';
+import { SUUNTOAPP_WORKOUT_QUEUE_COLLECTION_NAME } from '../suunto/constants';
+import { COROSAPI_WORKOUT_QUEUE_COLLECTION_NAME } from '../coros/constants';
 import { GARMIN_HEALTHAPI_WORKOUT_QUEUE_COLLECTION_NAME } from '../garmin/constants';
 
-export function getServiceHistoryImportWorkoutQueueName(serviceName: ServiceNames): string {
-    switch (serviceName) {
-        default:
-            throw new Error(`History import not implemented for ${serviceName}`);
-        case ServiceNames.SuuntoApp:
-            return SUUNTOAPP_HISTORY_IMPORT_WORKOUT_QUEUE_COLLECTION_NAME;
-        case ServiceNames.COROSAPI:
-            return COROSAPI_HISTORY_IMPORT_WORKOUT_QUEUE_COLLECTION_NAME;
-    }
-}
-
-export function getServiceWorkoutQueueName(serviceName: ServiceNames, historyQueue = false): string {
-    if (historyQueue) {
-        return getServiceHistoryImportWorkoutQueueName(serviceName);
-    }
+export function getServiceWorkoutQueueName(serviceName: ServiceNames): string {
     switch (serviceName) {
         default:
             throw new Error(`Workout queue not implemented for ${serviceName}`);

--- a/functions/src/users/admin.spec.ts
+++ b/functions/src/users/admin.spec.ts
@@ -291,11 +291,11 @@ describe('getQueueStats Cloud Function', () => {
         expect(result.advanced.topErrors).toHaveLength(2);
 
         expect(result).toHaveProperty('pending');
-        // Check totals from mocked count (5) * (3 providers * 2 queues per provider * 3 statuses) = this logic is simpler in the implementation loop
-        // pending: 5 count * 5 queues = 25
-        expect(result.pending).toBe(25);
-        expect(result.succeeded).toBe(25);
-        expect(result.stuck).toBe(25);
+        // Check totals from mocked count (5) * (3 providers * 1 queue per provider * 3 statuses)
+        // pending: 5 count * 3 queues = 15
+        expect(result.pending).toBe(15);
+        expect(result.succeeded).toBe(15);
+        expect(result.stuck).toBe(15);
         expect(result.providers).toHaveLength(3);
 
         // Check DLQ stats

--- a/functions/src/users/admin.ts
+++ b/functions/src/users/admin.ts
@@ -379,8 +379,8 @@ export const getQueueStats = onCall({
     }
 
     const PROVIDER_QUEUES: Record<string, string[]> = {
-        'Suunto': ['suuntoAppWorkoutQueue', 'suuntoAppHistoryImportActivityQueue'],
-        'COROS': ['COROSAPIWorkoutQueue', 'COROSAPIHistoryImportWorkoutQueue'],
+        'Suunto': ['suuntoAppWorkoutQueue'],
+        'COROS': ['COROSAPIWorkoutQueue'],
         'Garmin': ['garminHealthAPIActivityQueue']
     };
 


### PR DESCRIPTION
Removes the distinction between standard and history import queues.

All workouts are now added to a single queue with an expiration timestamp.
This simplifies queue management and processing logic.

Updates queue processing functions to reflect the unified queue.
Adjusts queue statistics calculation to account for the change.
