### PR TITLE
fix: hydrate persisted lap pace data

### DIFF
--- a/docs/training-workspace.md
+++ b/docs/training-workspace.md
@@ -7,7 +7,7 @@ metric payload, the sports-lib durability protocol, or the refresh pipeline chan
 Current compatibility baseline:
 
 - Quantified Self derived-metric schema: `16`
-- `@sports-alliance/sports-lib`: `18.1.1`
+- `@sports-alliance/sports-lib`: `18.1.2`
 - Training sport families: Running, Cycling, Swimming, Rowing, Walking & Hiking, Nordic Skiing, Strength, and Paddling
 - Imported FTP/VO2 capacity disciplines: Running and Cycling only
 - Rolling power-system capacity: every exact canonical activity type with usable persisted power curves
@@ -1654,7 +1654,7 @@ When a Training change depends on a new sports-lib version:
 7. Verify a real account with ready, partial, sparse, and missing-data states.
 
 Existing snapshots rebuild lazily after a schema bump. Schema 16 adds the eight-family context/profile summaries. The
-repository pins sports-lib `18.1.1`, whose companion gravity-durability policy emits explicit `unsupported-context`
+repository pins sports-lib `18.1.2`, whose companion gravity-durability policy emits explicit `unsupported-context`
 evidence for Enduro/Downhill activities. The Functions aggregator also rejects legacy eligible Enduro/Downhill
 durability evidence defensively. Reparse affected existing activities through the targeted sports-lib reparse lifecycle
 so their persisted compact evidence adopts the corrected result. This is a policy correction within durability protocol

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -15,7 +15,7 @@
         "@google-cloud/billing-budgets": "^6.1.1",
         "@google-cloud/tasks": "^6.2.1",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@sports-alliance/sports-lib": "18.1.1",
+        "@sports-alliance/sports-lib": "18.1.2",
         "blob": "^0.1.0",
         "bs58": "^4.0.1",
         "cors": "^2.8.5",
@@ -5955,9 +5955,9 @@
       }
     },
     "node_modules/@sports-alliance/sports-lib": {
-      "version": "18.1.1",
-      "resolved": "https://registry.npmjs.org/@sports-alliance/sports-lib/-/sports-lib-18.1.1.tgz",
-      "integrity": "sha512-evCg+nBPd4K3+UUfFLHAeYdqNw+SXH9QCjujsKyh+3h3vDQnxtmHfdOG7QkS+3CFpl6dFhlLKiKXYRO7HUqV4w==",
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/@sports-alliance/sports-lib/-/sports-lib-18.1.2.tgz",
+      "integrity": "sha512-gbEkSXXg4PGQr0UXXoGrFbDD5a6R3NBfwafyTz+7NdPS+jsDtNH9JIBw5pszQPBofmAH2vIng+I6a4AuoMn7vQ==",
       "dependencies": {
         "@googlemaps/polyline-codec": "^1.0.28",
         "fast-xml-parser": "^5.3.3",

--- a/functions/package.json
+++ b/functions/package.json
@@ -10,7 +10,7 @@
     "@google-cloud/billing-budgets": "^6.1.1",
     "@google-cloud/tasks": "^6.2.1",
     "@modelcontextprotocol/sdk": "1.29.0",
-    "@sports-alliance/sports-lib": "18.1.1",
+    "@sports-alliance/sports-lib": "18.1.2",
     "blob": "^0.1.0",
     "bs58": "^4.0.1",
     "cors": "^2.8.5",

--- a/functions/src/reparse/SPORTS_LIB_REPARSE_RUNBOOK.md
+++ b/functions/src/reparse/SPORTS_LIB_REPARSE_RUNBOOK.md
@@ -7,6 +7,16 @@ Target version source of truth:
 - `SPORTS_LIB_REPARSE_TARGET_VERSION`
 - File: `functions/src/reparse/sports-lib-reparse.config.ts`
 
+### Sports Lib 18.1.2 lap pace transition
+
+Sports Lib 18.1.2 fills missing pace, swim-pace, and grade-adjusted-pace summary stats from compatible speed stats on
+events, activities, and laps. Native JSON hydration applies this behavior in memory to existing speed-only Firestore
+documents, so the Laps table benefits immediately without rewriting historical data. New imports and any ordinary
+future reparse serialize the additive derived lap stats through the existing sanitized event/activity writers.
+
+Do not enable the automatic scanner or enqueue a historical reparse solely for this change. Saved routes are unaffected,
+and the MCP lap projection remains unchanged because it does not expose pace fields.
+
 ## Candidate Discovery Model
 
 ### Global mode (production path)

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@fontsource/inter": "^5.3.0",
         "@fontsource/material-symbols-rounded": "^5.3.2",
         "@sentry/angular": "^10.56.0",
-        "@sports-alliance/sports-lib": "18.1.1",
+        "@sports-alliance/sports-lib": "18.1.2",
         "@types/file-saver": "^2.0.7",
         "@zumer/snapdom": "^2.1.0",
         "buffer": "^6.0.3",
@@ -7912,9 +7912,9 @@
       }
     },
     "node_modules/@sports-alliance/sports-lib": {
-      "version": "18.1.1",
-      "resolved": "https://registry.npmjs.org/@sports-alliance/sports-lib/-/sports-lib-18.1.1.tgz",
-      "integrity": "sha512-evCg+nBPd4K3+UUfFLHAeYdqNw+SXH9QCjujsKyh+3h3vDQnxtmHfdOG7QkS+3CFpl6dFhlLKiKXYRO7HUqV4w==",
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/@sports-alliance/sports-lib/-/sports-lib-18.1.2.tgz",
+      "integrity": "sha512-gbEkSXXg4PGQr0UXXoGrFbDD5a6R3NBfwafyTz+7NdPS+jsDtNH9JIBw5pszQPBofmAH2vIng+I6a4AuoMn7vQ==",
       "dependencies": {
         "@googlemaps/polyline-codec": "^1.0.28",
         "fast-xml-parser": "^5.3.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@fontsource/inter": "^5.3.0",
     "@fontsource/material-symbols-rounded": "^5.3.2",
     "@sentry/angular": "^10.56.0",
-    "@sports-alliance/sports-lib": "18.1.1",
+    "@sports-alliance/sports-lib": "18.1.2",
     "@types/file-saver": "^2.0.7",
     "@zumer/snapdom": "^2.1.0",
     "buffer": "^6.0.3",

--- a/src/app/components/event/laps/event.card.laps.component.spec.ts
+++ b/src/app/components/event/laps/event.card.laps.component.spec.ts
@@ -5,14 +5,18 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatSelectionListChange } from '@angular/material/list';
 import {
     ActivityInterface,
+    ActivityTypes,
     DataDuration,
     DataPaceAvg,
     DataSpeedAvg,
     DataSpeedMax,
     DataSpeedMin,
+    EventImporterJSON,
     EventInterface,
+    FileType,
     LapInterface,
     LapTypes,
+    Privacy,
     UserUnitSettingsInterface
 } from '@sports-alliance/sports-lib';
 import { readFileSync } from 'node:fs';
@@ -141,6 +145,58 @@ describe('EventCardLapsComponent', () => {
         expect(component.getColumns(activity, LapTypes.Manual)).toContain(DataPaceAvg.type);
         expect(component.getColumns(activity, LapTypes.Manual)).not.toContain(DataSpeedAvg.type);
         expect(component.getDataSource(activity, LapTypes.Manual)?.data[0][DataPaceAvg.type]).toBe('05:00 min/km');
+    });
+
+    it('shows pace for persisted speed-only laps after Sports Lib JSON hydration', () => {
+        const hydratedEvent = EventImporterJSON.getEventFromJSON({
+            name: 'speed-only laps',
+            startDate: 0,
+            endDate: 2000,
+            srcFileType: FileType.FIT,
+            description: null,
+            isMerge: false,
+            privacy: Privacy.Private,
+            powerCurve: null,
+            stats: {},
+            activities: [{
+                name: null,
+                startDate: 0,
+                endDate: 2000,
+                type: ActivityTypes.Running,
+                powerMeter: false,
+                trainer: false,
+                powerCurve: null,
+                stats: {},
+                streams: [],
+                laps: [4, 5].map((averageSpeed, index) => ({
+                    lapId: index + 1,
+                    startDate: index * 1000,
+                    endDate: (index + 1) * 1000,
+                    startIndex: null,
+                    endIndex: null,
+                    type: LapTypes.Manual,
+                    stats: { [DataSpeedAvg.type]: averageSpeed },
+                })),
+                creator: { name: 'test', devices: [] },
+                intensityZones: [],
+                events: [],
+            }],
+        });
+        const activity = hydratedEvent.getFirstActivity();
+        component.event = hydratedEvent;
+        component.selectedActivities = [activity];
+
+        component.ngOnChanges();
+
+        expect(component.getColumns(activity, LapTypes.Manual)).toContain(DataPaceAvg.type);
+        const rows = component.getDataSource(activity, LapTypes.Manual)?.data;
+        expect(rows?.[0]).toMatchObject({
+            '#': 'Avg',
+            isLapAverage: true,
+            [DataPaceAvg.type]: '03:45 min/km',
+        });
+        expect(rows?.[1]).toMatchObject({ '#': 1, [DataPaceAvg.type]: '04:10 min/km' });
+        expect(rows?.[2]).toMatchObject({ '#': 2, [DataPaceAvg.type]: '03:20 min/km' });
     });
 
     it('shows unit-aware metric averages directly below the table header', () => {


### PR DESCRIPTION
## Summary
- Upgrade Quantified Self frontend and Functions to `@sports-alliance/sports-lib@18.1.2`.
- Display pace for persisted running laps that contain speed summaries but lack stored pace.
- Document the no-backfill transition: historic data hydrates in memory; normal future imports and reparses persist derived stats.

## Root cause
Sports Lib previously generated pace-family summaries mainly while parsing activities. Persisted speed-only laps restored from native JSON therefore reached Event Details without an Average Pace stat, leaving the selected pace column empty.

## User impact
Running and trail-running lap tables show their existing pace column for older speed-only activities. Cycling and swimming presentation rules remain unchanged.

## Dependency and release order
The shared Sports Lib implementation is already on `sports-alliance/sports-lib` `main` at `3cb5a4a28`. Publish the exact `18.1.2` package before merging or deploying this consumer update; the committed lockfiles pin its deterministic integrity.

## Validation
- `npx vitest run` — 400 files, 4,871 tests
- `npm --prefix functions test` — 211 files, 2,982 tests
- `npm run build`
- `npm --prefix functions run mcp:contract:check`
- Focused Event Details persisted-lap regression