### PR TITLE
chore: migrate GitHub deploys to workload identity

### DIFF
--- a/.github/workflows/buildAndDeployBeta.yml
+++ b/.github/workflows/buildAndDeployBeta.yml
@@ -17,7 +17,7 @@ jobs:
   deploy:
     needs: test
     runs-on: ubuntu-latest
-    environment: beta
+    environment: beta-hosting
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/buildAndDeployMain.yml
+++ b/.github/workflows/buildAndDeployMain.yml
@@ -16,9 +16,21 @@ jobs:
   deploy:
     needs: test
     runs-on: ubuntu-latest
+    environment: production-hosting
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: projects/242713487388/locations/global/workloadIdentityPools/qs-github/providers/github
+          service_account: qs-github-production-hosting@quantified-self-io.iam.gserviceaccount.com
+          create_credentials_file: true
+          export_environment_variables: true
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -55,10 +67,5 @@ jobs:
       - name: Remove sourcemaps
         run: find dist -name "*.map" -delete
 
-      - name: Create SA key
-        run: echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > "${{ runner.temp }}/firebase_service_account.json"
-
       - name: Deploy to Firebase
-        run: |
-          export GOOGLE_APPLICATION_CREDENTIALS="${{ runner.temp }}/firebase_service_account.json"
-          firebase deploy --only hosting:production
+        run: firebase deploy --only hosting:production

--- a/.github/workflows/buildAndDeployProduction.yml
+++ b/.github/workflows/buildAndDeployProduction.yml
@@ -5,15 +5,61 @@ on:
     types: [published]
 
 jobs:
-  test:
-    uses: ./.github/workflows/_run-tests.yml
-
-  deploy:
-    needs: test
+  resolve:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      commit: ${{ steps.resolve.outputs.commit }}
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Resolve a release commit from main
+        id: resolve
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          git fetch --no-tags origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          commit="$(git rev-list -n 1 "${RELEASE_TAG}")"
+          if ! git merge-base --is-ancestor "$commit" origin/main; then
+            echo "The release tag must reference a commit contained in main." >&2
+            exit 1
+          fi
+
+          echo "commit=$commit" >> "$GITHUB_OUTPUT"
+
+  test:
+    needs: resolve
+    uses: ./.github/workflows/_run-tests.yml
+    with:
+      ref: ${{ needs.resolve.outputs.commit }}
+
+  deploy:
+    needs:
+      - resolve
+      - test
+    runs-on: ubuntu-latest
+    environment: production-deploy
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.commit }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: projects/242713487388/locations/global/workloadIdentityPools/qs-github/providers/github
+          service_account: qs-github-production-deploy@quantified-self-io.iam.gserviceaccount.com
+          create_credentials_file: true
+          export_environment_variables: true
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -50,10 +96,5 @@ jobs:
       - name: Remove sourcemaps
         run: find dist -name "*.map" -delete
 
-      - name: Create SA key
-        run: echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > "${{ runner.temp }}/firebase_service_account.json"
-
       - name: Deploy to Firebase
-        run: |
-          export GOOGLE_APPLICATION_CREDENTIALS="${{ runner.temp }}/firebase_service_account.json"
-          firebase deploy --only hosting:production,functions,firestore,storage
+        run: firebase deploy --only hosting:production,functions,firestore,storage

--- a/.github/workflows/deployFunctionsManual.yml
+++ b/.github/workflows/deployFunctionsManual.yml
@@ -57,12 +57,23 @@ jobs:
       - resolve
       - test
     runs-on: ubuntu-latest
-    environment: production
+    environment: production-deploy
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.resolve.outputs.commit }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: projects/242713487388/locations/global/workloadIdentityPools/qs-github/providers/github
+          service_account: qs-github-production-deploy@quantified-self-io.iam.gserviceaccount.com
+          create_credentials_file: true
+          export_environment_variables: true
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -78,12 +89,5 @@ jobs:
           npm ci
           npm run build
 
-      - name: Create service account key
-        run: |
-          umask 077
-          echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > "${{ runner.temp }}/firebase_service_account.json"
-
       - name: Deploy Functions
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/firebase_service_account.json
         run: firebase deploy --only functions


### PR DESCRIPTION
## Summary

Migrates every GitHub deployment workflow from the long-lived Firebase service-account JSON key to Google Workload Identity Federation.

- Uses distinct GitHub Environments and service accounts for beta Hosting, production Hosting, and privileged production deployment.
- Grants the production deploy identity only the required Firebase, Cloud Functions, Cloud Scheduler, Rules, Service Usage, and narrowly scoped service-account impersonation roles.
- Removes `FIREBASE_SERVICE_ACCOUNT` key-file creation and `GOOGLE_APPLICATION_CREDENTIALS` exports from all deployment workflows.
- Requires a published release tag to resolve to a commit already contained in `main`.

## Validation

- Ruby YAML parsing and `git diff --check`
- `npm run credentials:test`
- Pre-commit Gitleaks and credential-file-name checks
- Pre-push MCP contract check and 47 targeted MCP tests

## Rollout

GitHub Environments, WIF provider bindings, dedicated service accounts, and IAM roles have been verified before this PR. Keep the legacy `FIREBASE_SERVICE_ACCOUNT` secret until the production paths have each completed a successful WIF deployment.