### PR TITLE
fix: migrate Functions Firestore statics for emulator compatibility

### DIFF
--- a/docs/training-workspace.md
+++ b/docs/training-workspace.md
@@ -1470,6 +1470,10 @@ Inspect authenticated `/training` at desktop, tablet, and narrow-mobile widths. 
 Start with the repository workflows in `.agent/workflows/serve-local.md` and
 `.agent/workflows/start-emulators.md`. Build Functions before starting the emulators.
 
+Functions runtime code must import `FieldValue`, `Timestamp`, and `FieldPath` from `firebase-admin/firestore`. Do not
+access those statics through `admin.firestore`: the Functions emulator replaces that namespace with a callable proxy
+that does not retain the Admin SDK's legacy static exports.
+
 The localhost frontend normally calls emulated Functions; `local-prod-functions` explicitly targets production Functions.
 Backend code can still reach real services depending on environment variables and credentials, so verify the active
 project and never assume `localhost` means isolated data.

--- a/functions/src/activity-sync/disconnect-routes.spec.ts
+++ b/functions/src/activity-sync/disconnect-routes.spec.ts
@@ -81,17 +81,16 @@ vi.mock('firebase-functions/v2/firestore', () => ({
 }));
 
 vi.mock('firebase-admin', () => ({
-  firestore: Object.assign(
-    () => ({
-      collection: mockCollection,
-      runTransaction: mockRunTransaction,
-    }),
-    {
-      FieldValue: {
-        delete: mockFieldValueDelete,
-      },
-    },
-  ),
+  firestore: () => ({
+    collection: mockCollection,
+    runTransaction: mockRunTransaction,
+  }),
+}));
+
+vi.mock('firebase-admin/firestore', () => ({
+  FieldValue: {
+    delete: mockFieldValueDelete,
+  },
 }));
 
 vi.mock('../shared/user-deletion-guard', () => ({

--- a/functions/src/activity-sync/route-cleanup.ts
+++ b/functions/src/activity-sync/route-cleanup.ts
@@ -1,5 +1,6 @@
 import { ServiceNames } from '@sports-alliance/sports-lib';
 import * as admin from 'firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 import * as logger from 'firebase-functions/logger';
 import { ACTIVITY_SYNC_ROUTES, ActivitySyncRouteId } from '../../../shared/activity-sync-routes';
 import {
@@ -253,14 +254,14 @@ export async function restoreActivitySyncRoutesForPendingDisconnectClear(
         } else {
           routeDeliveryUpdates[route.id as RouteDeliverySyncRouteId] = { enabled: true };
         }
-        restoreMarkerUpdates[route.id] = admin.firestore.FieldValue.delete();
+        restoreMarkerUpdates[route.id] = FieldValue.delete();
       } else if (serviceRestoreSettings[route.id] === true && restoreSettings[route.id] !== true) {
         restoreMarkerUpdates[route.id] = true;
       }
     }
 
     if (Object.keys(serviceRestoreSettings).length > 0) {
-      restoreMarkerUpdates[serviceRestoreKey] = admin.firestore.FieldValue.delete();
+      restoreMarkerUpdates[serviceRestoreKey] = FieldValue.delete();
     }
 
     if (

--- a/functions/src/admin/handlers/queues.handlers.ts
+++ b/functions/src/admin/handlers/queues.handlers.ts
@@ -1,6 +1,7 @@
 import { HttpsError } from 'firebase-functions/v2/https';
 import * as logger from 'firebase-functions/logger';
 import * as admin from 'firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 import { randomUUID } from 'node:crypto';
 import { onAdminCall } from '../../shared/auth';
 import { getCloudTaskQueueStatsForQueue } from '../../utils';
@@ -1275,13 +1276,13 @@ export const retrySportsLibReparseHeavyJob = onAdminCall<
             status: 'pending',
             processingTier: SPORTS_LIB_REPARSE_PROCESSING_TIERS.Heavy,
             heavyReason: SPORTS_LIB_REPARSE_HEAVY_REASONS.ManualAdmin,
-            updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-            enqueuedAt: admin.firestore.FieldValue.serverTimestamp(),
-            processedAt: admin.firestore.FieldValue.delete(),
-            lastError: admin.firestore.FieldValue.delete(),
-            failureReason: admin.firestore.FieldValue.delete(),
-            terminalFailure: admin.firestore.FieldValue.delete(),
-            terminalFailureAt: admin.firestore.FieldValue.delete(),
+            updatedAt: FieldValue.serverTimestamp(),
+            enqueuedAt: FieldValue.serverTimestamp(),
+            processedAt: FieldValue.delete(),
+            lastError: FieldValue.delete(),
+            failureReason: FieldValue.delete(),
+            terminalFailure: FieldValue.delete(),
+            terminalFailureAt: FieldValue.delete(),
         }, { merge: true });
 
         return {
@@ -1296,14 +1297,14 @@ export const retrySportsLibReparseHeavyJob = onAdminCall<
     const restoreFailedRetryClaim = async (errorMessage: string): Promise<void> => {
         await jobRef.set({
             status: 'failed',
-            updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+            updatedAt: FieldValue.serverTimestamp(),
             lastError: errorMessage,
-            enqueuedAt: admin.firestore.FieldValue.delete(),
-            failureReason: claimedRetry.failureReason || admin.firestore.FieldValue.delete(),
-            terminalFailure: claimedRetry.terminalFailure ? true : admin.firestore.FieldValue.delete(),
+            enqueuedAt: FieldValue.delete(),
+            failureReason: claimedRetry.failureReason || FieldValue.delete(),
+            terminalFailure: claimedRetry.terminalFailure ? true : FieldValue.delete(),
             terminalFailureAt: claimedRetry.terminalFailure
-                ? (claimedRetry.terminalFailureAt || admin.firestore.FieldValue.serverTimestamp())
-                : admin.firestore.FieldValue.delete(),
+                ? (claimedRetry.terminalFailureAt || FieldValue.serverTimestamp())
+                : FieldValue.delete(),
         }, { merge: true });
     };
 

--- a/functions/src/derived-metrics/set-training-build-benchmark.spec.ts
+++ b/functions/src/derived-metrics/set-training-build-benchmark.spec.ts
@@ -28,9 +28,7 @@ const hoisted = vi.hoisted(() => {
     const activityCollection = { where };
     const userDoc = { collection: vi.fn(() => activityCollection) };
     const collection = vi.fn(() => ({ doc: vi.fn(() => userDoc) }));
-    const firestore = Object.assign(vi.fn(() => ({ doc, runTransaction, collection })), {
-        FieldValue: { delete: vi.fn(() => ({ __delete__: true })) },
-    });
+    const firestore = vi.fn(() => ({ doc, runTransaction, collection }));
     return {
         transactionGet,
         transactionSet,
@@ -50,6 +48,9 @@ const hoisted = vi.hoisted(() => {
 });
 
 vi.mock('firebase-admin', () => ({ firestore: hoisted.firestore }));
+vi.mock('firebase-admin/firestore', () => ({
+    FieldValue: { delete: vi.fn(() => ({ __delete__: true })) },
+}));
 vi.mock('../../../shared/functions-manifest', () => ({
     FUNCTIONS_MANIFEST: { setTrainingBuildBenchmark: { region: 'europe-west2' } },
 }));

--- a/functions/src/derived-metrics/set-training-build-benchmark.ts
+++ b/functions/src/derived-metrics/set-training-build-benchmark.ts
@@ -1,4 +1,5 @@
 import * as admin from 'firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 import { HttpsError, onCall } from 'firebase-functions/v2/https';
 import { FUNCTIONS_MANIFEST } from '../../../shared/functions-manifest';
 import {
@@ -174,7 +175,7 @@ export const setTrainingBuildBenchmark = onCall({
                 trainingSettings: {
                     buildBenchmarks: {
                         [discipline]: selection === null
-                            ? admin.firestore.FieldValue.delete()
+                            ? FieldValue.delete()
                             : selection,
                     },
                 },

--- a/functions/src/derived-metrics/set-training-visible-disciplines.spec.ts
+++ b/functions/src/derived-metrics/set-training-visible-disciplines.spec.ts
@@ -15,9 +15,7 @@ const hoisted = vi.hoisted(() => {
         set: transactionSet,
     }));
     const doc = vi.fn((path: string) => ({ path }));
-    const firestore = Object.assign(vi.fn(() => ({ doc, runTransaction })), {
-        FieldValue: { delete: vi.fn(() => ({ __delete__: true })) },
-    });
+    const firestore = vi.fn(() => ({ doc, runTransaction }));
     return {
         transactionSet,
         runTransaction,
@@ -30,6 +28,9 @@ const hoisted = vi.hoisted(() => {
 });
 
 vi.mock('firebase-admin', () => ({ firestore: hoisted.firestore }));
+vi.mock('firebase-admin/firestore', () => ({
+    FieldValue: { delete: vi.fn(() => ({ __delete__: true })) },
+}));
 vi.mock('../../../shared/functions-manifest', () => ({
     FUNCTIONS_MANIFEST: { setTrainingVisibleDisciplines: { region: 'europe-west2' } },
 }));

--- a/functions/src/derived-metrics/set-training-visible-disciplines.ts
+++ b/functions/src/derived-metrics/set-training-visible-disciplines.ts
@@ -1,4 +1,5 @@
 import * as admin from 'firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 import { HttpsError, onCall } from 'firebase-functions/v2/https';
 import {
     normalizeTrainingVisibleDisciplines,
@@ -52,7 +53,7 @@ export const setTrainingVisibleDisciplines = onCall({
             transaction.set(db.doc(`users/${uid}/config/settings`), {
                 trainingSettings: {
                     visibleDisciplines: visibleDisciplines === null
-                        ? admin.firestore.FieldValue.delete()
+                        ? FieldValue.delete()
                         : visibleDisciplines,
                 },
             }, { merge: true });

--- a/functions/src/email/registration-welcome.spec.ts
+++ b/functions/src/email/registration-welcome.spec.ts
@@ -25,14 +25,16 @@ vi.mock('firebase-functions/v2/firestore', () => ({
 
 vi.mock('firebase-admin', () => ({
     auth: hoisted.auth,
-    firestore: Object.assign(hoisted.firestore, {
-        FieldValue: {
-            serverTimestamp: () => 'SERVER_TIMESTAMP',
-        },
-        Timestamp: {
-            fromDate: (date: Date) => ({ toDate: () => date }),
-        },
-    }),
+    firestore: hoisted.firestore,
+}));
+
+vi.mock('firebase-admin/firestore', () => ({
+    FieldValue: {
+        serverTimestamp: () => 'SERVER_TIMESTAMP',
+    },
+    Timestamp: {
+        fromDate: (date: Date) => ({ toDate: () => date }),
+    },
 }));
 
 vi.mock('../shared/user-deletion-guard', () => ({

--- a/functions/src/email/registration-welcome.ts
+++ b/functions/src/email/registration-welcome.ts
@@ -1,7 +1,7 @@
 import * as admin from 'firebase-admin';
 import * as logger from 'firebase-functions/logger';
 import { onDocumentWritten } from 'firebase-functions/v2/firestore';
-import { DocumentData } from 'firebase-admin/firestore';
+import { DocumentData, FieldValue } from 'firebase-admin/firestore';
 import {
     getUserDeletionGuardState,
     getUserDeletionGuardStateInTransaction,
@@ -80,7 +80,7 @@ export async function queueRegistrationWelcomeEmail(
         }
 
         transaction.create(lifecycleRef, {
-            registrationWelcomeQueuedAt: admin.firestore.FieldValue.serverTimestamp(),
+            registrationWelcomeQueuedAt: FieldValue.serverTimestamp(),
         });
 
         if (mailDoc.exists) {

--- a/functions/src/events/merge-events.spec.ts
+++ b/functions/src/events/merge-events.spec.ts
@@ -189,12 +189,6 @@ vi.mock('firebase-admin', () => {
     }),
   }));
 
-  Object.assign(firestoreFn, {
-    FieldValue: {
-      serverTimestamp: hoisted.mockServerTimestamp,
-    },
-  });
-
   return {
     firestore: firestoreFn,
     storage: () => ({
@@ -232,6 +226,12 @@ vi.mock('firebase-admin', () => {
     }),
   };
 });
+
+vi.mock('firebase-admin/firestore', () => ({
+  FieldValue: {
+    serverTimestamp: hoisted.mockServerTimestamp,
+  },
+}));
 
 vi.mock('@sports-alliance/sports-lib', () => ({
   EventImporterJSON: hoisted.mockEventImporterJSON,

--- a/functions/src/events/merge-events.spec.ts
+++ b/functions/src/events/merge-events.spec.ts
@@ -28,6 +28,9 @@ const hoisted = vi.hoisted(() => {
   const mockGenerateMergeEventID = vi.fn(() => 'merged-event-id');
   const mockSportsLibVersionToCode = vi.fn(() => 9001004);
   const mockServerTimestamp = vi.fn(() => 'SERVER_TIMESTAMP');
+  const mockTimestampFromDate = vi.fn((date: Date) => ({
+    toMillis: () => date.getTime(),
+  }));
   const mockStorageSave = vi.fn();
   const mockStorageGetMetadata = vi.fn();
 
@@ -104,6 +107,7 @@ const hoisted = vi.hoisted(() => {
       mockGenerateMergeEventID,
       mockSportsLibVersionToCode,
       mockServerTimestamp,
+      mockTimestampFromDate,
       mockStorageSave,
       mockStorageGetMetadata,
       mockEventImporterJSON,
@@ -230,6 +234,9 @@ vi.mock('firebase-admin', () => {
 vi.mock('firebase-admin/firestore', () => ({
   FieldValue: {
     serverTimestamp: hoisted.mockServerTimestamp,
+  },
+  Timestamp: {
+    fromDate: hoisted.mockTimestampFromDate,
   },
 }));
 

--- a/functions/src/events/merge-events.ts
+++ b/functions/src/events/merge-events.ts
@@ -1,5 +1,6 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import * as admin from 'firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 import * as logger from 'firebase-functions/logger';
 import { createHash } from 'node:crypto';
 import { gunzipSync } from 'node:zlib';
@@ -407,7 +408,7 @@ async function persistProcessingMetadata(userID: string, eventID: string): Promi
     processingEntity: EVENT_PROCESSING_ENTITY,
     sportsLibVersion: SPORTS_LIB_VERSION,
     sportsLibVersionCode: sportsLibVersionToCode(SPORTS_LIB_VERSION),
-    processedAt: admin.firestore.FieldValue.serverTimestamp(),
+    processedAt: FieldValue.serverTimestamp(),
   };
 
   await setEventDocumentIfUserActive(

--- a/functions/src/events/merge-operation.ts
+++ b/functions/src/events/merge-operation.ts
@@ -1,5 +1,5 @@
 import * as admin from 'firebase-admin';
-import { FieldValue } from 'firebase-admin/firestore';
+import { FieldValue, type Timestamp } from 'firebase-admin/firestore';
 import { HttpsError } from 'firebase-functions/v2/https';
 import { createHash, randomUUID } from 'node:crypto';
 
@@ -31,7 +31,7 @@ interface MergeOperationRecord {
   leaseExpiresAtMs: number;
   response: MergeEventResponse | null;
   lastErrorCode: string | null;
-  expireAt: admin.firestore.Timestamp;
+  expireAt: Timestamp;
   createdAt: unknown;
   updatedAt: unknown;
   completedAt?: unknown;
@@ -76,7 +76,7 @@ function isNonNegativeInteger(value: unknown): value is number {
   return typeof value === 'number' && Number.isInteger(value) && value >= 0;
 }
 
-function isValidFirestoreTimestamp(value: unknown): value is admin.firestore.Timestamp {
+function isValidFirestoreTimestamp(value: unknown): value is Timestamp {
   const toMillis = (value as { toMillis?: unknown } | null)?.toMillis;
   if (typeof toMillis !== 'function') {
     return false;

--- a/functions/src/events/merge-operation.ts
+++ b/functions/src/events/merge-operation.ts
@@ -1,4 +1,5 @@
 import * as admin from 'firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 import { HttpsError } from 'firebase-functions/v2/https';
 import { createHash, randomUUID } from 'node:crypto';
 
@@ -246,7 +247,7 @@ function newProcessingRecord(
     nowMs: number;
   },
 ): MergeOperationRecord {
-  const serverTimestamp = admin.firestore.FieldValue.serverTimestamp();
+  const serverTimestamp = FieldValue.serverTimestamp();
   return {
     schemaVersion: MERGE_OPERATION_SCHEMA_VERSION,
     status: 'processing',
@@ -434,7 +435,7 @@ export async function completeMergeOperation(input: {
         throw new HttpsError('aborted', 'Merge operation ownership changed. Retry the same merge request.');
       }
 
-      const serverTimestamp = admin.firestore.FieldValue.serverTimestamp();
+      const serverTimestamp = FieldValue.serverTimestamp();
       resolvedResponse = input.response;
       return {
         ...existing,
@@ -494,7 +495,7 @@ export async function markMergeOperationRetryable(input: {
         return existing;
       }
 
-      const serverTimestamp = admin.firestore.FieldValue.serverTimestamp();
+      const serverTimestamp = FieldValue.serverTimestamp();
       return {
         schemaVersion: MERGE_OPERATION_SCHEMA_VERSION,
         status: 'retryable',

--- a/functions/src/firestore-modular-statics.spec.ts
+++ b/functions/src/firestore-modular-statics.spec.ts
@@ -1,0 +1,69 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const LEGACY_FIRESTORE_STATICS = new Set([
+  'FieldPath',
+  'FieldValue',
+  'Timestamp',
+]);
+
+function listRuntimeTypeScriptFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return entry.name === '__tests__' || entry.name === 'scripts'
+        ? []
+        : listRuntimeTypeScriptFiles(path);
+    }
+    if (
+      !entry.isFile()
+      || !entry.name.endsWith('.ts')
+      || entry.name.endsWith('.d.ts')
+      || entry.name.endsWith('.spec.ts')
+      || entry.name.endsWith('.test.ts')
+    ) {
+      return [];
+    }
+    return [path];
+  });
+}
+
+function isLegacyFirestoreStaticAccess(node: ts.Node): node is ts.PropertyAccessExpression {
+  if (!ts.isPropertyAccessExpression(node) || !LEGACY_FIRESTORE_STATICS.has(node.name.text)) {
+    return false;
+  }
+  const firestoreAccess = node.expression;
+  return ts.isPropertyAccessExpression(firestoreAccess)
+    && firestoreAccess.name.text === 'firestore'
+    && ts.isIdentifier(firestoreAccess.expression)
+    && firestoreAccess.expression.text === 'admin';
+}
+
+describe('Functions Firestore imports', () => {
+  it('does not use legacy admin.firestore static exports in runtime code', () => {
+    const sourceRoot = __dirname;
+    const violations: string[] = [];
+
+    for (const file of listRuntimeTypeScriptFiles(sourceRoot)) {
+      const sourceFile = ts.createSourceFile(
+        file,
+        readFileSync(file, 'utf8'),
+        ts.ScriptTarget.Latest,
+        true,
+        ts.ScriptKind.TS,
+      );
+      const visit = (node: ts.Node): void => {
+        if (isLegacyFirestoreStaticAccess(node)) {
+          const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+          violations.push(`${relative(sourceRoot, file)}:${line + 1}:${character + 1} ${node.getText(sourceFile)}`);
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(sourceFile);
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/functions/src/firestore-modular-statics.spec.ts
+++ b/functions/src/firestore-modular-statics.spec.ts
@@ -30,7 +30,49 @@ function listRuntimeTypeScriptFiles(directory: string): string[] {
   });
 }
 
-function isLegacyFirestoreStaticAccess(node: ts.Node): node is ts.PropertyAccessExpression {
+function getFirebaseAdminNamespaceBindings(sourceFile: ts.SourceFile): Set<string> {
+  const bindings = new Set<string>();
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isImportDeclaration(node)
+      && ts.isStringLiteral(node.moduleSpecifier)
+      && node.moduleSpecifier.text === 'firebase-admin'
+    ) {
+      const importClause = node.importClause;
+      if (importClause?.name) {
+        bindings.add(importClause.name.text);
+      }
+      if (importClause?.namedBindings && ts.isNamespaceImport(importClause.namedBindings)) {
+        bindings.add(importClause.namedBindings.name.text);
+      }
+    }
+
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+      const initializer = node.initializer;
+      if (
+        initializer
+        && ts.isCallExpression(initializer)
+        && ts.isIdentifier(initializer.expression)
+        && initializer.expression.text === 'require'
+        && initializer.arguments.length === 1
+        && ts.isStringLiteral(initializer.arguments[0])
+        && initializer.arguments[0].text === 'firebase-admin'
+      ) {
+        bindings.add(node.name.text);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+
+  return bindings;
+}
+
+function isLegacyFirestoreStaticAccess(
+  node: ts.Node,
+  firebaseAdminBindings: Set<string>,
+): node is ts.PropertyAccessExpression {
   if (!ts.isPropertyAccessExpression(node) || !LEGACY_FIRESTORE_STATICS.has(node.name.text)) {
     return false;
   }
@@ -38,30 +80,76 @@ function isLegacyFirestoreStaticAccess(node: ts.Node): node is ts.PropertyAccess
   return ts.isPropertyAccessExpression(firestoreAccess)
     && firestoreAccess.name.text === 'firestore'
     && ts.isIdentifier(firestoreAccess.expression)
-    && firestoreAccess.expression.text === 'admin';
+    && firebaseAdminBindings.has(firestoreAccess.expression.text);
+}
+
+function findLegacyFirestoreStaticAccesses(
+  fileName: string,
+  source: string,
+): string[] {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const firebaseAdminBindings = getFirebaseAdminNamespaceBindings(sourceFile);
+  const violations: string[] = [];
+  const visit = (node: ts.Node): void => {
+    if (isLegacyFirestoreStaticAccess(node, firebaseAdminBindings)) {
+      const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+      violations.push(`${fileName}:${line + 1}:${character + 1} ${node.getText(sourceFile)}`);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return violations;
 }
 
 describe('Functions Firestore imports', () => {
+  it('detects legacy static access through a renamed firebase-admin namespace import', () => {
+    const violations = findLegacyFirestoreStaticAccesses(
+      'fixture.ts',
+      "import * as firebaseAdmin from 'firebase-admin';\nfirebaseAdmin.firestore.FieldValue.serverTimestamp();\n",
+    );
+
+    expect(violations).toEqual([
+      'fixture.ts:2:1 firebaseAdmin.firestore.FieldValue',
+    ]);
+  });
+
+  it('detects legacy static access through a default firebase-admin import', () => {
+    const violations = findLegacyFirestoreStaticAccesses(
+      'fixture.ts',
+      'import firebaseAdmin from "firebase-admin";\nfirebaseAdmin.firestore.Timestamp.now();\n',
+    );
+
+    expect(violations).toEqual([
+      'fixture.ts:2:1 firebaseAdmin.firestore.Timestamp',
+    ]);
+  });
+
+  it('detects legacy static access through a firebase-admin require alias', () => {
+    const violations = findLegacyFirestoreStaticAccesses(
+      'fixture.ts',
+      "const firebaseAdmin = require('firebase-admin');\nfirebaseAdmin.firestore.FieldPath.documentId();\n",
+    );
+
+    expect(violations).toEqual([
+      'fixture.ts:2:1 firebaseAdmin.firestore.FieldPath',
+    ]);
+  });
+
   it('does not use legacy admin.firestore static exports in runtime code', () => {
     const sourceRoot = __dirname;
     const violations: string[] = [];
 
     for (const file of listRuntimeTypeScriptFiles(sourceRoot)) {
-      const sourceFile = ts.createSourceFile(
-        file,
+      violations.push(...findLegacyFirestoreStaticAccesses(
+        relative(sourceRoot, file),
         readFileSync(file, 'utf8'),
-        ts.ScriptTarget.Latest,
-        true,
-        ts.ScriptKind.TS,
-      );
-      const visit = (node: ts.Node): void => {
-        if (isLegacyFirestoreStaticAccess(node)) {
-          const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
-          violations.push(`${relative(sourceRoot, file)}:${line + 1}:${character + 1} ${node.getText(sourceFile)}`);
-        }
-        ts.forEachChild(node, visit);
-      };
-      visit(sourceFile);
+      ));
     }
 
     expect(violations).toEqual([]);

--- a/functions/src/garmin/migrate-tokens.spec.ts
+++ b/functions/src/garmin/migrate-tokens.spec.ts
@@ -62,12 +62,13 @@ mockWhere.mockReturnValue(queryObj);
 mockGet.mockResolvedValue(querySnapshotEmpty);
 
 vi.mock('firebase-admin', () => ({
-    firestore: Object.assign(vi.fn(() => ({
+    firestore: vi.fn(() => ({
         collection: mockCollectionTop,
-    })), {
-        Timestamp: { fromDate: (d: any) => d },
-        FieldValue: { serverTimestamp: () => 'SERVER_TIMESTAMP' }
-    })
+    }))
+}));
+
+vi.mock('firebase-admin/firestore', () => ({
+    FieldValue: { serverTimestamp: () => 'SERVER_TIMESTAMP' }
 }));
 
 vi.mock('../request-helper', () => ({

--- a/functions/src/garmin/migrate-tokens.ts
+++ b/functions/src/garmin/migrate-tokens.ts
@@ -1,5 +1,6 @@
 
 import * as admin from 'firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 import * as logger from 'firebase-functions/logger';
 import * as requestPromise from '../request-helper';
 import { config } from '../config';
@@ -120,7 +121,7 @@ export async function migrateUserToken(userID: string, oauth1Token: any) {
                 tokenType: 'Bearer',
                 dateCreated: currentDate.getTime(),
                 dateRefreshed: currentDate.getTime(),
-                migratedAt: admin.firestore.FieldValue.serverTimestamp()
+                migratedAt: FieldValue.serverTimestamp()
             });
 
         logger.info(`Successfully migrated tokens for user ${userID}`);
@@ -133,4 +134,3 @@ export async function migrateUserToken(userID: string, oauth1Token: any) {
 }
 
 // HTTP Trigger
-

--- a/functions/src/mcp/activity-chart-rate-limit.ts
+++ b/functions/src/mcp/activity-chart-rate-limit.ts
@@ -1,4 +1,5 @@
 import * as admin from 'firebase-admin';
+import { Timestamp } from 'firebase-admin/firestore';
 import { createHash } from 'node:crypto';
 import { getUserDeletionGuardStateInTransaction } from '../shared/user-deletion-guard';
 import { MCP_OAUTH_COLLECTIONS } from './oauth.service';
@@ -67,7 +68,7 @@ const defaultDependencies: ActivityChartRateLimitDependencies = {
       },
     }));
   },
-  timestampFromMillis: value => admin.firestore.Timestamp.fromMillis(value),
+  timestampFromMillis: value => Timestamp.fromMillis(value),
 };
 
 export function buildActivityChartRateLimitBucketId(

--- a/functions/src/mcp/geocoding-rate-limit.ts
+++ b/functions/src/mcp/geocoding-rate-limit.ts
@@ -1,4 +1,5 @@
 import * as admin from 'firebase-admin';
+import { Timestamp } from 'firebase-admin/firestore';
 import { createHash } from 'node:crypto';
 import {
   getUserDeletionGuardStateInTransaction,
@@ -78,7 +79,7 @@ const defaultDependencies: McpGeocodingRateLimitDependencies = {
       },
     }));
   },
-  timestampFromMillis: value => admin.firestore.Timestamp.fromMillis(value),
+  timestampFromMillis: value => Timestamp.fromMillis(value),
 };
 
 export function buildMcpGeocodingRateLimitBucketId(

--- a/functions/src/mcp/oauth.firestore-store.spec.ts
+++ b/functions/src/mcp/oauth.firestore-store.spec.ts
@@ -11,16 +11,15 @@ const {
 }));
 
 vi.mock('firebase-admin', () => ({
-  firestore: Object.assign(firestoreMock, {
-    Timestamp: {
-      fromMillis: timestampFromMillisMock,
-    },
-  }),
+  firestore: firestoreMock,
 }));
 
 vi.mock('firebase-admin/firestore', () => ({
   FieldValue: {
     delete: fieldValueDeleteMock,
+  },
+  Timestamp: {
+    fromMillis: timestampFromMillisMock,
   },
 }));
 

--- a/functions/src/mcp/oauth.service.ts
+++ b/functions/src/mcp/oauth.service.ts
@@ -5,7 +5,7 @@ import { BlockList, isIP, LookupFunction } from 'node:net';
 import { Agent } from 'node:https';
 import { lookup } from 'node:dns/promises';
 import fetch from 'node-fetch';
-import { FieldValue } from 'firebase-admin/firestore';
+import { FieldValue, Timestamp } from 'firebase-admin/firestore';
 import {
   getUserDeletionGuardStateInTransaction,
 } from '../shared/user-deletion-guard';
@@ -300,8 +300,8 @@ export interface McpOAuthStore {
   revokeConnection(target: McpConnectionRevocationTarget, nowMs: number): Promise<void>;
 }
 
-function timestamp(ms: number): admin.firestore.Timestamp {
-  return admin.firestore.Timestamp.fromMillis(ms);
+function timestamp(ms: number): Timestamp {
+  return Timestamp.fromMillis(ms);
 }
 
 function documentData<T>(snapshot: admin.firestore.DocumentSnapshot): T | null {

--- a/functions/src/orphaned-service-tokens.ts
+++ b/functions/src/orphaned-service-tokens.ts
@@ -1,4 +1,5 @@
 import * as admin from 'firebase-admin';
+import { Timestamp } from 'firebase-admin/firestore';
 import * as logger from 'firebase-functions/logger';
 import { ServiceNames } from '@sports-alliance/sports-lib';
 import { getExpireAtTimestamp, TTL_CONFIG } from './shared/ttl-config';
@@ -24,7 +25,7 @@ export async function archiveOrphanedServiceToken(
             uid,
             originalTokenId,
             token: tokenData || {},
-            archivedAt: admin.firestore.Timestamp.now(),
+            archivedAt: Timestamp.now(),
             expireAt: getExpireAtTimestamp(TTL_CONFIG.ORPHANED_TOKEN_IN_DAYS),
             lastError: errorString,
         });

--- a/functions/src/queue-utils.spec.ts
+++ b/functions/src/queue-utils.spec.ts
@@ -20,11 +20,8 @@ const hoisted = vi.hoisted(() => {
         batch: vi.fn(() => batch),
         collection,
     });
-    // Attach Timestamp for getExpireAtTimestamp
-    (firestore as any).Timestamp = {
-        fromDate: vi.fn((date) => date),
-    };
-    return { batch, bulkWriter, collection, firestore };
+    const timestampFromDate = vi.fn((date) => date);
+    return { batch, bulkWriter, collection, firestore, timestampFromDate };
 });
 
 vi.mock('firebase-admin', () => ({
@@ -32,6 +29,12 @@ vi.mock('firebase-admin', () => ({
         firestore: hoisted.firestore,
     },
     firestore: hoisted.firestore,
+}));
+
+vi.mock('firebase-admin/firestore', () => ({
+    Timestamp: {
+        fromDate: hoisted.timestampFromDate,
+    },
 }));
 
 describe('queue-utils', () => {

--- a/functions/src/queue/cleanup-tombstone.spec.ts
+++ b/functions/src/queue/cleanup-tombstone.spec.ts
@@ -17,21 +17,23 @@ const {
 }));
 
 vi.mock('firebase-admin', () => {
-    const firestore = Object.assign(() => ({
+    const firestore = () => ({
         collection: mockCollection,
-    }), {
-        FieldValue: {
-            serverTimestamp: mockServerTimestamp,
-        },
-        Timestamp: {
-            fromDate: mockFromDate,
-        },
     });
 
     return {
         firestore,
     };
 });
+
+vi.mock('firebase-admin/firestore', () => ({
+    FieldValue: {
+        serverTimestamp: mockServerTimestamp,
+    },
+    Timestamp: {
+        fromDate: mockFromDate,
+    },
+}));
 
 vi.mock('firebase-functions/logger', () => ({
     error: vi.fn(),

--- a/functions/src/queue/cleanup-tombstone.ts
+++ b/functions/src/queue/cleanup-tombstone.ts
@@ -1,4 +1,5 @@
 import * as admin from 'firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 import * as logger from 'firebase-functions/logger';
 import { getExpireAtTimestamp, TTL_CONFIG } from '../shared/ttl-config';
 
@@ -31,7 +32,7 @@ export async function markQueueItemDeletedForUserCleanup(
                 originalCollection: collectionName,
                 queueItemId,
                 reason,
-                deletedAt: admin.firestore.FieldValue.serverTimestamp(),
+                deletedAt: FieldValue.serverTimestamp(),
                 expireAt: getExpireAtTimestamp(TTL_CONFIG.QUEUE_ITEM_IN_DAYS),
             }, { merge: true });
         return true;

--- a/functions/src/queue/pending-disconnect-release.spec.ts
+++ b/functions/src/queue/pending-disconnect-release.spec.ts
@@ -68,15 +68,8 @@ const hoisted = vi.hoisted(() => {
 });
 
 vi.mock('firebase-admin', () => {
-    const firestore = Object.assign(() => ({
+    const firestore = () => ({
         collection: hoisted.collection,
-    }), {
-        FieldValue: {
-            delete: vi.fn(() => hoisted.deleteSentinel),
-        },
-        Timestamp: {
-            fromDate: hoisted.timestampFromDate,
-        },
     });
 
     return {
@@ -84,6 +77,15 @@ vi.mock('firebase-admin', () => {
         firestore,
     };
 });
+
+vi.mock('firebase-admin/firestore', () => ({
+    FieldValue: {
+        delete: vi.fn(() => hoisted.deleteSentinel),
+    },
+    Timestamp: {
+        fromDate: hoisted.timestampFromDate,
+    },
+}));
 
 vi.mock('firebase-functions/logger', () => ({
     info: hoisted.loggerInfo,

--- a/functions/src/queue/pending-disconnect-release.ts
+++ b/functions/src/queue/pending-disconnect-release.ts
@@ -1,4 +1,5 @@
 import * as admin from 'firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 import * as logger from 'firebase-functions/logger';
 import { ServiceNames } from '@sports-alliance/sports-lib';
 import { SLEEP_PROVIDERS, type SleepProvider } from '../../../shared/sleep';
@@ -33,7 +34,7 @@ function asNonEmptyString(value: unknown): string | null {
 }
 
 function buildDeferredQueueReleaseUpdate(): Record<string, unknown> {
-    const deleteField = admin.firestore.FieldValue.delete();
+    const deleteField = FieldValue.delete();
     return {
         processed: false,
         processedAt: deleteField,

--- a/functions/src/queue/queue-item.interface.ts
+++ b/functions/src/queue/queue-item.interface.ts
@@ -1,4 +1,5 @@
 import * as admin from 'firebase-admin';
+import { Timestamp } from 'firebase-admin/firestore';
 import { ServiceNames } from '@sports-alliance/sports-lib';
 import { ActivitySyncRouteId } from '../../../shared/activity-sync-routes';
 import { RouteDeliverySyncRouteId } from '../../../shared/route-delivery-sync-routes';
@@ -15,7 +16,7 @@ export interface QueueItemInterface {
   dispatchRecoveryGeneration?: number,
   errors?: QueueItemError[],
   processedAt?: number,
-  expireAt?: admin.firestore.Timestamp | Date,
+  expireAt?: Timestamp | Date,
   dispatchedToCloudTask: number | null,
   firebaseUserID?: string,
   resultStatus?: 'success' | 'skipped' | 'deferred',

--- a/functions/src/route-delivery-sync/backfill.spec.ts
+++ b/functions/src/route-delivery-sync/backfill.spec.ts
@@ -93,7 +93,7 @@ vi.mock('firebase-admin', () => {
   mockRoutesStartAfter.mockReturnValue(routesQuery);
   mockRoutesLimit.mockReturnValue(routesQuery);
 
-  const firestoreFn = Object.assign(() => ({
+  const firestoreFn = () => ({
     collection: vi.fn((name: string) => {
       if (name !== 'users') {
         throw new Error(`Unexpected top collection: ${name}`);
@@ -109,14 +109,16 @@ vi.mock('firebase-admin', () => {
         })),
       };
     }),
-  }), {
-    FieldPath: { documentId: mockDocumentId },
   });
 
   return {
     firestore: firestoreFn,
   };
 });
+
+vi.mock('firebase-admin/firestore', () => ({
+  FieldPath: { documentId: mockDocumentId },
+}));
 
 import { backfillRouteDeliverySyncRoute } from './backfill';
 

--- a/functions/src/route-delivery-sync/backfill.ts
+++ b/functions/src/route-delivery-sync/backfill.ts
@@ -1,5 +1,6 @@
 import { HttpsError, onCall } from 'firebase-functions/v2/https';
 import * as admin from 'firebase-admin';
+import { FieldPath } from 'firebase-admin/firestore';
 import * as logger from 'firebase-functions/logger';
 import { ServiceNames } from '@sports-alliance/sports-lib';
 import { FirestoreRouteJSON } from '../../../shared/app-route.interface';
@@ -240,7 +241,7 @@ export const backfillRouteDeliverySyncRoute = onCall({
             .collection('users')
             .doc(userID)
             .collection('routes')
-            .orderBy(admin.firestore.FieldPath.documentId())
+            .orderBy(FieldPath.documentId())
             .limit(BACKFILL_PAGE_SIZE);
 
         if (pageCursor) {

--- a/functions/src/schedule/enforce-subscription-limits.spec.ts
+++ b/functions/src/schedule/enforce-subscription-limits.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as admin from 'firebase-admin';
+import { Timestamp } from 'firebase-admin/firestore';
 
 // Mock dependencies using vi.hoisted for top-level access
 const {
@@ -20,25 +21,6 @@ const {
         doc: vi.fn(),
         recursiveDelete: vi.fn().mockResolvedValue(undefined),
     };
-    fs.Timestamp = {
-        now: () => ({
-            toMillis: () => Date.now(),
-            toDate: () => new Date(),
-            toISOString: () => new Date().toISOString()
-        }),
-        fromDate: (d: Date) => ({
-            toDate: () => d,
-            toMillis: () => d.getTime(),
-            toISOString: () => d.toISOString()
-        })
-    };
-    fs.FieldValue = {
-        serverTimestamp: () => 'SERVER_TIMESTAMP',
-        delete: () => 'DELETE_SENTINEL'
-    };
-    fs.FieldPath = {
-        documentId: vi.fn(() => '__name__')
-    };
     return {
         mockGetUser: auth.getUser,
         mockSetCustomUserClaims: auth.setCustomUserClaims,
@@ -50,6 +32,28 @@ const {
     };
 });
 
+const modularFirestoreStatics = vi.hoisted(() => ({
+    Timestamp: {
+        now: () => ({
+            toMillis: () => Date.now(),
+            toDate: () => new Date(),
+            toISOString: () => new Date().toISOString()
+        }),
+        fromDate: (d: Date) => ({
+            toDate: () => d,
+            toMillis: () => d.getTime(),
+            toISOString: () => d.toISOString()
+        })
+    },
+    FieldValue: {
+        serverTimestamp: () => 'SERVER_TIMESTAMP',
+        delete: () => 'DELETE_SENTINEL'
+    },
+    FieldPath: {
+        documentId: vi.fn(() => '__name__')
+    },
+}));
+
 // Mock firebase-admin
 vi.mock('firebase-admin', () => {
     const authMock = vi.fn(() => mockAuthInstance);
@@ -60,6 +64,8 @@ vi.mock('firebase-admin', () => {
         firestore: firestoreMock
     };
 });
+
+vi.mock('firebase-admin/firestore', () => modularFirestoreStatics);
 
 // Mock firebase-functions
 vi.mock('firebase-functions/v2/scheduler', () => ({
@@ -193,7 +199,7 @@ describe('enforceSubscriptionLimits', () => {
 
         // Mock system doc fetch for grace period
         mockFirestoreInstance.doc.mockImplementation((path: string) => {
-            if (path === 'users/user1/system/status') return mockDoc({ gracePeriodUntil: admin.firestore.Timestamp.fromDate(futureDate) });
+            if (path === 'users/user1/system/status') return mockDoc({ gracePeriodUntil: Timestamp.fromDate(futureDate) });
             return mockDoc({});
         });
 
@@ -217,7 +223,7 @@ describe('enforceSubscriptionLimits', () => {
 
         // Mock system docs
         mockFirestoreInstance.doc.mockImplementation((path: string) => {
-            if (path.includes('system/status')) return mockDoc({ gracePeriodUntil: admin.firestore.Timestamp.fromDate(futureDate) });
+            if (path.includes('system/status')) return mockDoc({ gracePeriodUntil: Timestamp.fromDate(futureDate) });
             return mockDoc({});
         });
 
@@ -248,7 +254,7 @@ describe('enforceSubscriptionLimits', () => {
         });
 
         mockFirestoreInstance.doc.mockImplementation((path: string) => {
-            if (path === 'users/user1/system/status') return mockDoc({ gracePeriodUntil: admin.firestore.Timestamp.fromDate(futureDate) });
+            if (path === 'users/user1/system/status') return mockDoc({ gracePeriodUntil: Timestamp.fromDate(futureDate) });
             return mockDoc({});
         });
 
@@ -337,7 +343,7 @@ describe('enforceSubscriptionLimits', () => {
 
     it('should disconnect and clear claims when grace period has expired (free user)', async () => {
         const pastDate = new Date(Date.now() - 100000);
-        const systemDoc = mockDoc({ gracePeriodUntil: admin.firestore.Timestamp.fromDate(pastDate) });
+        const systemDoc = mockDoc({ gracePeriodUntil: Timestamp.fromDate(pastDate) });
 
         mockFirestoreInstance.collection.mockImplementation((path: string) => {
             if (path === GARMIN_API_TOKENS_COLLECTION_NAME) return mockQuery([{ id: 'user1' }]);
@@ -381,7 +387,7 @@ describe('enforceSubscriptionLimits', () => {
 
         mockFirestoreInstance.doc.mockImplementation((path: string) => {
             if (path === 'users/user1/system/status') {
-                return mockDoc({ gracePeriodUntil: admin.firestore.Timestamp.fromDate(pastDate) });
+                return mockDoc({ gracePeriodUntil: Timestamp.fromDate(pastDate) });
             }
             return mockDoc({});
         });
@@ -408,7 +414,7 @@ describe('enforceSubscriptionLimits', () => {
 
         mockFirestoreInstance.doc.mockImplementation((path: string) => {
             if (path === 'users/user1/system/status') {
-                return mockDoc({ gracePeriodUntil: admin.firestore.Timestamp.fromDate(pastDate) });
+                return mockDoc({ gracePeriodUntil: Timestamp.fromDate(pastDate) });
             }
             return mockDoc({});
         });
@@ -450,7 +456,7 @@ describe('enforceSubscriptionLimits', () => {
 
         mockFirestoreInstance.doc.mockImplementation((path: string) => {
             if (path === 'users/user1/system/status') {
-                return mockDoc({ gracePeriodUntil: admin.firestore.Timestamp.fromDate(pastDate) });
+                return mockDoc({ gracePeriodUntil: Timestamp.fromDate(pastDate) });
             }
             return mockDoc({});
         });
@@ -595,7 +601,7 @@ describe('enforceSubscriptionLimits', () => {
 
         mockFirestoreInstance.doc.mockImplementation((path: string) => {
             if (path === 'users/user1/system/status') {
-                return mockDoc({ gracePeriodUntil: admin.firestore.Timestamp.fromDate(pastDate) });
+                return mockDoc({ gracePeriodUntil: Timestamp.fromDate(pastDate) });
             }
             return mockDoc({});
         });
@@ -637,7 +643,7 @@ describe('enforceSubscriptionLimits', () => {
         });
 
         mockFirestoreInstance.doc.mockImplementation(() =>
-            mockDoc({ gracePeriodUntil: admin.firestore.Timestamp.fromDate(pastDate) })
+            mockDoc({ gracePeriodUntil: Timestamp.fromDate(pastDate) })
         );
 
         // Make one deauth fail
@@ -659,7 +665,7 @@ describe('enforceSubscriptionLimits', () => {
         const systemDoc = {
             get: vi.fn().mockResolvedValue({
                 exists: true,
-                data: () => ({ gracePeriodUntil: admin.firestore.Timestamp.fromDate(pastDate) })
+                data: () => ({ gracePeriodUntil: Timestamp.fromDate(pastDate) })
             }),
             set: vi.fn().mockRejectedValue(new Error('system set failed')),
             update: vi.fn().mockResolvedValue({}),
@@ -692,7 +698,7 @@ describe('enforceSubscriptionLimits', () => {
 
     it('should clean orphaned roots and continue deauthorization when clearing claims hits auth/user-not-found', async () => {
         const pastDate = new Date(Date.now() - 100000);
-        const systemDoc = mockDoc({ gracePeriodUntil: admin.firestore.Timestamp.fromDate(pastDate) });
+        const systemDoc = mockDoc({ gracePeriodUntil: Timestamp.fromDate(pastDate) });
 
         mockGetUser.mockRejectedValueOnce({ code: 'auth/user-not-found' } as any);
 
@@ -721,7 +727,7 @@ describe('enforceSubscriptionLimits', () => {
 
     it('should preserve unrelated claims while clearing subscription access', async () => {
         const pastDate = new Date(Date.now() - 100000);
-        const systemDoc = mockDoc({ gracePeriodUntil: admin.firestore.Timestamp.fromDate(pastDate) });
+        const systemDoc = mockDoc({ gracePeriodUntil: Timestamp.fromDate(pastDate) });
 
         mockGetUser.mockResolvedValue({
             customClaims: {
@@ -760,7 +766,7 @@ describe('enforceSubscriptionLimits', () => {
 
     it('should fall back to empty claims when the auth user has no custom claims', async () => {
         const pastDate = new Date(Date.now() - 100000);
-        const systemDoc = mockDoc({ gracePeriodUntil: admin.firestore.Timestamp.fromDate(pastDate) });
+        const systemDoc = mockDoc({ gracePeriodUntil: Timestamp.fromDate(pastDate) });
 
         mockGetUser.mockResolvedValue({
             uid: 'user1'
@@ -800,7 +806,7 @@ describe('enforceSubscriptionLimits', () => {
 
         mockFirestoreInstance.doc.mockImplementation((path: string) => {
             if (path === 'users/user1/system/status') {
-                return mockDoc({ gracePeriodUntil: admin.firestore.Timestamp.fromDate(pastDate) });
+                return mockDoc({ gracePeriodUntil: Timestamp.fromDate(pastDate) });
             }
             return mockDoc({});
         });

--- a/functions/src/schedule/enforce-subscription-limits.ts
+++ b/functions/src/schedule/enforce-subscription-limits.ts
@@ -1,5 +1,6 @@
 import { onSchedule } from 'firebase-functions/v2/scheduler';
 import * as admin from 'firebase-admin';
+import { FieldPath, FieldValue, Timestamp } from 'firebase-admin/firestore';
 import * as logger from 'firebase-functions/logger';
 import { deauthorizeServiceForSubscriptionEnforcement } from '../OAuth2';
 import { ServiceNames } from '@sports-alliance/sports-lib';
@@ -45,7 +46,7 @@ export const enforceSubscriptionLimits = onSchedule({
         let query = admin.firestore()
             .collection('users')
             .select('hasSubscribedOnce')
-            .orderBy(admin.firestore.FieldPath.documentId())
+            .orderBy(FieldPath.documentId())
             .limit(USER_SCAN_PAGE_SIZE);
 
         if (cursor) {
@@ -154,7 +155,7 @@ function isGracePeriodActive(gracePeriodUntil?: FirebaseFirestore.Timestamp): bo
         return false;
     }
 
-    return gracePeriodUntil.toMillis() > admin.firestore.Timestamp.now().toMillis();
+    return gracePeriodUntil.toMillis() > Timestamp.now().toMillis();
 }
 
 function isAuthUserNotFoundError(error: unknown): boolean {
@@ -292,13 +293,13 @@ async function processUser(uid: string, hasConnectedServices: boolean, hasPaidHi
             }
 
             // FAIL-SAFE: Trigger might have failed. Initialize grace period now.
-            const newGracePeriodUntil = admin.firestore.Timestamp.fromDate(
+            const newGracePeriodUntil = Timestamp.fromDate(
                 new Date(Date.now() + GRACE_PERIOD_DAYS * 24 * 60 * 60 * 1000)
             );
             logger.info(`FAIL-SAFE: No grace period found for non-pro user ${uid}. Initializing to ${newGracePeriodUntil.toDate().toISOString()}.`);
             await admin.firestore().doc(`users/${uid}/system/status`).set({
                 gracePeriodUntil: newGracePeriodUntil,
-                lastDowngradedAt: admin.firestore.FieldValue.serverTimestamp()
+                lastDowngradedAt: FieldValue.serverTimestamp()
             }, { merge: true });
 
             // Ensure claims are synced so backend checks recognize the grace period
@@ -316,8 +317,8 @@ async function processUser(uid: string, hasConnectedServices: boolean, hasPaidHi
             // Clear stale grace period state and preserve unrelated claims such as admin.
             try {
                 await admin.firestore().doc(`users/${uid}/system/status`).set({
-                    gracePeriodUntil: admin.firestore.FieldValue.delete(),
-                    lastDowngradedAt: admin.firestore.FieldValue.delete()
+                    gracePeriodUntil: FieldValue.delete(),
+                    lastDowngradedAt: FieldValue.delete()
                 }, { merge: true });
             } catch (e) {
                 logger.error(`Error clearing grace period state for ${uid}`, e);

--- a/functions/src/schedule/notifications.spec.ts
+++ b/functions/src/schedule/notifications.spec.ts
@@ -27,18 +27,17 @@ vi.mock('../shared/user-deletion-guard', () => ({
 
 vi.mock('firebase-admin', () => ({
     initializeApp: vi.fn(),
-    firestore: Object.assign(
-        vi.fn(() => mockFirestore),
-        {
-            Timestamp: {
-                fromDate: (date: Date) => ({
-                    toDate: () => date,
-                    toMillis: () => date.getTime(),
-                    toISOString: () => date.toISOString()
-                })
-            }
-        }
-    )
+    firestore: vi.fn(() => mockFirestore)
+}));
+
+vi.mock('firebase-admin/firestore', () => ({
+    Timestamp: {
+        fromDate: (date: Date) => ({
+            toDate: () => date,
+            toMillis: () => date.getTime(),
+            toISOString: () => date.toISOString()
+        })
+    }
 }));
 
 describe('checkSubscriptionNotifications', () => {

--- a/functions/src/schedule/notifications.ts
+++ b/functions/src/schedule/notifications.ts
@@ -1,6 +1,7 @@
 import { onSchedule } from 'firebase-functions/v2/scheduler';
 import * as logger from 'firebase-functions/logger';
 import * as admin from 'firebase-admin';
+import { Timestamp } from 'firebase-admin/firestore';
 import { getExpireAtTimestamp, TTL_CONFIG } from '../shared/ttl-config';
 import {
     buildEmailPlanDetails,
@@ -33,8 +34,8 @@ export const checkSubscriptionNotifications = onSchedule({ schedule: 'every 24 h
     const snapshot = await db.collectionGroup('subscriptions')
         .where('status', 'in', ['active', 'trialing'])
         .where('cancel_at_period_end', '==', true)
-        .where('current_period_end', '>=', admin.firestore.Timestamp.fromDate(threeDaysFromNow))
-        .where('current_period_end', '<', admin.firestore.Timestamp.fromDate(fourDaysFromNow))
+        .where('current_period_end', '>=', Timestamp.fromDate(threeDaysFromNow))
+        .where('current_period_end', '<', Timestamp.fromDate(fourDaysFromNow))
         .get();
 
     logger.info(`Found ${snapshot.size} subscriptions expiring between ${threeDaysFromNow.toISOString()} and ${fourDaysFromNow.toISOString()}`);

--- a/functions/src/schedule/retry-pending-service-disconnects.spec.ts
+++ b/functions/src/schedule/retry-pending-service-disconnects.spec.ts
@@ -21,17 +21,9 @@ vi.mock('firebase-functions/logger', () => ({
 }));
 
 vi.mock('firebase-admin', () => {
-  const firestore = Object.assign(() => ({
+  const firestore = () => ({
     collection: hoisted.collection,
     doc: hoisted.doc,
-  }), {
-    FieldPath: {
-      documentId: vi.fn(() => '__name__'),
-    },
-    Timestamp: {
-      now: vi.fn(() => ({ toMillis: () => 1_000 })),
-      fromMillis: vi.fn((value: number) => ({ toMillis: () => value })),
-    },
   });
 
   return {
@@ -39,6 +31,16 @@ vi.mock('firebase-admin', () => {
     firestore,
   };
 });
+
+vi.mock('firebase-admin/firestore', () => ({
+  FieldPath: {
+    documentId: vi.fn(() => '__name__'),
+  },
+  Timestamp: {
+    now: vi.fn(() => ({ toMillis: () => 1_000 })),
+    fromMillis: vi.fn((value: number) => ({ toMillis: () => value })),
+  },
+}));
 
 vi.mock('../tokens', () => ({
   getTokenData: hoisted.getTokenData,

--- a/functions/src/schedule/retry-pending-service-disconnects.ts
+++ b/functions/src/schedule/retry-pending-service-disconnects.ts
@@ -1,5 +1,6 @@
 import { onSchedule } from 'firebase-functions/v2/scheduler';
 import * as admin from 'firebase-admin';
+import { FieldPath, Timestamp } from 'firebase-admin/firestore';
 import * as logger from 'firebase-functions/logger';
 import { ServiceNames } from '@sports-alliance/sports-lib';
 import { COROSAPI_ACCESS_TOKENS_COLLECTION_NAME } from '../coros/constants';
@@ -56,7 +57,7 @@ const PENDING_DISCONNECT_COLLECTIONS: ReadonlyArray<PendingDisconnectCollectionC
 async function isGracePeriodActive(uid: string): Promise<boolean> {
   const systemDoc = await admin.firestore().doc(`users/${uid}/system/status`).get();
   const gracePeriodUntil = systemDoc.data()?.gracePeriodUntil as FirebaseFirestore.Timestamp | undefined;
-  return !!gracePeriodUntil && gracePeriodUntil.toMillis() > admin.firestore.Timestamp.now().toMillis();
+  return !!gracePeriodUntil && gracePeriodUntil.toMillis() > Timestamp.now().toMillis();
 }
 
 async function hasActiveProSubscription(uid: string): Promise<boolean> {
@@ -144,7 +145,7 @@ async function updatePendingDisconnectScanCursor(
 
 async function getDuePendingDisconnectRoots(
   config: PendingDisconnectCollectionConfig,
-  now: admin.firestore.Timestamp,
+  now: Timestamp,
 ): Promise<admin.firestore.QueryDocumentSnapshot[]> {
   const scanType: PendingDisconnectScanType = 'due_retry';
   const cursor = await getPendingDisconnectScanCursor(config, scanType);
@@ -156,7 +157,7 @@ async function getDuePendingDisconnectRoots(
       .where('disconnectManualReviewRequired', '==', false)
       .where('disconnectNextAttemptAt', '<=', now)
       .orderBy('disconnectNextAttemptAt')
-      .orderBy(admin.firestore.FieldPath.documentId())
+      .orderBy(FieldPath.documentId())
       .limit(PENDING_SERVICE_DISCONNECT_BATCH_LIMIT);
 
     if (pageCursor?.documentId && pageCursor.disconnectNextAttemptAt) {
@@ -186,7 +187,7 @@ async function getPendingDisconnectRootsForEntitlementCheck(
     let query = admin.firestore()
       .collection(config.collectionName)
       .where('disconnectState', '==', 'disconnect_pending')
-      .orderBy(admin.firestore.FieldPath.documentId())
+      .orderBy(FieldPath.documentId())
       .limit(PENDING_SERVICE_DISCONNECT_BATCH_LIMIT);
 
     if (pageCursor?.documentId) {
@@ -339,7 +340,7 @@ export const retryPendingServiceDisconnects = onSchedule({
   timeoutSeconds: 300,
   memory: '512MiB',
 }, async () => {
-  const now = admin.firestore.Timestamp.now();
+  const now = Timestamp.now();
 
   for (const config of PENDING_DISCONNECT_COLLECTIONS) {
     const restoredEntitlementClearedCount = await clearPendingDisconnectsForRestoredEntitlements(config);

--- a/functions/src/schedule/sports-lib-reparse.spec.ts
+++ b/functions/src/schedule/sports-lib-reparse.spec.ts
@@ -298,18 +298,19 @@ vi.mock('firebase-admin', () => {
         doc: hoisted.firestoreDoc,
         recursiveDelete: hoisted.recursiveDelete,
     }));
-    Object.assign(firestoreFn, {
-        FieldValue: {
-            serverTimestamp: hoisted.serverTimestamp,
-            delete: hoisted.deleteField,
-        },
-        FieldPath: {
-            documentId: () => '__name__',
-        },
-    });
 
     return { firestore: firestoreFn };
 });
+
+vi.mock('firebase-admin/firestore', () => ({
+    FieldPath: {
+        documentId: () => '__name__',
+    },
+    FieldValue: {
+        serverTimestamp: hoisted.serverTimestamp,
+        delete: hoisted.deleteField,
+    },
+}));
 
 import { scheduleSportsLibReparseScan } from './sports-lib-reparse';
 

--- a/functions/src/schedule/sports-lib-reparse.ts
+++ b/functions/src/schedule/sports-lib-reparse.ts
@@ -1,5 +1,6 @@
 import { onSchedule } from 'firebase-functions/v2/scheduler';
 import * as admin from 'firebase-admin';
+import { FieldPath, FieldValue } from 'firebase-admin/firestore';
 import * as logger from 'firebase-functions/logger';
 import {
     SPORTS_LIB_REPARSE_CHECKPOINT_PATH,
@@ -250,8 +251,8 @@ export const scheduleSportsLibReparseScan = onSchedule({
     const cursorProcessingVersionCode = getProcessingVersionCode(checkpointData?.cursorProcessingVersionCode);
 
     await checkpointRef.set({
-        lastPassStartedAt: admin.firestore.FieldValue.serverTimestamp(),
-        lastScanAt: admin.firestore.FieldValue.serverTimestamp(),
+        lastPassStartedAt: FieldValue.serverTimestamp(),
+        lastScanAt: FieldValue.serverTimestamp(),
         lastScanCount: 0,
         lastEnqueuedCount: 0,
         targetSportsLibVersion,
@@ -346,9 +347,9 @@ export const scheduleSportsLibReparseScan = onSchedule({
                     status: 'skipped',
                     reason: SPORTS_LIB_REPARSE_SKIP_REASON_NO_ORIGINAL_FILES,
                     targetSportsLibVersion,
-                    checkedAt: admin.firestore.FieldValue.serverTimestamp(),
-                    terminalFailure: admin.firestore.FieldValue.delete(),
-                    terminalFailureAt: admin.firestore.FieldValue.delete(),
+                    checkedAt: FieldValue.serverTimestamp(),
+                    terminalFailure: FieldValue.delete(),
+                    terminalFailureAt: FieldValue.delete(),
                 }, 'no_source_files');
                 return;
             }
@@ -389,9 +390,9 @@ export const scheduleSportsLibReparseScan = onSchedule({
                 ...(routingDecision.heavyReason ? { heavyReason: routingDecision.heavyReason } : {}),
                 ...(routingDecision.eventDurationMs !== null ? { eventDurationMs: routingDecision.eventDurationMs } : {}),
                 attemptCount: typeof existingJobData?.attemptCount === 'number' ? existingJobData.attemptCount : 0,
-                createdAt: existingJob.exists ? existingJobData?.createdAt : admin.firestore.FieldValue.serverTimestamp(),
-                updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-                enqueuedAt: admin.firestore.FieldValue.serverTimestamp(),
+                createdAt: existingJob.exists ? existingJobData?.createdAt : FieldValue.serverTimestamp(),
+                updatedAt: FieldValue.serverTimestamp(),
+                enqueuedAt: FieldValue.serverTimestamp(),
                 expireAt: getExpireAtTimestamp(TTL_CONFIG.SPORTS_LIB_REPARSE_JOBS_IN_DAYS),
             };
 
@@ -401,13 +402,13 @@ export const scheduleSportsLibReparseScan = onSchedule({
 
             await jobRef.set({
                 ...basePayload,
-                ...(routingDecision.heavyReason ? {} : { heavyReason: admin.firestore.FieldValue.delete() }),
-                ...(routingDecision.eventDurationMs !== null ? {} : { eventDurationMs: admin.firestore.FieldValue.delete() }),
-                lastError: admin.firestore.FieldValue.delete(),
-                failureReason: admin.firestore.FieldValue.delete(),
-                terminalFailure: admin.firestore.FieldValue.delete(),
-                terminalFailureAt: admin.firestore.FieldValue.delete(),
-                processedAt: admin.firestore.FieldValue.delete(),
+                ...(routingDecision.heavyReason ? {} : { heavyReason: FieldValue.delete() }),
+                ...(routingDecision.eventDurationMs !== null ? {} : { eventDurationMs: FieldValue.delete() }),
+                lastError: FieldValue.delete(),
+                failureReason: FieldValue.delete(),
+                terminalFailure: FieldValue.delete(),
+                terminalFailureAt: FieldValue.delete(),
+                processedAt: FieldValue.delete(),
             }, { merge: true });
 
             try {
@@ -438,9 +439,9 @@ export const scheduleSportsLibReparseScan = onSchedule({
                     }
                     await jobRef.set({
                         status: 'failed',
-                        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+                        updatedAt: FieldValue.serverTimestamp(),
                         lastError: errorMessage,
-                        enqueuedAt: admin.firestore.FieldValue.delete(),
+                        enqueuedAt: FieldValue.delete(),
                     }, { merge: true });
                     logger.warn('[sports-lib-reparse] Marked job failed because task creation returned false.', {
                         jobId,
@@ -458,9 +459,9 @@ export const scheduleSportsLibReparseScan = onSchedule({
                 }
                 await jobRef.set({
                     status: 'failed',
-                    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+                    updatedAt: FieldValue.serverTimestamp(),
                     lastError: errorMessage,
-                    enqueuedAt: admin.firestore.FieldValue.delete(),
+                    enqueuedAt: FieldValue.delete(),
                 }, { merge: true });
                 throw error;
             }
@@ -489,7 +490,7 @@ export const scheduleSportsLibReparseScan = onSchedule({
             }
 
             let userQuery = db.collection(`users/${uid}/events`)
-                .orderBy(admin.firestore.FieldPath.documentId())
+                .orderBy(FieldPath.documentId())
                 .limit(remainingScan);
 
             if (previousCursor) {
@@ -524,11 +525,11 @@ export const scheduleSportsLibReparseScan = onSchedule({
         const completedAllUIDPasses = Object.values(nextCursorByUID).every(cursor => !cursor);
         await checkpointRef.set({
             overrideCursorByUid: nextCursorByUID,
-            lastScanAt: admin.firestore.FieldValue.serverTimestamp(),
+            lastScanAt: FieldValue.serverTimestamp(),
             lastScanCount: scannedCount,
             lastEnqueuedCount: enqueuedCount,
             targetSportsLibVersion,
-            ...(completedAllUIDPasses ? { lastPassCompletedAt: admin.firestore.FieldValue.serverTimestamp() } : {}),
+            ...(completedAllUIDPasses ? { lastPassCompletedAt: FieldValue.serverTimestamp() } : {}),
         }, { merge: true });
 
         logger.info('[sports-lib-reparse] Override scan complete', {
@@ -546,7 +547,7 @@ export const scheduleSportsLibReparseScan = onSchedule({
         .where('processingEntity', '==', EVENT_PROCESSING_ENTITY)
         .where('sportsLibVersionCode', '<', targetSportsLibVersionCode)
         .orderBy('sportsLibVersionCode', 'asc')
-        .orderBy(admin.firestore.FieldPath.documentId())
+        .orderBy(FieldPath.documentId())
         .limit(settings.scanLimit);
 
     if (cursorProcessingDocPath && cursorProcessingVersionCode !== null) {
@@ -558,8 +559,8 @@ export const scheduleSportsLibReparseScan = onSchedule({
         await checkpointRef.set({
             cursorProcessingDocPath: null,
             cursorProcessingVersionCode: null,
-            lastScanAt: admin.firestore.FieldValue.serverTimestamp(),
-            lastPassCompletedAt: admin.firestore.FieldValue.serverTimestamp(),
+            lastScanAt: FieldValue.serverTimestamp(),
+            lastPassCompletedAt: FieldValue.serverTimestamp(),
             lastScanCount: 0,
             lastEnqueuedCount: 0,
             targetSportsLibVersion,
@@ -713,11 +714,11 @@ export const scheduleSportsLibReparseScan = onSchedule({
         cursorProcessingDocPath: canPersistCursor ? lastProcessingDocPath : null,
         cursorProcessingVersionCode: canPersistCursor ? lastProcessingVersionCode : null,
         ...(passCompleted ? { cursorEventPath: null } : {}),
-        lastScanAt: admin.firestore.FieldValue.serverTimestamp(),
+        lastScanAt: FieldValue.serverTimestamp(),
         lastScanCount: scannedCount,
         lastEnqueuedCount: enqueuedCount,
         targetSportsLibVersion,
-        ...(passCompleted ? { lastPassCompletedAt: admin.firestore.FieldValue.serverTimestamp() } : {}),
+        ...(passCompleted ? { lastPassCompletedAt: FieldValue.serverTimestamp() } : {}),
     }, { merge: true });
 
     logger.info('[sports-lib-reparse] Scan complete', {

--- a/functions/src/schedule/sports-lib-route-reparse.spec.ts
+++ b/functions/src/schedule/sports-lib-route-reparse.spec.ts
@@ -157,15 +157,18 @@ vi.mock('firebase-admin', () => {
         },
         recursiveDelete: hoisted.mockRecursiveDelete,
     });
-    (firestore as any).FieldValue = {
-        serverTimestamp: hoisted.mockServerTimestamp,
-        delete: hoisted.mockDelete,
-    };
-    (firestore as any).FieldPath = {
-        documentId: () => '__name__',
-    };
     return { firestore };
 });
+
+vi.mock('firebase-admin/firestore', () => ({
+    FieldPath: {
+        documentId: () => '__name__',
+    },
+    FieldValue: {
+        serverTimestamp: hoisted.mockServerTimestamp,
+        delete: hoisted.mockDelete,
+    },
+}));
 
 vi.mock('../../../shared/functions-manifest', () => ({
     FUNCTIONS_MANIFEST: {

--- a/functions/src/schedule/sports-lib-route-reparse.ts
+++ b/functions/src/schedule/sports-lib-route-reparse.ts
@@ -1,5 +1,6 @@
 import { onSchedule } from 'firebase-functions/v2/scheduler';
 import * as admin from 'firebase-admin';
+import { FieldPath, FieldValue } from 'firebase-admin/firestore';
 import * as logger from 'firebase-functions/logger';
 
 import { FUNCTIONS_MANIFEST } from '../../../shared/functions-manifest';
@@ -279,9 +280,9 @@ async function processRouteDocument(
             status: 'skipped',
             reason: SPORTS_LIB_REPARSE_SKIP_REASON_NO_ORIGINAL_FILES,
             targetSportsLibVersion,
-            checkedAt: admin.firestore.FieldValue.serverTimestamp(),
-            terminalFailure: admin.firestore.FieldValue.delete(),
-            terminalFailureAt: admin.firestore.FieldValue.delete(),
+            checkedAt: FieldValue.serverTimestamp(),
+            terminalFailure: FieldValue.delete(),
+            terminalFailureAt: FieldValue.delete(),
         }, 'no_source_files');
         return {
             enqueuedCount: options.enqueuedCount,
@@ -321,9 +322,9 @@ async function processRouteDocument(
         targetSportsLibVersion,
         status: 'pending',
         attemptCount: typeof existingJobData?.attemptCount === 'number' ? existingJobData.attemptCount : 0,
-        createdAt: existingJob.exists ? existingJobData?.createdAt : admin.firestore.FieldValue.serverTimestamp(),
-        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-        enqueuedAt: admin.firestore.FieldValue.serverTimestamp(),
+        createdAt: existingJob.exists ? existingJobData?.createdAt : FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+        enqueuedAt: FieldValue.serverTimestamp(),
         expireAt: getExpireAtTimestamp(TTL_CONFIG.SPORTS_LIB_REPARSE_JOBS_IN_DAYS),
     };
 
@@ -336,10 +337,10 @@ async function processRouteDocument(
 
     await jobRef.set({
         ...basePayload,
-        lastError: admin.firestore.FieldValue.delete(),
-        terminalFailure: admin.firestore.FieldValue.delete(),
-        terminalFailureAt: admin.firestore.FieldValue.delete(),
-        processedAt: admin.firestore.FieldValue.delete(),
+        lastError: FieldValue.delete(),
+        terminalFailure: FieldValue.delete(),
+        terminalFailureAt: FieldValue.delete(),
+        processedAt: FieldValue.delete(),
     }, { merge: true });
 
     try {
@@ -378,9 +379,9 @@ async function processRouteDocument(
         }
         await jobRef.set({
             status: 'failed',
-            updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+            updatedAt: FieldValue.serverTimestamp(),
             lastError: errorMessage,
-            enqueuedAt: admin.firestore.FieldValue.delete(),
+            enqueuedAt: FieldValue.delete(),
         }, { merge: true });
         logger.warn('[sports-lib-route-reparse] Marked job failed because task creation returned false.', {
             jobId,
@@ -403,9 +404,9 @@ async function processRouteDocument(
         }
         await jobRef.set({
             status: 'failed',
-            updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+            updatedAt: FieldValue.serverTimestamp(),
             lastError: errorMessage,
-            enqueuedAt: admin.firestore.FieldValue.delete(),
+            enqueuedAt: FieldValue.delete(),
         }, { merge: true });
         throw error;
     }
@@ -437,8 +438,8 @@ export const scheduleSportsLibRouteReparseScan = onSchedule({
         : 'global';
 
     await checkpointRef.set({
-        lastPassStartedAt: admin.firestore.FieldValue.serverTimestamp(),
-        lastScanAt: admin.firestore.FieldValue.serverTimestamp(),
+        lastPassStartedAt: FieldValue.serverTimestamp(),
+        lastScanAt: FieldValue.serverTimestamp(),
         lastScanCount: 0,
         lastEnqueuedCount: 0,
         targetSportsLibVersion,
@@ -465,7 +466,7 @@ export const scheduleSportsLibRouteReparseScan = onSchedule({
             }
 
             let userQuery = db.collection(`users/${uid}/routes`)
-                .orderBy(admin.firestore.FieldPath.documentId())
+                .orderBy(FieldPath.documentId())
                 .limit(remainingScan);
 
             if (previousCursor) {
@@ -508,11 +509,11 @@ export const scheduleSportsLibRouteReparseScan = onSchedule({
         const completedAllUIDPasses = Object.values(nextCursorByUID).every(cursor => !cursor);
         await checkpointRef.set({
             overrideCursorByUid: nextCursorByUID,
-            lastScanAt: admin.firestore.FieldValue.serverTimestamp(),
+            lastScanAt: FieldValue.serverTimestamp(),
             lastScanCount: scannedCount,
             lastEnqueuedCount: enqueuedCount,
             targetSportsLibVersion,
-            ...(completedAllUIDPasses ? { lastPassCompletedAt: admin.firestore.FieldValue.serverTimestamp() } : {}),
+            ...(completedAllUIDPasses ? { lastPassCompletedAt: FieldValue.serverTimestamp() } : {}),
         }, { merge: true });
 
         logger.info('[sports-lib-route-reparse] Override scan complete', {
@@ -530,7 +531,7 @@ export const scheduleSportsLibRouteReparseScan = onSchedule({
         .where('processingEntity', '==', 'route')
         .where('sportsLibVersionCode', '<', targetSportsLibVersionCode)
         .orderBy('sportsLibVersionCode', 'asc')
-        .orderBy(admin.firestore.FieldPath.documentId())
+        .orderBy(FieldPath.documentId())
         .limit(settings.scanLimit);
 
     if (cursorProcessingDocPath && cursorProcessingVersionCode !== null) {
@@ -542,8 +543,8 @@ export const scheduleSportsLibRouteReparseScan = onSchedule({
         await checkpointRef.set({
             cursorProcessingDocPath: null,
             cursorProcessingVersionCode: null,
-            lastScanAt: admin.firestore.FieldValue.serverTimestamp(),
-            lastPassCompletedAt: admin.firestore.FieldValue.serverTimestamp(),
+            lastScanAt: FieldValue.serverTimestamp(),
+            lastPassCompletedAt: FieldValue.serverTimestamp(),
             lastScanCount: 0,
             lastEnqueuedCount: 0,
             targetSportsLibVersion,
@@ -639,11 +640,11 @@ export const scheduleSportsLibRouteReparseScan = onSchedule({
     await checkpointRef.set({
         cursorProcessingDocPath: canPersistCursor ? lastProcessingDocPath : null,
         cursorProcessingVersionCode: canPersistCursor ? lastProcessingVersionCode : null,
-        lastScanAt: admin.firestore.FieldValue.serverTimestamp(),
+        lastScanAt: FieldValue.serverTimestamp(),
         lastScanCount: scannedCount,
         lastEnqueuedCount: enqueuedCount,
         targetSportsLibVersion,
-        ...(completedPass ? { lastPassCompletedAt: admin.firestore.FieldValue.serverTimestamp() } : {}),
+        ...(completedPass ? { lastPassCompletedAt: FieldValue.serverTimestamp() } : {}),
     }, { merge: true });
 
     logger.info('[sports-lib-route-reparse] Scan complete', {

--- a/functions/src/service-auth-lifecycle.spec.ts
+++ b/functions/src/service-auth-lifecycle.spec.ts
@@ -73,13 +73,9 @@ const {
 });
 
 vi.mock('firebase-admin', () => {
-  const firestore = Object.assign(() => ({
+  const firestore = () => ({
     runTransaction: mockRunTransaction,
     recursiveDelete: mockRecursiveDelete,
-  }), {
-    FieldValue: {
-      delete: vi.fn().mockReturnValue('delete-sentinel'),
-    },
   });
 
   return {
@@ -89,6 +85,12 @@ vi.mock('firebase-admin', () => {
     firestore,
   };
 });
+
+vi.mock('firebase-admin/firestore', () => ({
+  FieldValue: {
+    delete: vi.fn().mockReturnValue('delete-sentinel'),
+  },
+}));
 
 vi.mock('./service-connection-meta', () => ({
   markServiceReconnectRequired: mockMarkServiceReconnectRequired,

--- a/functions/src/service-auth-lifecycle.ts
+++ b/functions/src/service-auth-lifecycle.ts
@@ -1,4 +1,5 @@
 import * as admin from 'firebase-admin';
+import { Timestamp } from 'firebase-admin/firestore';
 import * as logger from 'firebase-functions/logger';
 import {
   Auth2ServiceTokenInterface,
@@ -248,8 +249,8 @@ function getSnapshotDataForOperationalCleanup(snapshot: DocumentSnapshot | Query
 }
 
 function areFirestoreTimestampsEqual(
-  left: admin.firestore.Timestamp | null | undefined,
-  right: admin.firestore.Timestamp | null | undefined,
+  left: Timestamp | null | undefined,
+  right: Timestamp | null | undefined,
 ): boolean {
   if (!left || !right) {
     return left === right;

--- a/functions/src/service-disconnect-pending-state.spec.ts
+++ b/functions/src/service-disconnect-pending-state.spec.ts
@@ -1,4 +1,4 @@
-import * as admin from 'firebase-admin';
+import { Timestamp } from 'firebase-admin/firestore';
 import { describe, expect, it, vi } from 'vitest';
 import {
   buildPendingDisconnectMarkState,
@@ -12,32 +12,26 @@ import {
   type PendingServiceDisconnectRootData,
 } from './service-disconnect-pending-state';
 
-vi.mock('firebase-admin', () => {
-  const firestore = Object.assign(() => ({}), {
-    Timestamp: {
-      fromMillis: (value: number) => ({
-        toMillis: () => value,
-        toDate: () => new Date(value),
-      }),
-    },
-  });
-
-  return {
-    default: { firestore },
-    firestore,
-  };
-});
+vi.mock('firebase-admin', () => ({ firestore: vi.fn() }));
+vi.mock('firebase-admin/firestore', () => ({
+  Timestamp: {
+    fromMillis: (value: number) => ({
+      toMillis: () => value,
+      toDate: () => new Date(value),
+    }),
+  },
+}));
 
 const NOW_MS = Date.UTC(2026, 0, 2, 3, 4, 5);
 const MINUTE_MS = 60 * 1000;
 const HOUR_MS = 60 * MINUTE_MS;
 const DAY_MS = 24 * HOUR_MS;
 
-function timestamp(value: number): admin.firestore.Timestamp {
-  return admin.firestore.Timestamp.fromMillis(value);
+function timestamp(value: number): Timestamp {
+  return Timestamp.fromMillis(value);
 }
 
-function toMillis(value: admin.firestore.Timestamp | null | undefined): number | null | undefined {
+function toMillis(value: Timestamp | null | undefined): number | null | undefined {
   return value?.toMillis();
 }
 

--- a/functions/src/service-disconnect-pending-state.ts
+++ b/functions/src/service-disconnect-pending-state.ts
@@ -1,4 +1,4 @@
-import * as admin from 'firebase-admin';
+import { Timestamp } from 'firebase-admin/firestore';
 import { SERVICE_CONNECTION_STATES } from '../../shared/service-connection';
 import type { ServiceDisconnectPendingMetaInput } from './service-connection-meta';
 
@@ -18,9 +18,9 @@ export interface PendingServiceDisconnectRootData {
   disconnectState?: string | null;
   disconnectReason?: string | null;
   disconnectAttemptCount?: number | null;
-  disconnectNextAttemptAt?: admin.firestore.Timestamp | null;
-  disconnectLastAttemptAt?: admin.firestore.Timestamp | null;
-  disconnectRetryExpiresAt?: admin.firestore.Timestamp | null;
+  disconnectNextAttemptAt?: Timestamp | null;
+  disconnectLastAttemptAt?: Timestamp | null;
+  disconnectRetryExpiresAt?: Timestamp | null;
   disconnectLastStatusCode?: number | null;
   disconnectLastErrorMessage?: string | null;
   disconnectManualReviewRequired?: boolean | null;
@@ -28,9 +28,9 @@ export interface PendingServiceDisconnectRootData {
 
 export interface PendingDisconnectMarkState {
   rootData: PendingServiceDisconnectRootData;
-  initialNextAttemptAt: admin.firestore.Timestamp;
-  initialRetryExpiresAt: admin.firestore.Timestamp;
-  nowTimestamp: admin.firestore.Timestamp;
+  initialNextAttemptAt: Timestamp;
+  initialRetryExpiresAt: Timestamp;
+  nowTimestamp: Timestamp;
 }
 
 export interface PendingDisconnectRetryFailureTransition {
@@ -50,17 +50,17 @@ const PENDING_SERVICE_DISCONNECT_BACKOFF_MS = [
   24 * 60 * 60 * 1000,
 ];
 
-function asTimestamp(value: admin.firestore.Timestamp | null | undefined, fallbackMs: number): admin.firestore.Timestamp {
-  return value || admin.firestore.Timestamp.fromMillis(fallbackMs);
+function asTimestamp(value: Timestamp | null | undefined, fallbackMs: number): Timestamp {
+  return value || Timestamp.fromMillis(fallbackMs);
 }
 
-export function buildRetryWindowExpiresAt(nowMs: number): admin.firestore.Timestamp {
-  return admin.firestore.Timestamp.fromMillis(
+export function buildRetryWindowExpiresAt(nowMs: number): Timestamp {
+  return Timestamp.fromMillis(
     nowMs + PENDING_SERVICE_DISCONNECT_RETRY_WINDOW_DAYS * 24 * 60 * 60 * 1000,
   );
 }
 
-export function timestampToISOString(value: admin.firestore.Timestamp | null | undefined): string | undefined {
+export function timestampToISOString(value: Timestamp | null | undefined): string | undefined {
   return typeof value?.toDate === 'function'
     ? value.toDate().toISOString()
     : undefined;
@@ -79,12 +79,12 @@ export function isRetryableSubscriptionEnforcementDisconnectStatus(statusCode: n
     || (statusCode >= 500 && statusCode <= 599);
 }
 
-export function buildPendingServiceDisconnectNextAttemptAt(attemptCount: number, nowMs = Date.now()): admin.firestore.Timestamp {
+export function buildPendingServiceDisconnectNextAttemptAt(attemptCount: number, nowMs = Date.now()): Timestamp {
   const backoffIndex = Math.min(
     Math.max(0, attemptCount),
     PENDING_SERVICE_DISCONNECT_BACKOFF_MS.length - 1,
   );
-  return admin.firestore.Timestamp.fromMillis(nowMs + PENDING_SERVICE_DISCONNECT_BACKOFF_MS[backoffIndex]);
+  return Timestamp.fromMillis(nowMs + PENDING_SERVICE_DISCONNECT_BACKOFF_MS[backoffIndex]);
 }
 
 export function sanitizePendingServiceDisconnectErrorMessage(value: string): string {
@@ -145,7 +145,7 @@ export function buildPendingDisconnectMarkState(
   reason: ServiceDisconnectPendingReason = SERVICE_DISCONNECT_PENDING_REASON.SubscriptionEnforcement,
   nowMs = Date.now(),
 ): PendingDisconnectMarkState {
-  const nowTimestamp = admin.firestore.Timestamp.fromMillis(nowMs);
+  const nowTimestamp = Timestamp.fromMillis(nowMs);
   const initialNextAttemptAt = buildPendingServiceDisconnectNextAttemptAt(0, nowMs);
   const initialRetryExpiresAt = buildRetryWindowExpiresAt(nowMs);
   const alreadyPending = isServiceDisconnectPendingData(existing);
@@ -182,7 +182,7 @@ export function buildPendingDisconnectRecoveryRetryData(
   failure: PendingServiceDisconnectFailure,
   nowMs = Date.now(),
 ): PendingServiceDisconnectRootData {
-  const nowTimestamp = admin.firestore.Timestamp.fromMillis(nowMs);
+  const nowTimestamp = Timestamp.fromMillis(nowMs);
   const attemptCount = 0;
 
   return {
@@ -203,7 +203,7 @@ export function buildPendingDisconnectRetryFailureTransition(
   failure: PendingServiceDisconnectFailure,
   nowMs = Date.now(),
 ): PendingDisconnectRetryFailureTransition {
-  const nowTimestamp = admin.firestore.Timestamp.fromMillis(nowMs);
+  const nowTimestamp = Timestamp.fromMillis(nowMs);
   const previousAttemptCount = typeof existing.disconnectAttemptCount === 'number'
     ? existing.disconnectAttemptCount
     : 0;

--- a/functions/src/service-disconnect-pending.spec.ts
+++ b/functions/src/service-disconnect-pending.spec.ts
@@ -18,12 +18,8 @@ const hoisted = vi.hoisted(() => ({
 }));
 
 vi.mock('firebase-admin', () => {
-  const firestore = Object.assign(() => ({
+  const firestore = () => ({
     runTransaction: hoisted.runTransaction,
-  }), {
-    Timestamp: {
-      fromMillis: vi.fn((value: number) => ({ toMillis: () => value })),
-    },
   });
 
   return {
@@ -35,6 +31,9 @@ vi.mock('firebase-admin', () => {
 vi.mock('firebase-admin/firestore', () => ({
   FieldValue: {
     delete: hoisted.fieldValueDelete,
+  },
+  Timestamp: {
+    fromMillis: vi.fn((value: number) => ({ toMillis: () => value })),
   },
 }));
 

--- a/functions/src/service-disconnect-pending.ts
+++ b/functions/src/service-disconnect-pending.ts
@@ -42,7 +42,7 @@ export type {
   ServiceDisconnectPendingReason,
 } from './service-disconnect-pending-state';
 
-function buildPendingDisconnectFieldDeletes(): Record<string, admin.firestore.FieldValue> {
+function buildPendingDisconnectFieldDeletes(): Record<string, FieldValue> {
   return {
     disconnectState: FieldValue.delete(),
     disconnectReason: FieldValue.delete(),

--- a/functions/src/shared/ttl-config.spec.ts
+++ b/functions/src/shared/ttl-config.spec.ts
@@ -1,32 +1,20 @@
 import { describe, it, expect, vi } from 'vitest';
 import { getExpireAtTimestamp, TTL_CONFIG } from './ttl-config';
-import * as admin from 'firebase-admin';
-import { Timestamp as FirestoreTimestamp } from 'firebase-admin/firestore';
 
-const { mockNamespaceFromDate, mockFallbackFromDate } = vi.hoisted(() => ({
-    mockNamespaceFromDate: vi.fn((date: Date) => ({
-        toDate: () => date,
-        toMillis: () => date.getTime()
-    })),
-    mockFallbackFromDate: vi.fn((date: Date) => ({
+const { mockFromDate } = vi.hoisted(() => ({
+    mockFromDate: vi.fn((date: Date) => ({
         toDate: () => date,
         toMillis: () => date.getTime()
     }))
 }));
 
-// Mock firebase-admin namespace API
 vi.mock('firebase-admin', () => ({
-    firestore: {
-        Timestamp: {
-            fromDate: mockNamespaceFromDate
-        }
-    }
+    firestore: vi.fn()
 }));
 
-// Mock firebase-admin/firestore module API
 vi.mock('firebase-admin/firestore', () => ({
     Timestamp: {
-        fromDate: mockFallbackFromDate
+        fromDate: mockFromDate
     }
 }));
 
@@ -52,7 +40,7 @@ describe('TTL Configuration', () => {
             const timestamp = getExpireAtTimestamp(days);
 
             expect(timestamp.toMillis()).toBe(expectedTime);
-            expect(admin.firestore.Timestamp.fromDate).toHaveBeenCalled(); // Verify namespace usage
+            expect(mockFromDate).toHaveBeenCalledOnce();
 
             vi.useRealTimers();
         });
@@ -70,27 +58,19 @@ describe('TTL Configuration', () => {
             vi.useRealTimers();
         });
 
-        it('should fallback to firestore module Timestamp when namespace Timestamp is unavailable', () => {
+        it('uses the modular Timestamp export when firebase-admin has no legacy statics', () => {
             const now = 1672531200000; // 2023-01-01T00:00:00.000Z
             vi.useFakeTimers();
             vi.setSystemTime(now);
-            mockNamespaceFromDate.mockClear();
-            mockFallbackFromDate.mockClear();
+            mockFromDate.mockClear();
 
-            const originalTimestamp = (admin as any).firestore.Timestamp;
-            (admin as any).firestore.Timestamp = undefined;
-            try {
-                const days = 1;
-                const expectedTime = now + (days * 24 * 60 * 60 * 1000);
-                const timestamp = getExpireAtTimestamp(days);
-                expect(timestamp.toMillis()).toBe(expectedTime);
-                expect(mockNamespaceFromDate).not.toHaveBeenCalled();
-                expect(mockFallbackFromDate).toHaveBeenCalledOnce();
-                expect((FirestoreTimestamp as any).fromDate).toBe(mockFallbackFromDate);
-            } finally {
-                (admin as any).firestore.Timestamp = originalTimestamp;
-                vi.useRealTimers();
-            }
+            const days = 1;
+            const expectedTime = now + (days * 24 * 60 * 60 * 1000);
+            const timestamp = getExpireAtTimestamp(days);
+
+            expect(timestamp.toMillis()).toBe(expectedTime);
+            expect(mockFromDate).toHaveBeenCalledOnce();
+            vi.useRealTimers();
         });
     });
 });

--- a/functions/src/shared/ttl-config.ts
+++ b/functions/src/shared/ttl-config.ts
@@ -1,5 +1,4 @@
-import * as admin from 'firebase-admin';
-import { Timestamp as FirestoreTimestamp } from 'firebase-admin/firestore';
+import { Timestamp } from 'firebase-admin/firestore';
 
 /**
  * Global Time-To-Live (TTL) configuration for the project.
@@ -22,9 +21,7 @@ export const TTL_CONFIG = {
  * @param days - Number of days from now when the document should expire
  * @returns Firestore Timestamp
  */
-export function getExpireAtTimestamp(days: number): admin.firestore.Timestamp {
+export function getExpireAtTimestamp(days: number): Timestamp {
     const expiresAt = new Date(Date.now() + days * 24 * 60 * 60 * 1000);
-    const namespaceTimestamp = (admin as { firestore?: { Timestamp?: typeof FirestoreTimestamp } }).firestore?.Timestamp;
-    const timestampFactory = namespaceTimestamp || FirestoreTimestamp;
-    return timestampFactory.fromDate(expiresAt) as admin.firestore.Timestamp;
+    return Timestamp.fromDate(expiresAt);
 }

--- a/functions/src/stripe/claims.spec.ts
+++ b/functions/src/stripe/claims.spec.ts
@@ -85,14 +85,17 @@ const mockFirestore = {
 vi.mock('firebase-admin', () => {
     const firestoreFn = () => mockFirestore;
 
-    firestoreFn.FieldValue = {
-        serverTimestamp: vi.fn().mockReturnValue('SERVER_TIMESTAMP')
-    };
     return {
         auth: () => mockAuth,
         firestore: firestoreFn,
     };
 });
+
+vi.mock('firebase-admin/firestore', () => ({
+    FieldValue: {
+        serverTimestamp: vi.fn().mockReturnValue('SERVER_TIMESTAMP')
+    }
+}));
 
 // Update mock to return the handler
 vi.mock('firebase-functions/v2/https', () => ({

--- a/functions/src/stripe/claims.ts
+++ b/functions/src/stripe/claims.ts
@@ -30,6 +30,7 @@
 
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import * as admin from 'firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 import * as logger from 'firebase-functions/logger';
 import { ALLOWED_CORS_ORIGINS } from '../utils';
 import { getStripe } from './client';
@@ -418,7 +419,7 @@ export async function reconcileClaims(uid: string): Promise<{ role: string }> {
                 }
 
                 transaction.set(systemStatusRef, {
-                    claimsUpdatedAt: admin.firestore.FieldValue.serverTimestamp()
+                    claimsUpdatedAt: FieldValue.serverTimestamp()
                 }, { merge: true });
                 return true;
             });

--- a/functions/src/stripe/cleanup.spec.ts
+++ b/functions/src/stripe/cleanup.spec.ts
@@ -18,12 +18,8 @@ const { mockFirestore, mockCollection, mockDocRef, mockDocSnap, mockFieldValue }
     const mockVal = {
         delete: vi.fn().mockReturnValue('DELETE_SENTINEL')
     };
-    const firestore = Object.assign(firestoreFn, {
-        FieldValue: mockVal
-    });
-
     return {
-        mockFirestore: firestore,
+        mockFirestore: firestoreFn,
         mockCollection: mockCol,
         mockDocRef: mockRef,
         mockDocSnap: mockSnap,
@@ -34,6 +30,10 @@ const { mockFirestore, mockCollection, mockDocRef, mockDocSnap, mockFieldValue }
 vi.mock('firebase-admin', () => ({
     firestore: mockFirestore,
     auth: () => ({})
+}));
+
+vi.mock('firebase-admin/firestore', () => ({
+    FieldValue: mockFieldValue
 }));
 
 vi.mock('firebase-functions/v2/https', () => ({

--- a/functions/src/stripe/cleanup.ts
+++ b/functions/src/stripe/cleanup.ts
@@ -19,6 +19,7 @@
 
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import * as admin from 'firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 import * as logger from 'firebase-functions/logger';
 import { ALLOWED_CORS_ORIGINS, enforceAppCheck } from '../utils';
 import { getStripe } from './client';
@@ -119,8 +120,8 @@ export const cleanupStripeCustomer = onCall({
         // 4. Cleanup if deleted
         if (customerDeleted) {
             await userRef.update({
-                stripeId: admin.firestore.FieldValue.delete(),
-                stripeLink: admin.firestore.FieldValue.delete()
+                stripeId: FieldValue.delete(),
+                stripeLink: FieldValue.delete()
             });
             logger.info(`Successfully cleaned up stale Stripe ID for user ${uid}.`);
             return { success: true, cleaned: true };

--- a/functions/src/stripe/subscription-state.ts
+++ b/functions/src/stripe/subscription-state.ts
@@ -1,4 +1,4 @@
-import * as admin from 'firebase-admin';
+import { Timestamp } from 'firebase-admin/firestore';
 import { calculateGracePeriodEnd } from '../../../shared/limits';
 
 export interface SubscriptionSnapshotLike {
@@ -10,7 +10,7 @@ export interface CanonicalEndingSubscription {
     subscriptionId: string;
     subscription: FirebaseFirestore.DocumentData;
     currentPeriodEndMs: number;
-    scheduledGracePeriodUntil: admin.firestore.Timestamp;
+    scheduledGracePeriodUntil: Timestamp;
 }
 
 export function getTimestampMillis(value: unknown): number | null {
@@ -52,13 +52,13 @@ export function isActiveSubscription(
 
 export function getGracePeriodUntilFromSubscriptionPeriodEnd(
     subscription: FirebaseFirestore.DocumentData | undefined,
-): admin.firestore.Timestamp | null {
+): Timestamp | null {
     const currentPeriodEndMs = getTimestampMillis(subscription?.current_period_end);
     if (currentPeriodEndMs === null) {
         return null;
     }
 
-    return admin.firestore.Timestamp.fromDate(calculateGracePeriodEnd(currentPeriodEndMs));
+    return Timestamp.fromDate(calculateGracePeriodEnd(currentPeriodEndMs));
 }
 
 export function getCanonicalEndingSubscription(

--- a/functions/src/stripe/subscriptions.spec.ts
+++ b/functions/src/stripe/subscriptions.spec.ts
@@ -40,6 +40,23 @@ vi.mock('../service-disconnect-pending', () => ({
 
 vi.mock('firebase-functions/logger', () => mockLogger);
 
+vi.mock('firebase-admin/firestore', () => ({
+    FieldValue: {
+        delete: () => 'DELETE_SENTINEL',
+        serverTimestamp: () => 'SERVER_TIMESTAMP'
+    },
+    Timestamp: {
+        fromDate: (date: Date) => ({
+            toDate: () => date,
+            toMillis: () => date.getTime()
+        }),
+        now: () => ({
+            toDate: () => new Date(),
+            toMillis: () => Date.now()
+        })
+    }
+}));
+
 // Mock firebase-functions BEFORE imports
 vi.mock('firebase-functions/v2/firestore', () => ({
     onDocumentWritten: (options: unknown, handler: unknown) => {
@@ -213,14 +230,8 @@ describe('onSubscriptionUpdated', () => {
             runTransaction: runTransactionSpy,
         } as unknown as admin.firestore.Firestore);
 
-        (admin.firestore as unknown as Record<string, unknown>).Timestamp = {
-            fromDate: (date: Date) => ({ toDate: () => date }),
-            now: () => ({ toMillis: () => Date.now() })
-        };
-        (admin.firestore as unknown as Record<string, unknown>).FieldValue = {
-            delete: () => 'DELETE_SENTINEL',
-            serverTimestamp: () => 'SERVER_TIMESTAMP'
-        };
+        (admin.firestore as unknown as Record<string, unknown>).Timestamp = undefined;
+        (admin.firestore as unknown as Record<string, unknown>).FieldValue = undefined;
 
         authSpy = vi.spyOn(admin, 'auth').mockReturnValue({
             getUser: vi.fn().mockResolvedValue({ customClaims: {} }),

--- a/functions/src/stripe/subscriptions.ts
+++ b/functions/src/stripe/subscriptions.ts
@@ -39,6 +39,7 @@
 
 import { onDocumentWritten } from 'firebase-functions/v2/firestore';
 import * as admin from 'firebase-admin';
+import { FieldValue, Timestamp } from 'firebase-admin/firestore';
 import * as logger from 'firebase-functions/logger';
 import { ServiceNames } from '@sports-alliance/sports-lib';
 import { reconcileClaims } from './claims';
@@ -215,7 +216,7 @@ export const onSubscriptionUpdated = onDocumentWritten({
         .find(subscription => subscription?.cancel_at_period_end === true);
     const fallbackGracePeriodUntil = getGracePeriodUntilFromSubscriptionPeriodEnd(
         eventCancellationSubscription,
-    ) || admin.firestore.Timestamp.fromDate(
+    ) || Timestamp.fromDate(
         new Date(Date.now() + GRACE_PERIOD_DAYS * 24 * 60 * 60 * 1000)
     );
 
@@ -242,10 +243,10 @@ export const onSubscriptionUpdated = onDocumentWritten({
                 latestActiveSnapshot.docs,
             )?.scheduledGracePeriodUntil || null;
             transaction.set(systemStatusRef, {
-                gracePeriodUntil: admin.firestore.FieldValue.delete(),
+                gracePeriodUntil: FieldValue.delete(),
                 scheduledGracePeriodUntil: scheduledGracePeriodUntil
-                    || admin.firestore.FieldValue.delete(),
-                lastDowngradedAt: admin.firestore.FieldValue.delete(),
+                    || FieldValue.delete(),
+                lastDowngradedAt: FieldValue.delete(),
             }, { merge: true });
 
             return {
@@ -265,12 +266,12 @@ export const onSubscriptionUpdated = onDocumentWritten({
         const scheduledGracePeriodUntilMs = getTimestampMillis(systemDoc.data()?.scheduledGracePeriodUntil);
         const gracePeriodUntil = scheduledGracePeriodUntilMs === null
             ? fallbackGracePeriodUntil
-            : admin.firestore.Timestamp.fromDate(new Date(scheduledGracePeriodUntilMs));
+            : Timestamp.fromDate(new Date(scheduledGracePeriodUntilMs));
 
         transaction.set(systemStatusRef, {
             gracePeriodUntil,
-            scheduledGracePeriodUntil: admin.firestore.FieldValue.delete(),
-            lastDowngradedAt: admin.firestore.FieldValue.serverTimestamp()
+            scheduledGracePeriodUntil: FieldValue.delete(),
+            lastDowngradedAt: FieldValue.serverTimestamp()
         }, { merge: true });
 
         return { status: 'set' as const, gracePeriodUntil };

--- a/functions/src/suunto/route-sync.spec.ts
+++ b/functions/src/suunto/route-sync.spec.ts
@@ -59,7 +59,7 @@ vi.mock('firebase-functions/v2/https', () => ({
 }));
 
 vi.mock('firebase-admin', () => ({
-  firestore: Object.assign(() => ({
+  firestore: () => ({
     collection: () => ({
       doc: () => ({
         collection: () => ({
@@ -69,11 +69,13 @@ vi.mock('firebase-admin', () => ({
         }),
       }),
     }),
-  }), {
-    FieldValue: {
-      delete: () => deleteFieldSentinel,
-    },
   }),
+}));
+
+vi.mock('firebase-admin/firestore', () => ({
+  FieldValue: {
+    delete: () => deleteFieldSentinel,
+  },
 }));
 
 import { addSuuntoAppRoutesToQueue, insertSuuntoAppRouteToQueue } from './route-sync';

--- a/functions/src/suunto/route-sync.ts
+++ b/functions/src/suunto/route-sync.ts
@@ -4,6 +4,7 @@ import * as functions from 'firebase-functions/v1';
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import * as logger from 'firebase-functions/logger';
 import * as admin from 'firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 import { ServiceNames } from '@sports-alliance/sports-lib';
 
 import { verifySuuntoWebhookSignature } from './webhook-signature';
@@ -105,12 +106,12 @@ async function updateSuuntoRouteImportMeta(
     failedRouteImportProviderCount: summary.failedProviderCount,
     totalRoutesFromLastRouteImportCount: summary.totalCount,
     routeImportStatesByProviderSourceKey,
-    routeImportStatesByProviderUserId: admin.firestore.FieldValue.delete(),
+    routeImportStatesByProviderUserId: FieldValue.delete(),
     ...(summary.failedProviderCount === 0
       && completedProviderCount === routeImportStatesByProviderSourceKey.length
       && completedProviderCount > 0
       ? { didLastRouteImport: completedAt }
-      : { didLastRouteImport: admin.firestore.FieldValue.delete() }),
+      : { didLastRouteImport: FieldValue.delete() }),
   }, { merge: true });
 }
 

--- a/functions/src/tasks/sports-lib-reparse-worker.spec.ts
+++ b/functions/src/tasks/sports-lib-reparse-worker.spec.ts
@@ -138,14 +138,15 @@ vi.mock('firebase-admin', () => {
         doc: hoisted.doc,
         recursiveDelete: hoisted.recursiveDelete,
     }));
-    Object.assign(firestoreFn, {
-        FieldValue: {
-            serverTimestamp: hoisted.serverTimestamp,
-            delete: hoisted.deleteField,
-        },
-    });
     return { firestore: firestoreFn };
 });
+
+vi.mock('firebase-admin/firestore', () => ({
+    FieldValue: {
+        serverTimestamp: hoisted.serverTimestamp,
+        delete: hoisted.deleteField,
+    },
+}));
 
 import { processSportsLibReparseHeavyTask, processSportsLibReparseTask } from './sports-lib-reparse-worker';
 

--- a/functions/src/tasks/sports-lib-reparse-worker.ts
+++ b/functions/src/tasks/sports-lib-reparse-worker.ts
@@ -1,5 +1,6 @@
 import { onTaskDispatched } from 'firebase-functions/v2/tasks';
 import * as admin from 'firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 import * as logger from 'firebase-functions/logger';
 import {
     SPORTS_LIB_REPARSE_AUTO_TOO_HEAVY_DURATION_MS,
@@ -80,15 +81,15 @@ async function markJobFailed(
     const isTerminalFailure = options?.terminalFailure === true;
     await jobRef.set({
         status: 'failed',
-        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-        processedAt: admin.firestore.FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+        processedAt: FieldValue.serverTimestamp(),
         lastError: errorMessage,
-        failureReason: options?.failureReason || admin.firestore.FieldValue.delete(),
-        terminalFailure: isTerminalFailure ? true : admin.firestore.FieldValue.delete(),
+        failureReason: options?.failureReason || FieldValue.delete(),
+        terminalFailure: isTerminalFailure ? true : FieldValue.delete(),
         terminalFailureAt: isTerminalFailure
-            ? admin.firestore.FieldValue.serverTimestamp()
-            : admin.firestore.FieldValue.delete(),
-        ...(options?.clearEnqueuedAt ? { enqueuedAt: admin.firestore.FieldValue.delete() } : {}),
+            ? FieldValue.serverTimestamp()
+            : FieldValue.delete(),
+        ...(options?.clearEnqueuedAt ? { enqueuedAt: FieldValue.delete() } : {}),
     }, { merge: true });
 }
 
@@ -98,14 +99,14 @@ async function markJobSuperseded(
 ): Promise<void> {
     await jobRef.set({
         status: 'superseded',
-        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-        processedAt: admin.firestore.FieldValue.serverTimestamp(),
-        supersededAt: admin.firestore.FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+        processedAt: FieldValue.serverTimestamp(),
+        supersededAt: FieldValue.serverTimestamp(),
         supersededBySportsLibVersion: runtimeSportsLibVersion,
-        lastError: admin.firestore.FieldValue.delete(),
-        failureReason: admin.firestore.FieldValue.delete(),
-        terminalFailure: admin.firestore.FieldValue.delete(),
-        terminalFailureAt: admin.firestore.FieldValue.delete(),
+        lastError: FieldValue.delete(),
+        failureReason: FieldValue.delete(),
+        terminalFailure: FieldValue.delete(),
+        terminalFailureAt: FieldValue.delete(),
     }, { merge: true });
 }
 
@@ -243,13 +244,13 @@ async function requeueHeavyFromNormalWorker(
         processingTier: SPORTS_LIB_REPARSE_PROCESSING_TIERS.Heavy,
         heavyReason: SPORTS_LIB_REPARSE_HEAVY_REASONS.Duration,
         eventDurationMs,
-        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-        enqueuedAt: admin.firestore.FieldValue.serverTimestamp(),
-        processedAt: admin.firestore.FieldValue.delete(),
-        lastError: admin.firestore.FieldValue.delete(),
-        failureReason: admin.firestore.FieldValue.delete(),
-        terminalFailure: admin.firestore.FieldValue.delete(),
-        terminalFailureAt: admin.firestore.FieldValue.delete(),
+        updatedAt: FieldValue.serverTimestamp(),
+        enqueuedAt: FieldValue.serverTimestamp(),
+        processedAt: FieldValue.delete(),
+        lastError: FieldValue.delete(),
+        failureReason: FieldValue.delete(),
+        terminalFailure: FieldValue.delete(),
+        terminalFailureAt: FieldValue.delete(),
     }, { merge: true });
 
     let taskCreated = false;
@@ -311,10 +312,10 @@ async function markJobTooHeavyForAutomaticReparse(
         status: 'failed',
         reason: failureReason,
         targetSportsLibVersion,
-        checkedAt: admin.firestore.FieldValue.serverTimestamp(),
+        checkedAt: FieldValue.serverTimestamp(),
         lastError: errorMessage,
         terminalFailure: true,
-        terminalFailureAt: admin.firestore.FieldValue.serverTimestamp(),
+        terminalFailureAt: FieldValue.serverTimestamp(),
     });
     if (!statusWritten) {
         await deleteJobForUserDeletion(jobRef, jobId, job, 'too_heavy_status_write_skipped');
@@ -491,10 +492,10 @@ async function processSportsLibReparseTaskRequest(
             ? SPORTS_LIB_REPARSE_PROCESSING_TIERS.Heavy
             : (job.processingTier || SPORTS_LIB_REPARSE_PROCESSING_TIERS.Normal),
         attemptCount: nextAttemptCount,
-        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-        failureReason: admin.firestore.FieldValue.delete(),
-        terminalFailure: admin.firestore.FieldValue.delete(),
-        terminalFailureAt: admin.firestore.FieldValue.delete(),
+        updatedAt: FieldValue.serverTimestamp(),
+        failureReason: FieldValue.delete(),
+        terminalFailure: FieldValue.delete(),
+        terminalFailureAt: FieldValue.delete(),
     }, { merge: true });
 
     logger.info('[sports-lib-reparse-worker] Job started.', {
@@ -527,9 +528,9 @@ async function processSportsLibReparseTaskRequest(
                 status: 'skipped',
                 reason: SPORTS_LIB_REPARSE_SKIP_REASON_NO_ORIGINAL_FILES,
                 targetSportsLibVersion,
-                checkedAt: admin.firestore.FieldValue.serverTimestamp(),
-                terminalFailure: admin.firestore.FieldValue.delete(),
-                terminalFailureAt: admin.firestore.FieldValue.delete(),
+                checkedAt: FieldValue.serverTimestamp(),
+                terminalFailure: FieldValue.delete(),
+                terminalFailureAt: FieldValue.delete(),
             });
             if (!statusWritten) {
                 await deleteForUserDeletion('status_write_skipped');
@@ -539,11 +540,11 @@ async function processSportsLibReparseTaskRequest(
             const statusWritten = await writeWorkerReparseStatus(job, jobId, {
                 status: 'completed',
                 targetSportsLibVersion,
-                checkedAt: admin.firestore.FieldValue.serverTimestamp(),
-                processedAt: admin.firestore.FieldValue.serverTimestamp(),
+                checkedAt: FieldValue.serverTimestamp(),
+                processedAt: FieldValue.serverTimestamp(),
                 lastError: '',
-                terminalFailure: admin.firestore.FieldValue.delete(),
-                terminalFailureAt: admin.firestore.FieldValue.delete(),
+                terminalFailure: FieldValue.delete(),
+                terminalFailureAt: FieldValue.delete(),
             });
             if (!statusWritten) {
                 await deleteForUserDeletion('status_write_skipped');
@@ -553,12 +554,12 @@ async function processSportsLibReparseTaskRequest(
 
         await jobRef.set({
             status: 'completed',
-            processedAt: admin.firestore.FieldValue.serverTimestamp(),
-            updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-            lastError: admin.firestore.FieldValue.delete(),
-            failureReason: admin.firestore.FieldValue.delete(),
-            terminalFailure: admin.firestore.FieldValue.delete(),
-            terminalFailureAt: admin.firestore.FieldValue.delete(),
+            processedAt: FieldValue.serverTimestamp(),
+            updatedAt: FieldValue.serverTimestamp(),
+            lastError: FieldValue.delete(),
+            failureReason: FieldValue.delete(),
+            terminalFailure: FieldValue.delete(),
+            terminalFailureAt: FieldValue.delete(),
         }, { merge: true });
 
         logger.info('[sports-lib-reparse-worker] Job completed.', {
@@ -604,12 +605,12 @@ async function processSportsLibReparseTaskRequest(
                 status: 'failed',
                 reason: failureReason,
                 targetSportsLibVersion,
-                checkedAt: admin.firestore.FieldValue.serverTimestamp(),
+                checkedAt: FieldValue.serverTimestamp(),
                 lastError: errorMessage,
-                terminalFailure: terminalFailure ? true : admin.firestore.FieldValue.delete(),
+                terminalFailure: terminalFailure ? true : FieldValue.delete(),
                 terminalFailureAt: terminalFailure
-                    ? admin.firestore.FieldValue.serverTimestamp()
-                    : admin.firestore.FieldValue.delete(),
+                    ? FieldValue.serverTimestamp()
+                    : FieldValue.delete(),
             });
             if (!statusWritten) {
                 await deleteForUserDeletion('failure_status_write_skipped');

--- a/functions/src/tasks/sports-lib-route-reparse-worker.spec.ts
+++ b/functions/src/tasks/sports-lib-route-reparse-worker.spec.ts
@@ -43,12 +43,15 @@ vi.mock('firebase-admin', () => {
         }),
         recursiveDelete: hoisted.mockRecursiveDelete,
     });
-    (firestore as any).FieldValue = {
-        serverTimestamp: hoisted.mockServerTimestamp,
-        delete: hoisted.mockDelete,
-    };
     return { firestore };
 });
+
+vi.mock('firebase-admin/firestore', () => ({
+    FieldValue: {
+        serverTimestamp: hoisted.mockServerTimestamp,
+        delete: hoisted.mockDelete,
+    },
+}));
 
 vi.mock('../../../shared/functions-manifest', () => ({
     FUNCTIONS_MANIFEST: {

--- a/functions/src/tasks/sports-lib-route-reparse-worker.ts
+++ b/functions/src/tasks/sports-lib-route-reparse-worker.ts
@@ -1,5 +1,6 @@
 import { onTaskDispatched } from 'firebase-functions/v2/tasks';
 import * as admin from 'firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 import * as logger from 'firebase-functions/logger';
 
 import { FUNCTIONS_MANIFEST } from '../../../shared/functions-manifest';
@@ -65,13 +66,13 @@ async function markJobFailed(
     const isTerminalFailure = options?.terminalFailure === true;
     await jobRef.set({
         status: 'failed',
-        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-        processedAt: admin.firestore.FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+        processedAt: FieldValue.serverTimestamp(),
         lastError: errorMessage,
-        terminalFailure: isTerminalFailure ? true : admin.firestore.FieldValue.delete(),
+        terminalFailure: isTerminalFailure ? true : FieldValue.delete(),
         terminalFailureAt: isTerminalFailure
-            ? admin.firestore.FieldValue.serverTimestamp()
-            : admin.firestore.FieldValue.delete(),
+            ? FieldValue.serverTimestamp()
+            : FieldValue.delete(),
     }, { merge: true });
 }
 
@@ -199,9 +200,9 @@ async function processSportsLibRouteReparseTaskRequest(
     await jobRef.set({
         status: 'processing',
         attemptCount: nextAttemptCount,
-        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-        terminalFailure: admin.firestore.FieldValue.delete(),
-        terminalFailureAt: admin.firestore.FieldValue.delete(),
+        updatedAt: FieldValue.serverTimestamp(),
+        terminalFailure: FieldValue.delete(),
+        terminalFailureAt: FieldValue.delete(),
     }, { merge: true });
 
     try {
@@ -218,9 +219,9 @@ async function processSportsLibRouteReparseTaskRequest(
                 status: 'skipped',
                 reason: SPORTS_LIB_REPARSE_SKIP_REASON_NO_ORIGINAL_FILES,
                 targetSportsLibVersion,
-                checkedAt: admin.firestore.FieldValue.serverTimestamp(),
-                terminalFailure: admin.firestore.FieldValue.delete(),
-                terminalFailureAt: admin.firestore.FieldValue.delete(),
+                checkedAt: FieldValue.serverTimestamp(),
+                terminalFailure: FieldValue.delete(),
+                terminalFailureAt: FieldValue.delete(),
             });
             if (!statusWritten) {
                 await deleteForUserDeletion('status_write_skipped');
@@ -229,21 +230,21 @@ async function processSportsLibRouteReparseTaskRequest(
 
             await jobRef.set({
                 status: 'skipped',
-                processedAt: admin.firestore.FieldValue.serverTimestamp(),
-                updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-                lastError: admin.firestore.FieldValue.delete(),
-                terminalFailure: admin.firestore.FieldValue.delete(),
-                terminalFailureAt: admin.firestore.FieldValue.delete(),
+                processedAt: FieldValue.serverTimestamp(),
+                updatedAt: FieldValue.serverTimestamp(),
+                lastError: FieldValue.delete(),
+                terminalFailure: FieldValue.delete(),
+                terminalFailureAt: FieldValue.delete(),
             }, { merge: true });
         } else {
             const statusWritten = await writeWorkerRouteReparseStatus(job, jobId, {
                 status: 'completed',
                 targetSportsLibVersion,
-                checkedAt: admin.firestore.FieldValue.serverTimestamp(),
-                processedAt: admin.firestore.FieldValue.serverTimestamp(),
+                checkedAt: FieldValue.serverTimestamp(),
+                processedAt: FieldValue.serverTimestamp(),
                 lastError: '',
-                terminalFailure: admin.firestore.FieldValue.delete(),
-                terminalFailureAt: admin.firestore.FieldValue.delete(),
+                terminalFailure: FieldValue.delete(),
+                terminalFailureAt: FieldValue.delete(),
             });
             if (!statusWritten) {
                 await deleteForUserDeletion('status_write_skipped');
@@ -252,11 +253,11 @@ async function processSportsLibRouteReparseTaskRequest(
 
             await jobRef.set({
                 status: 'completed',
-                processedAt: admin.firestore.FieldValue.serverTimestamp(),
-                updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-                lastError: admin.firestore.FieldValue.delete(),
-                terminalFailure: admin.firestore.FieldValue.delete(),
-                terminalFailureAt: admin.firestore.FieldValue.delete(),
+                processedAt: FieldValue.serverTimestamp(),
+                updatedAt: FieldValue.serverTimestamp(),
+                lastError: FieldValue.delete(),
+                terminalFailure: FieldValue.delete(),
+                terminalFailureAt: FieldValue.delete(),
             }, { merge: true });
         }
 
@@ -300,12 +301,12 @@ async function processSportsLibRouteReparseTaskRequest(
                 status: 'failed',
                 reason: 'REPARSE_FAILED',
                 targetSportsLibVersion,
-                checkedAt: admin.firestore.FieldValue.serverTimestamp(),
+                checkedAt: FieldValue.serverTimestamp(),
                 lastError: errorMessage,
-                terminalFailure: terminalFailure ? true : admin.firestore.FieldValue.delete(),
+                terminalFailure: terminalFailure ? true : FieldValue.delete(),
                 terminalFailureAt: terminalFailure
-                    ? admin.firestore.FieldValue.serverTimestamp()
-                    : admin.firestore.FieldValue.delete(),
+                    ? FieldValue.serverTimestamp()
+                    : FieldValue.delete(),
             });
             if (!statusWritten) {
                 await deleteForUserDeletion('failure_status_write_skipped');

--- a/functions/src/user/user.spec.ts
+++ b/functions/src/user/user.spec.ts
@@ -62,16 +62,9 @@ const testEnv = firebaseFunctionsTest();
 
 // Mock admin
 vi.mock('firebase-admin', () => {
-    const firestoreMock = Object.assign(vi.fn(() => ({
+    const firestoreMock = vi.fn(() => ({
         collection: firestoreCollectionMock
-    })), {
-        Timestamp: {
-            fromDate: vi.fn((date: Date) => ({ seconds: Math.floor(date.getTime() / 1000), nanoseconds: 0 }))
-        },
-        FieldValue: {
-            serverTimestamp: vi.fn(() => 'SERVER_TIMESTAMP')
-        }
-    });
+    }));
 
     return {
         auth: () => ({
@@ -82,6 +75,15 @@ vi.mock('firebase-admin', () => {
         initializeApp: vi.fn(),
     };
 });
+
+vi.mock('firebase-admin/firestore', () => ({
+    FieldValue: {
+        serverTimestamp: vi.fn(() => 'SERVER_TIMESTAMP')
+    },
+    Timestamp: {
+        fromDate: vi.fn((date: Date) => ({ seconds: Math.floor(date.getTime() / 1000), nanoseconds: 0 }))
+    }
+}));
 
 // Mock firebase-functions
 vi.mock('firebase-functions/v1', () => {

--- a/functions/src/user/user.ts
+++ b/functions/src/user/user.ts
@@ -1,6 +1,7 @@
 import * as functions from 'firebase-functions/v1';
 import * as logger from 'firebase-functions/logger';
 import * as admin from 'firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 
 
 import { isCorsAllowed } from '../utils';
@@ -67,7 +68,7 @@ export const deleteSelf = functions
 
             try {
                 await deletionMarkerRef.set({
-                    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+                    createdAt: FieldValue.serverTimestamp(),
                     source: 'deleteSelf',
                     expireAt: getExpireAtTimestamp(USER_DELETION_TOMBSTONE_RETENTION_IN_DAYS),
                 }, { merge: true });

--- a/functions/src/utils-usage.spec.ts
+++ b/functions/src/utils-usage.spec.ts
@@ -81,8 +81,6 @@ const hoisted = vi.hoisted(() => {
         batch: vi.fn(),
         runTransaction,
     });
-    (firestore as any).FieldValue = { serverTimestamp };
-
     const bucketSave = vi.fn();
     const bucketCopy = vi.fn();
     const bucketDelete = vi.fn();
@@ -138,6 +136,12 @@ vi.mock('firebase-admin', () => ({
     firestore: hoisted.firestore,
     storage: hoisted.storage,
     auth: hoisted.auth,
+}));
+
+vi.mock('firebase-admin/firestore', () => ({
+    FieldValue: {
+        serverTimestamp: hoisted.serverTimestamp,
+    },
 }));
 
 vi.mock('./shared/user-deletion-guard', () => ({

--- a/functions/src/utils.ts
+++ b/functions/src/utils.ts
@@ -2,6 +2,7 @@ import * as functions from 'firebase-functions/v1';
 type Request = functions.https.Request;
 type Response = functions.Response;
 import * as admin from 'firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 import * as crypto from 'crypto';
 import * as logger from 'firebase-functions/logger';
 import { EventInterface } from '@sports-alliance/sports-lib';
@@ -462,7 +463,7 @@ export async function setEvent(userID: string, eventID: string, event: EventInte
       processingEntity: EVENT_PROCESSING_ENTITY,
       sportsLibVersion: SPORTS_LIB_VERSION,
       sportsLibVersionCode: sportsLibVersionToCode(SPORTS_LIB_VERSION),
-      processedAt: admin.firestore.FieldValue.serverTimestamp(),
+      processedAt: FieldValue.serverTimestamp(),
     };
 
     const processingMetaRef = admin.firestore()

--- a/functions/src/wahoo/history-to-queue.spec.ts
+++ b/functions/src/wahoo/history-to-queue.spec.ts
@@ -22,9 +22,10 @@ const deletionGuardMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('firebase-admin', () => ({
-  firestore: Object.assign(() => firestoreMocks.firestore, {
-    FieldValue: { delete: () => 'delete-field' },
-  }),
+  firestore: () => firestoreMocks.firestore,
+}));
+vi.mock('firebase-admin/firestore', () => ({
+  FieldValue: { delete: () => 'delete-field' },
 }));
 vi.mock('../history', () => ({ getNextAllowedHistoryImportDate: vi.fn() }));
 vi.mock('../service-disconnect-pending', () => ({ isServiceDisconnectPendingForUser: vi.fn() }));

--- a/functions/src/wahoo/history-to-queue.ts
+++ b/functions/src/wahoo/history-to-queue.ts
@@ -1,4 +1,5 @@
 import * as admin from 'firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 import * as crypto from 'crypto';
 import * as logger from 'firebase-functions/logger';
 import { HttpsError, onCall } from 'firebase-functions/v2/https';
@@ -118,8 +119,8 @@ export async function finishWahooHistoryLease(
     const snapshot = await transaction.get(metaRef);
     if (`${snapshot.data()?.historyImportLeaseOwner || ''}` !== leaseOwner) return;
     const update: Record<string, unknown> = {
-      historyImportLeaseOwner: admin.firestore.FieldValue.delete(),
-      historyImportLeaseExpiresAt: admin.firestore.FieldValue.delete(),
+      historyImportLeaseOwner: FieldValue.delete(),
+      historyImportLeaseExpiresAt: FieldValue.delete(),
     };
     if (completed) {
       update.didLastHistoryImport = Date.now();

--- a/functions/src/wahoo/queue-store.spec.ts
+++ b/functions/src/wahoo/queue-store.spec.ts
@@ -45,7 +45,7 @@ const mocks = vi.hoisted(() => {
 });
 
 vi.mock('firebase-admin', () => ({
-  firestore: Object.assign(() => ({
+  firestore: () => ({
     collection: (name: string) => {
       if (name === 'users') {
         return {
@@ -77,9 +77,11 @@ vi.mock('firebase-admin', () => ({
     },
     runTransaction: mocks.runTransaction,
     recursiveDelete: mocks.recursiveDelete,
-  }), {
-    FieldValue: { delete: () => 'delete-sentinel' },
   }),
+}));
+
+vi.mock('firebase-admin/firestore', () => ({
+  FieldValue: { delete: () => 'delete-sentinel' },
 }));
 
 vi.mock('../shared/cloud-tasks', () => ({

--- a/functions/src/wahoo/queue-store.ts
+++ b/functions/src/wahoo/queue-store.ts
@@ -1,4 +1,5 @@
 import * as admin from 'firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 import * as crypto from 'crypto';
 import * as logger from 'firebase-functions/logger';
 import {
@@ -99,11 +100,11 @@ function isNewerRevision(
       && existingSummaryID !== incomingSummaryID);
 }
 
-function clearProcessingLeaseUpdate(): Record<string, admin.firestore.FieldValue> {
+function clearProcessingLeaseUpdate(): Record<string, FieldValue> {
   return {
-    processingOwner: admin.firestore.FieldValue.delete(),
-    processingRevision: admin.firestore.FieldValue.delete(),
-    processingLeaseExpiresAt: admin.firestore.FieldValue.delete(),
+    processingOwner: FieldValue.delete(),
+    processingRevision: FieldValue.delete(),
+    processingLeaseExpiresAt: FieldValue.delete(),
   };
 }
 
@@ -387,7 +388,7 @@ export async function releaseWahooEventPublicationLease(
     transaction.update(mappingRef, {
       eventPublicationLeases: remainingLeases.length > 0
         ? remainingLeases
-        : admin.firestore.FieldValue.delete(),
+        : FieldValue.delete(),
     });
   });
 }


### PR DESCRIPTION
## Summary

- migrate runtime `FieldValue`, `Timestamp`, and `FieldPath` uses to `firebase-admin/firestore`
- patch the three legacy `FieldValue` calls in `merge-operation.ts` introduced by the latest `develop`
- update affected Firestore mocks and add an AST regression guard that detects legacy statics through namespace, default, and CommonJS aliases
- document the Functions emulator constraint for Training workspace maintenance

## Root cause

The Functions emulator replaces `admin.firestore` with a callable proxy that does not retain the Admin SDK legacy static exports.

## Validation

- `npm --prefix functions test` (221 files, 2,968 tests)
- `npm --prefix functions run build`
- focused ESLint for the migration and its guard
- source-wide scan confirms no runtime `admin.firestore.FieldValue`, `.Timestamp`, or `.FieldPath` references remain
- local demo emulator loaded the full Functions manifest; authenticated `setTrainingVisibleDisciplines` returned HTTP 200

Closes #538