### PR TITLE
feat: enable calendar event actions

### DIFF
--- a/src/app/components/event-table/activity-range-table-section.component.html
+++ b/src/app/components/event-table/activity-range-table-section.component.html
@@ -29,7 +29,7 @@
   </div>
   } @else if (isReady() && user(); as user) {
   <app-event-table presentation="browse" [user]="user" [targetUser]="targetUser() || user"
-    [events]="events()" [showActions]="false" [isLoading]="false">
+    [events]="events()" [showActions]="true" [isLoading]="false">
   </app-event-table>
   }
 </section>

--- a/src/app/components/event-table/activity-range-table-section.component.spec.ts
+++ b/src/app/components/event-table/activity-range-table-section.component.spec.ts
@@ -68,7 +68,7 @@ describe('ActivityRangeTableSectionComponent', () => {
     const table = fixture.debugElement.query(By.directive(EventTableStubComponent))
       .componentInstance as EventTableStubComponent;
     expect(table.presentation).toBe('browse');
-    expect(table.showActions).toBe(false);
+    expect(table.showActions).toBe(true);
   });
 
   it('queries a target user while preserving the viewer for table preferences', async () => {

--- a/src/app/components/event-table/event.table.component.html
+++ b/src/app/components/event-table/event.table.component.html
@@ -128,13 +128,15 @@
             </mat-checkbox>
           </th>
           }
-          @if (isLast && canManageEvents) {
-          <th mat-header-cell *matHeaderCellDef>
+          @if (isLast && showRowActions) {
+          <th mat-header-cell *matHeaderCellDef [attr.aria-label]="canManageEvents ? null : 'Event actions'">
+            @if (canManageEvents) {
             <app-event-table-actions [selectedDataTypes]="selectedColumns"
               (selectedDataTypesChange)="selectedColumnsChange($event)"></app-event-table-actions>
+            }
           </th>
           }
-          @if ((!(isFirst && canManageEvents) && !(isLast && canManageEvents))) {
+          @if ((!(isFirst && canManageEvents) && !(isLast && showRowActions))) {
           <th mat-header-cell *matHeaderCellDef mat-sort-header [disabled]="!isColumnHeaderSortable(column)">
             <app-data-type-icon [dataType]="column"></app-data-type-icon>
           </th>

--- a/src/app/components/event-table/event.table.component.spec.ts
+++ b/src/app/components/event-table/event.table.component.spec.ts
@@ -354,7 +354,7 @@ describe('EventTableComponent', () => {
         expect(mainRow.contains(filtersRow)).toBe(true);
     });
 
-    it('renders a browse presentation without controls or persisted table changes', async () => {
+    it('renders row actions in browse presentation without bulk controls or persisted table changes', async () => {
         component.presentation = 'browse';
         component.showActions = true;
         component.ngOnChanges({
@@ -365,9 +365,16 @@ describe('EventTableComponent', () => {
 
         expect(fixture.nativeElement.querySelector('.table-toolbar')).toBeNull();
         expect(component.displayedColumns).not.toContain('Checkbox');
-        expect(component.displayedColumns).not.toContain('Actions');
+        expect(component.displayedColumns).toContain('Actions');
         expect(component.displayedColumns).not.toContain('Shared');
         expect(component.displayedColumns).not.toContain('Tags');
+        const template = readFileSync(
+            join(process.cwd(), 'src/app/components/event-table/event.table.component.html'),
+            'utf8'
+        );
+        expect(template).toContain("[attr.aria-label]=\"canManageEvents ? null : 'Event actions'\"");
+        expect(fixture.nativeElement.querySelector('app-event-table-actions')).toBeNull();
+        expect(component.showRowActions).toBe(true);
 
         await component.pageChanges({ pageSize: 50 } as any);
         await component.selectedColumnsChange(['Name', 'Start Date']);

--- a/src/app/components/event-table/event.table.component.ts
+++ b/src/app/components/event-table/event.table.component.ts
@@ -160,6 +160,10 @@ export class EventTableComponent extends DataTableAbstractDirective implements O
     return !this.isBrowsePresentation && !!this.showActions;
   }
 
+  get showRowActions(): boolean {
+    return !!this.showActions;
+  }
+
   get tableSortActive(): string {
     return this.user?.settings?.dashboardSettings?.tableSettings?.active || 'Start Date';
   }
@@ -819,9 +823,15 @@ export class EventTableComponent extends DataTableAbstractDirective implements O
       'Actions',
     ];
 
-    this.displayedColumns = this.canManageEvents
-      ? columns
-      : columns.filter(column => column !== 'Checkbox' && column !== 'Shared' && column !== 'Actions');
+    this.displayedColumns = columns.filter(column => {
+      if (column === 'Checkbox' || column === 'Shared') {
+        return this.canManageEvents;
+      }
+      if (column === 'Actions') {
+        return this.showRowActions;
+      }
+      return true;
+    });
   }
 
   async saveEventDescription(description: string, event: EventInterface) {

--- a/src/app/shared/help.content.spec.ts
+++ b/src/app/shared/help.content.spec.ts
@@ -245,6 +245,7 @@ describe('help.content', () => {
     expect(calendarSection?.content).toContain('visible-period activity query');
     expect(calendarSection?.content).toContain('independent from the dashboard event table');
     expect(calendarSection?.content).toContain('Merge and benchmark records are excluded');
+    expect(calendarSection?.content).toContain('action menu to share, reprocess, download, or delete it');
     expect(calendarSection?.links).toContainEqual({
       label: 'Activity Calendar Overview',
       icon: 'travel_explore',

--- a/src/app/shared/help.content.ts
+++ b/src/app/shared/help.content.ts
@@ -121,7 +121,7 @@ const ACTIVITY_CALENDAR_HELP_CONTENT = `## Open and navigate the calendar
 - Below the calendar, **Activities** compares activity groups by recorded duration. Each bar uses the same color as its circles and is scaled against the longest-duration group in the selected period. The info control beside the heading explains this comparison.
 - Available duration, distance, ascent, and descent totals appear with icons beneath each bar. A metric is omitted when no positive recorded value exists, and **--** beside an activity group means duration was not recorded.
 - Lift-served downhill activities such as alpine skiing, snowboarding, and downhill cycling do not add ascent but do contribute descent. Ascent and descent summary exclusions configured in **Settings** also apply.
-- The activity table beneath the duration bars lists normal activities in the selected Week, Month, or Year. It follows Calendar navigation exactly, so it has no additional search, sport, tag, or date filters; use column sorting, pagination, or select a row to open the activity. Month tables exclude adjacent dates shown only to complete the grid.
+- The activity table beneath the duration bars lists normal activities in the selected Week, Month, or Year. It follows Calendar navigation exactly, so it has no additional search, sport, tag, or date filters; use column sorting, pagination, select a row to open the activity, or use its action menu to share, reprocess, download, or delete it. Month tables exclude adjacent dates shown only to complete the grid.
 
 ## Preferences and data scope
 


### PR DESCRIPTION
### Motivation
- Expose per-event row actions (share, reprocess, download, delete) from the Activity Calendar’s event table while preserving the Calendar’s compact browse presentation without dashboard-only bulk controls or persisted table preferences.
- Make the actions accessible with a stable header cell and document the availability in the Activity Calendar help content.
- Add regression coverage to ensure browse tables show row actions without enabling selection, sharing-status, tag, or bulk-management controls.

### Description
- Enable row-level actions by rendering `app-event-table` with `showActions` in the calendar table section and add a `showRowActions` getter to `EventTableComponent` to distinguish browse row actions from owner-level bulk controls.
- Change `updateDisplayedColumns()` to include the `Actions` column for row actions while keeping `Checkbox` and `Shared` columns gated by `canManageEvents` so bulk controls remain disabled in browse presentation.
- Render an accessible blank header for the actions column in the table template using an `aria-label` when bulk management is not available, and keep `app-event-table-actions` present only for owner-managed views.
- Update the Activity Calendar help content to document the per-row action menu and adjust unit tests to assert the new behavior and accessibility expectations.

### Testing
- Ran the component specs with `npx vitest run src/app/components/event-table/event.table.component.spec.ts src/app/components/event-table/activity-range-table-section.component.spec.ts src/app/shared/help.content.spec.ts --reporter=dot` and all targeted tests passed (`112` tests passed).
- Performed a project build with `npm run build -- --progress=false` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78e1b4b9b0832dacc9f530d86f8d28)