### PR TITLE
docs: improve GitHub discovery

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,91 @@
+name: Bug report
+description: Report a reproducible problem in Quantified Self.
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Quantified Self. Do not include access tokens,
+        credentials, private activity files, precise locations, or other personal
+        health data in a public issue.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Product area
+      options:
+        - Account and sign-in
+        - Activity import or upload
+        - Garmin integration
+        - Suunto integration
+        - COROS integration
+        - Wahoo integration
+        - Dashboard or calendar
+        - Training analysis
+        - Event details or charts
+        - Routes or maps
+        - Workout comparison or benchmark reports
+        - Assistant or MCP
+        - Subscription or billing
+        - Self-hosting or development setup
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the problem and its impact.
+      placeholder: A concise description of the unexpected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest repeatable sequence. Redact private data.
+      placeholder: |
+        1. Open ...
+        2. Select ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What should have happened instead?
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Quantified Self version
+      description: The version shown in the app header or the commit/tag used for self-hosting.
+      placeholder: e.g. 10.10.2 or commit SHA
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Browser and device
+      placeholder: e.g. Firefox 141 on Linux, Safari on iPhone 16
+    validations:
+      required: true
+  - type: textarea
+    id: safe_diagnostics
+    attributes:
+      label: Sanitized diagnostics
+      description: Optional error text or screenshots with tokens, IDs, names, locations, and health data removed.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checklist
+      options:
+        - label: I searched existing issues for the same problem.
+          required: true
+        - label: I removed credentials, personal health data, private files, and precise locations.
+          required: true
+        - label: I can reproduce this on the version listed above.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and community support
+    url: https://github.com/jimmykane/quantified-self/discussions
+    about: Ask setup, usage, and development questions in GitHub Discussions.
+  - name: Hosted app help
+    url: https://quantified-self.io/help
+    about: Check product help, provider setup guidance, and troubleshooting.
+  - name: Security vulnerability
+    url: https://github.com/jimmykane/quantified-self/security/policy
+    about: Report vulnerabilities privately through the security policy instead of a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,73 @@
+name: Feature request
+description: Propose a user problem or workflow Quantified Self could support.
+title: "feature: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Strong requests begin with the user problem and evidence. Please avoid
+        including credentials, private activity files, precise locations, or
+        personal health data.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or opportunity
+      description: Who has this problem, when does it occur, and what is difficult today?
+      placeholder: When I ..., I need ..., because ...
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe the successful user result without prescribing implementation details.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed workflow
+      description: Optional steps, UI ideas, data sources, or examples.
+  - type: dropdown
+    id: audience
+    attributes:
+      label: Primary audience
+      options:
+        - Athlete using one provider
+        - Athlete using multiple providers or devices
+        - Athlete migrating between providers
+        - Coach or reviewer
+        - Self-hosting operator
+        - Contributor or integrator
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Current alternatives
+      description: How do users solve or work around this today?
+  - type: textarea
+    id: privacy
+    attributes:
+      label: Privacy, security, and data considerations
+      description: Note any sensitive fields, provider credentials, sharing, retention, location, or medical-claim concerns.
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Suggested acceptance criteria
+      placeholder: |
+        - [ ] A user can ...
+        - [ ] Missing or malformed data ...
+        - [ ] Relevant tests and help content ...
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checklist
+      options:
+        - label: I searched existing issues and linked related requests where relevant.
+          required: true
+        - label: I described the user problem separately from the proposed solution.
+          required: true

--- a/.github/ISSUE_TEMPLATE/provider_integration.yml
+++ b/.github/ISSUE_TEMPLATE/provider_integration.yml
@@ -1,0 +1,61 @@
+name: Provider or device integration request
+description: Request a new fitness provider, wearable, or data-source integration.
+title: "integration: "
+labels:
+  - enhancement
+body:
+  - type: input
+    id: provider
+    attributes:
+      label: Provider or device
+      placeholder: e.g. Polar, Health Connect, Apple Health
+    validations:
+      required: true
+  - type: dropdown
+    id: workflow
+    attributes:
+      label: Needed workflow
+      multiple: true
+      options:
+        - Import new activities automatically
+        - Import historical activities
+        - Import sleep or recovery data
+        - Import body measurements
+        - Export activities
+        - Send routes or courses
+        - Send workouts or training plans
+        - Use data through Assistant or MCP
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use case and expected value
+      description: Explain the real workflow this integration would unblock.
+    validations:
+      required: true
+  - type: textarea
+    id: api
+    attributes:
+      label: Known API or export options
+      description: Link public official documentation if available. Never paste credentials or private API keys.
+  - type: textarea
+    id: fields
+    attributes:
+      label: Important data fields
+      description: Which activities, metrics, sleep fields, files, or routes must be preserved?
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Current workaround
+      description: Describe manual exports, bridge services, or other tools used today.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checklist
+      options:
+        - label: I searched existing provider and device requests.
+          required: true
+        - label: I have not included credentials, private files, or personal health/location data.
+          required: true

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ These policies are infrastructure configuration; starting local emulators does n
 
 ## Contributing
 
-Contributions are welcome. Before opening a pull request:
+Contributions are welcome. Start with a [`good first issue`](https://github.com/jimmykane/quantified-self/labels/good%20first%20issue), or ask a question in [GitHub Discussions](https://github.com/jimmykane/quantified-self/discussions). Before opening a pull request:
 
 1. Keep changes focused and add or update the narrowest relevant tests.
 2. Run the applicable checks from the table above.


### PR DESCRIPTION
Tracks #573

## Summary

- link new contributors to `good first issue` and GitHub Discussions
- add structured issue forms for bugs, feature requests, and provider/device integrations
- direct support and security reports to the appropriate channels

## Correction

- removed the rejected fabricated product mock-up and its README reference
- a README GIF will only be added from a real, owner-approved product capture

## Validation

- parsed all issue-form YAML successfully
- verified the rejected GIF is absent from the branch and final diff
- compared the branch with `main`: five expected files and no unrelated changes
- no application tests run (documentation and GitHub configuration only)

## Repository settings to apply alongside this PR

- replace dated Hacktoberfest topics with: `garmin`, `suunto`, `coros`, `wahoo`, `fit-file`, `training-analysis`, `fitness-data`, `mcp`, and `sports-analytics`
- enable GitHub Discussions
- create the `good first issue` label
