### PR TITLE
feat: add supported activities reference page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Always-on rules:
 - When asked to commit, use unsigned commits by default (`git commit --no-gpg-sign`) unless the user explicitly asks for a signed commit.
 - After completing implementation changes, create an unsigned commit by default, staging only files changed for the current task with explicit paths. Do not push unless the user explicitly asks.
 - When building a feature, review the app help page and update or add help content when needed.
+- When adding a new indexable public page, add it to `src/sitemap.xml` in the same change. Also verify its `robots.txt` policy, SSR/prerender registration, route SEO metadata, public-route handling, internal links, and tests. Deliberately exclude non-indexable pages from the sitemap and set their `noindex` policy where applicable.
 - Before changing the Training workspace, Training settings, Training-derived metrics, or sports-lib durability integration,
   read `docs/training-workspace.md` completely and update the relevant sections in the same change. Keep this as the
   single detailed Training source of truth instead of creating a competing Training architecture document.

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ These policies are infrastructure configuration; starting local emulators does n
 - [Training workspace architecture and maintenance](docs/training-workspace.md)
 - [Frontend UI composition and shared route headers](docs/frontend-ui.md)
 - [Event chart sport defaults and visibility persistence](docs/event-chart-visibility.md)
+- [Supported activities and metrics catalog](docs/supported-activities.md)
 - [MCP-backed built-in Assistant](docs/assistant.md)
 - [Activity Calendar architecture and maintenance](docs/activity-calendar.md)
 - [Read-only MCP server](docs/mcp-server.md)

--- a/docs/supported-activities.md
+++ b/docs/supported-activities.md
@@ -1,0 +1,81 @@
+# Supported Activities and Metrics Catalog
+
+The public **Supported Activities & Metrics** page at `/features/supported-activities` is the user-facing reference
+for every canonical activity type recognized by the pinned `@sports-alliance/sports-lib` release. It explains the
+distinction between recognition, the activity family used throughout the product, and the records that an imported
+activity actually contains.
+
+## Canonical catalog ownership
+
+`shared/activity-type-group.metadata.ts` owns Quantified Self's presentation metadata for Sports Lib activity groups:
+labels, aliases, and ambiguity rules. It derives group membership from the unique canonical Sports Lib activity-type
+array and `getActivityGroupForActivityType`, then sorts each group by name. `getActivityTypeGroupCatalog()` joins that
+membership to the presentation metadata.
+
+This deliberately avoids treating Sports Lib's direct group-member convenience function as the catalog source: the
+unique canonical type array is the complete partition, including the Unspecified fallback family. The page therefore
+cannot silently omit a recognized type or show one in two families. The exhaustive helper test verifies the current
+release's group count, type count, deduplication, and exact partition.
+
+The Angular page is split into:
+
+- `supported-activities-page.content.ts` for the catalog-derived public content, visual mappings, and SEO data;
+- `supported-activities-page.component.*` for searchable, expanded family cards; and
+- `supported-activities-page.paths.ts` for the shared route path.
+
+It uses the existing `AppActivityTypeGroupIcons`, colors, and gradients. There is no second hand-maintained activity
+list, no raster icon set, and no provider compatibility matrix.
+
+## What “supported” means
+
+Recognizing an activity type means Quantified Self can classify and present an imported activity using that canonical
+type. It does not promise that every device, provider, import format, or recording setting supplies the same fields.
+Distance, route, terrain, sensors, laps, lengths, jumps, charts, and sport-specific details are shown only when
+compatible records arrive in the source data.
+
+The page, Help section, integration links, and discovery links must retain that source-dependent wording. Do not turn
+the catalog into a claim that a provider supports every type or metric.
+
+## Families and Event Details profiles
+
+Families organize activities for product presentation, filters, labels, icons, colors, and related fallback behavior.
+They are not a universal chart-profile declaration. Event Details resolves chart recommendations through the exact
+canonical activity type first; the current multi-activity fallback rules are maintained in
+[`event-chart-visibility.md`](event-chart-visibility.md).
+
+Two intentional examples must remain clear in user-facing content and regression tests:
+
+- **Boating** belongs to the Motorized family while retaining Sailing chart recommendations for an individual
+  Boating activity.
+- **Wheel Chair** belongs to Adaptive Mobility while retaining Cycling chart recommendations when compatible source
+  metrics exist. This does not by itself classify it as Cycling for Training.
+
+Hand Cycle and Velomobile are Cycling types. They use the existing Cycling chart recommendations and may enter
+Cycling Training analysis only when the current recorded-evidence and eligibility rules are satisfied. Do not flatten
+these distinctions merely to make a family appear uniform.
+
+## Diving
+
+Diving, Scuba Diving, Free Diving, Snorkeling, and Mermaiding have source-native Event Details presentation. Depth,
+decompression, timing/rate, tissue-load, SAC/RMV, gas, tank, and Dive Profile information appears only when the
+original activity source supplies compatible records. The product never invents, names, associates, or calculates
+missing gas or tank data.
+
+Diving-only Events omit terrain altitude, ascent, descent, and grade summaries because their vertical movement is
+represented as depth. Mixed Events retain terrain summaries only from non-Diving activities. The detailed chart and
+profile exclusions remain owned by [`event-chart-visibility.md`](event-chart-visibility.md).
+
+## Maintenance checklist
+
+When changing the pinned Sports Lib activity types or activity-group behavior:
+
+1. Update the shared dependency in both the application and Functions as required by the release lifecycle.
+2. Inspect the canonical catalog with `getActivityTypeGroupCatalog()` and update its exhaustive test expectations.
+3. Ensure every group has existing icon, color, and gradient mappings before the public page renders it.
+4. Update the public page, Help content, this document, sitemap/robots/prerender route configuration, and SEO checks
+   if the public route or its contract changes.
+5. If a chart recommendation changes, update the Event Details resolver tests, Help content, and
+   `event-chart-visibility.md` together; preserve exact-type-first behavior unless the product contract deliberately
+   changes.
+6. Run the focused catalog, page, routing, Help, hosting, and SEO tests, then `npm run lint` and
+   `npm run build-production`.

--- a/docs/supported-activities.md
+++ b/docs/supported-activities.md
@@ -33,6 +33,10 @@ type. It does not promise that every device, provider, import format, or recordi
 Distance, route, terrain, sensors, laps, lengths, jumps, charts, and sport-specific details are shown only when
 compatible records arrive in the source data.
 
+Event Details shows Laps when selected activities contain lap data, Swim Lengths when a swimming source includes
+per-length pool data, and Jumps when selected activities contain jump events. Charts and overlays likewise need
+compatible source time series. These are source-record surfaces, not additional promises made by catalog membership.
+
 The page, Help section, integration links, and discovery links must retain that source-dependent wording. Do not turn
 the catalog into a claim that a provider supports every type or metric.
 

--- a/shared/activity-type-group.metadata.ts
+++ b/shared/activity-type-group.metadata.ts
@@ -12,6 +12,10 @@ export interface ActivityTypeGroupMetadata {
   ambiguous: boolean;
 }
 
+export interface ActivityTypeGroupCatalogEntry extends ActivityTypeGroupMetadata {
+  activityTypes: ActivityTypes[];
+}
+
 const ActivityTypeGroupMetadataMap: Record<ActivityTypeGroup, ActivityTypeGroupMetadata> = {
   [ActivityTypeGroups.RunningGroup]: {
     id: ActivityTypeGroups.RunningGroup,
@@ -183,34 +187,18 @@ export function resolveActivityTypeGroup(value: unknown): ActivityTypeGroup | nu
 }
 
 export function getActivityTypesForGroup(activityTypeGroup: ActivityTypeGroup): ActivityTypes[] {
-  const helper = ActivityTypesHelper as unknown as {
-    getActivityTypesForActivityGroup?: (group: ActivityTypeGroup) => ActivityTypes[];
-    getActivityGroupForActivityType?: (activityType: ActivityTypes) => ActivityTypeGroup;
-  };
+  const canonicalActivityTypes = ActivityTypesHelper.getActivityTypesAsUniqueArray() as ActivityTypes[];
 
-  if (typeof helper.getActivityTypesForActivityGroup === 'function') {
-    try {
-      return helper.getActivityTypesForActivityGroup(activityTypeGroup);
-    } catch {
-      // Fall through to group-by-activity lookup so module initialization cannot fail.
-    }
-  }
+  return [...new Set(canonicalActivityTypes)]
+    .filter(activityType => ActivityTypesHelper.getActivityGroupForActivityType(activityType) === activityTypeGroup)
+    .sort((left, right) => left.localeCompare(right));
+}
 
-  if (typeof helper.getActivityGroupForActivityType === 'function') {
-    const deduped = new Set<ActivityTypes>();
-    for (const activityType of Object.values(ActivityTypes) as ActivityTypes[]) {
-      try {
-        if (helper.getActivityGroupForActivityType(activityType) === activityTypeGroup) {
-          deduped.add(activityType);
-        }
-      } catch {
-        // Ignore malformed values and continue collecting valid members.
-      }
-    }
-    return [...deduped];
-  }
-
-  return [];
+export function getActivityTypeGroupCatalog(): ActivityTypeGroupCatalogEntry[] {
+  return getActivityTypeGroupMetadataList().map(metadata => ({
+    ...metadata,
+    activityTypes: getActivityTypesForGroup(metadata.id),
+  }));
 }
 
 const EXPLICIT_INDOOR_ACTIVITY_TYPES = new Set<ActivityTypes>([

--- a/shared/activity-type-group.metadata.ts
+++ b/shared/activity-type-group.metadata.ts
@@ -16,6 +16,12 @@ export interface ActivityTypeGroupCatalogEntry extends ActivityTypeGroupMetadata
   activityTypes: ActivityTypes[];
 }
 
+const CanonicalActivityTypeValues = new Set<string>(Object.values(ActivityTypes));
+
+function isCanonicalActivityType(value: string): value is ActivityTypes {
+  return CanonicalActivityTypeValues.has(value);
+}
+
 const ActivityTypeGroupMetadataMap: Record<ActivityTypeGroup, ActivityTypeGroupMetadata> = {
   [ActivityTypeGroups.RunningGroup]: {
     id: ActivityTypeGroups.RunningGroup,
@@ -187,7 +193,8 @@ export function resolveActivityTypeGroup(value: unknown): ActivityTypeGroup | nu
 }
 
 export function getActivityTypesForGroup(activityTypeGroup: ActivityTypeGroup): ActivityTypes[] {
-  const canonicalActivityTypes = ActivityTypesHelper.getActivityTypesAsUniqueArray() as ActivityTypes[];
+  const canonicalActivityTypes = ActivityTypesHelper.getActivityTypesAsUniqueArray()
+    .filter(isCanonicalActivityType);
 
   return [...new Set(canonicalActivityTypes)]
     .filter(activityType => ActivityTypesHelper.getActivityGroupForActivityType(activityType) === activityTypeGroup)

--- a/src/app/app.routes.server.spec.ts
+++ b/src/app/app.routes.server.spec.ts
@@ -64,6 +64,7 @@ describe('serverRoutes', () => {
     expect(PRERENDERED_FEATURE_ROUTES).toEqual([
       'features',
       'features/workout-data-comparison',
+      'features/supported-activities',
       'features/activity-calendar',
       'features/training-analysis',
       'features/mcp-server',
@@ -111,6 +112,7 @@ describe('serverRoutes', () => {
     expect(prerenderedPaths.has('tools/compare/saved')).toBe(false);
     expect(prerenderedPaths.has('features')).toBe(true);
     expect(prerenderedPaths.has('features/workout-data-comparison')).toBe(true);
+    expect(prerenderedPaths.has('features/supported-activities')).toBe(true);
     expect(prerenderedPaths.has('features/activity-calendar')).toBe(true);
     expect(prerenderedPaths.has('features/training-analysis')).toBe(true);
     expect(prerenderedPaths.has('features/mcp-server')).toBe(true);

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -1,5 +1,6 @@
 import { RenderMode, ServerRoute } from '@angular/ssr';
 import { WORKOUT_DATA_COMPARISON_PATH } from './components/features/workout-data-comparison-page.paths';
+import { SUPPORTED_ACTIVITIES_PATH } from './components/features/supported-activities-page.paths';
 import { PUBLIC_FEATURE_PATHS, PUBLIC_GUIDE_PATHS } from './components/public-seo/public-seo-pages.paths';
 
 export const PRERENDERED_INTEGRATION_ROUTES = [
@@ -13,6 +14,7 @@ export const PRERENDERED_INTEGRATION_ROUTES = [
 export const PRERENDERED_FEATURE_ROUTES = [
   PUBLIC_FEATURE_PATHS.hub,
   WORKOUT_DATA_COMPARISON_PATH,
+  SUPPORTED_ACTIVITIES_PATH,
   PUBLIC_FEATURE_PATHS.activityCalendar,
   PUBLIC_FEATURE_PATHS.trainingAnalysis,
   PUBLIC_FEATURE_PATHS.mcpServer,

--- a/src/app/app.routing.module.spec.ts
+++ b/src/app/app.routing.module.spec.ts
@@ -349,6 +349,31 @@ describe('AppRoutingModule routes', () => {
     });
   });
 
+  it('should define a public supported activities feature route with lazily resolved SEO metadata', async () => {
+    const route = routes.find(candidate => candidate.path === 'features/supported-activities');
+    const routeData = await resolvedRouteData(route);
+    const jsonLd = routeData['jsonLd'] as Record<string, unknown> | undefined;
+
+    expect(route).toBeTruthy();
+    expect(route?.canMatch).toBeUndefined();
+    expect(route?.loadComponent).toBeTypeOf('function');
+    expect(route?.data).toMatchObject({
+      preload: true,
+      animation: 'Features',
+    });
+    expect(routeData['title']).toBe('Supported Activities & Metrics');
+    expect(routeData['description']).toContain('canonical activity types');
+    expect(routeData['description']).toContain('original activity source');
+    expect(routeData['keywords']).toBeUndefined();
+    expect(jsonLd).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'WebPage',
+      name: 'Supported Activities & Metrics',
+      url: 'https://quantified-self.io/features/supported-activities',
+      inLanguage: 'en',
+    });
+  });
+
   it('should define public feature SEO routes with lazily resolved metadata and no guards', async () => {
     const expectedRoutes = [
       {

--- a/src/app/app.routing.module.ts
+++ b/src/app/app.routing.module.ts
@@ -10,6 +10,7 @@ import { pricingRedirectGuard } from './authentication/pricing-redirect.guard';
 import { releasesResolver } from './resolvers/releases.resolver';
 import { toolsCompareAuthResolver } from './resolvers/tools-compare-auth.resolver';
 import { WORKOUT_DATA_COMPARISON_PATH } from './components/features/workout-data-comparison-page.paths';
+import { SUPPORTED_ACTIVITIES_PATH } from './components/features/supported-activities-page.paths';
 import {
   PUBLIC_FEATURE_PATHS,
   PUBLIC_GUIDE_PATHS,
@@ -58,6 +59,14 @@ function workoutDataComparisonRouteData(): ResolveData {
   );
 }
 
+function supportedActivitiesRouteData(): ResolveData {
+  return lazyRouteData(
+    () => import('./components/features/supported-activities-page.content')
+      .then(module => module.SUPPORTED_ACTIVITIES_ROUTE_DATA),
+    SEO_RESOLVED_KEYS,
+  );
+}
+
 function publicSeoRouteData(page: PublicSeoPageKey): ResolveData {
   return lazyRouteData(
     () => import('./components/public-seo/public-seo-pages.content')
@@ -84,6 +93,7 @@ const PUBLIC_LAYOUT_ROUTE_PATHS = new Set<string>([
   'integrations/coros',
   'integrations/wahoo',
   WORKOUT_DATA_COMPARISON_PATH,
+  SUPPORTED_ACTIVITIES_PATH,
   ...Object.values(PUBLIC_FEATURE_PATHS),
   ...Object.values(PUBLIC_GUIDE_PATHS),
   'share/event/:userID/:eventID',
@@ -338,6 +348,15 @@ const topLevelRoutes: Routes = [
     path: WORKOUT_DATA_COMPARISON_PATH,
     loadComponent: () => import('./components/features/workout-data-comparison-page.component').then(m => m.WorkoutDataComparisonPageComponent),
     resolve: workoutDataComparisonRouteData(),
+    data: {
+      preload: true,
+      animation: 'Features',
+    },
+  },
+  {
+    path: SUPPORTED_ACTIVITIES_PATH,
+    loadComponent: () => import('./components/features/supported-activities-page.component').then(m => m.SupportedActivitiesPageComponent),
+    resolve: supportedActivitiesRouteData(),
     data: {
       preload: true,
       animation: 'Features',

--- a/src/app/components/dashboard/dashboard.component.html
+++ b/src/app/components/dashboard/dashboard.component.html
@@ -39,7 +39,7 @@
               <mat-icon aria-hidden="true">sync</mat-icon>
               <span>Connect service</span>
             </button>
-            <a mat-button href="/features/supported-activities">
+            <a mat-button routerLink="/features/supported-activities">
               <mat-icon aria-hidden="true">category</mat-icon>
               <span>Check supported activities</span>
             </a>

--- a/src/app/components/dashboard/dashboard.component.html
+++ b/src/app/components/dashboard/dashboard.component.html
@@ -39,6 +39,10 @@
               <mat-icon aria-hidden="true">sync</mat-icon>
               <span>Connect service</span>
             </button>
+            <a mat-button href="/features/supported-activities">
+              <mat-icon aria-hidden="true">category</mat-icon>
+              <span>Check supported activities</span>
+            </a>
             <mat-menu #noActivityConnectServiceMenu="matMenu" class="qs-menu-panel">
               @for (option of noActivityConnectServiceOptions; track option.serviceName) {
               <button mat-menu-item type="button" (click)="onNoActivityConnectService(option.serviceName)">

--- a/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/src/app/components/dashboard/dashboard.component.spec.ts
@@ -337,6 +337,8 @@ describe('DashboardComponent', () => {
         expect(text).toContain('Upload an activity file or connect Garmin, Suunto, COROS, or Wahoo.');
         expect(template).toContain('[fullWidth]="true"');
         expect(template).toContain('uploadLabel="Upload activity"');
+        expect(template).toContain('routerLink="/features/supported-activities"');
+        expect(template).not.toContain('href="/features/supported-activities"');
         expect(component.dashboardActionPrompts.some(prompt => prompt.id === 'connectActivityService')).toBe(false);
     });
 

--- a/src/app/components/event-summary/event-summary.component.html
+++ b/src/app/components/event-summary/event-summary.component.html
@@ -40,6 +40,10 @@
       }
 
       <div class="event-summary-actions-secondary">
+        <a mat-icon-button class="summary-stats-action-button" href="/features/supported-activities"
+          matTooltip="Supported activities & metrics" aria-label="Supported activities and metrics">
+          <mat-icon>category</mat-icon>
+        </a>
         @if (hasDevices) {
         <button mat-icon-button class="summary-stats-action-button devices-button" (click)="openDevices()"
           matTooltip="View sensors & devices" aria-label="View sensors and devices">

--- a/src/app/components/event-summary/event-summary.component.html
+++ b/src/app/components/event-summary/event-summary.component.html
@@ -40,7 +40,7 @@
       }
 
       <div class="event-summary-actions-secondary">
-        <a mat-icon-button class="summary-stats-action-button" href="/features/supported-activities"
+        <a mat-icon-button class="summary-stats-action-button" routerLink="/features/supported-activities"
           matTooltip="Supported activities & metrics" aria-label="Supported activities and metrics">
           <mat-icon>category</mat-icon>
         </a>

--- a/src/app/components/event-summary/event-summary.component.spec.ts
+++ b/src/app/components/event-summary/event-summary.component.spec.ts
@@ -95,6 +95,16 @@ describe('EventSummaryComponent', () => {
         expect(component).toBeTruthy();
     });
 
+    it('uses client-side routing for the supported activities reference', () => {
+        const template = readFileSync(
+            resolve(process.cwd(), 'src/app/components/event-summary/event-summary.component.html'),
+            'utf8'
+        );
+
+        expect(template).toContain('routerLink="/features/supported-activities"');
+        expect(template).not.toContain('href="/features/supported-activities"');
+    });
+
     it('keeps the event detail summary out of an outer glass card surface', () => {
         const template = readFileSync(
             resolve(process.cwd(), 'src/app/components/event-summary/event-summary.component.html'),

--- a/src/app/components/features/supported-activities-page.component.html
+++ b/src/app/components/features/supported-activities-page.component.html
@@ -23,13 +23,39 @@
       <p class="eyebrow">What support means</p>
       <h2 id="support-levels-title">Recognition is not a promise of every metric</h2>
       <p>
-        A recognized activity type can be imported and presented in Quantified Self. The available detail still follows
-        the source file or connected service, not a universal sport template.
+        Quantified Self can classify and present a recognized type when it appears in imported data. The available
+        detail still follows the source file or connected service, not a universal sport template.
       </p>
     </div>
     <div class="support-level-grid">
       @for (item of supportLevels; track item.title) {
       <mat-card appearance="outlined" class="support-level-card">
+        <mat-card-header>
+          <div mat-card-avatar class="support-level-avatar">
+            <mat-icon aria-hidden="true">{{ item.icon }}</mat-icon>
+          </div>
+          <mat-card-title>{{ item.title }}</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <p>{{ item.copy }}</p>
+        </mat-card-content>
+      </mat-card>
+      }
+    </div>
+  </section>
+
+  <section class="content-section" aria-labelledby="specialized-surfaces-title">
+    <div class="section-heading">
+      <p class="eyebrow">Source-provided detail</p>
+      <h2 id="specialized-surfaces-title">Specialized surfaces appear when records exist</h2>
+      <p>
+        Importing a recognized type does not manufacture laps, lengths, jump events, or continuous chart samples.
+        Event Details exposes these surfaces only when compatible source records are present.
+      </p>
+    </div>
+    <div class="presentation-grid">
+      @for (item of specializedSurfaces; track item.title) {
+      <mat-card appearance="outlined" class="presentation-card">
         <mat-card-header>
           <div mat-card-avatar class="support-level-avatar">
             <mat-icon aria-hidden="true">{{ item.icon }}</mat-icon>

--- a/src/app/components/features/supported-activities-page.component.html
+++ b/src/app/components/features/supported-activities-page.component.html
@@ -1,0 +1,187 @@
+<main class="supported-activities-page">
+  <section class="hero-section" aria-labelledby="supported-activities-title">
+    <p class="eyebrow">Activity reference</p>
+    <h1 id="supported-activities-title">Supported activities &amp; metrics</h1>
+    <p class="hero-copy">
+      Quantified Self recognizes {{ totalActivityTypeCount }} canonical activity types. Browse the families used across
+      the app, then see why the metrics and Event Details charts available for one activity always depend on its
+      original recording.
+    </p>
+    <div class="hero-actions" aria-label="Supported activities actions">
+      <a mat-flat-button class="qs-mat-primary" routerLink="/login">
+        Get started free
+        <mat-icon iconPositionEnd>arrow_forward</mat-icon>
+      </a>
+      <a mat-stroked-button routerLink="/integrations">
+        Explore integrations
+      </a>
+    </div>
+  </section>
+
+  <section class="content-section" aria-labelledby="support-levels-title">
+    <div class="section-heading">
+      <p class="eyebrow">What support means</p>
+      <h2 id="support-levels-title">Recognition is not a promise of every metric</h2>
+      <p>
+        A recognized activity type can be imported and presented in Quantified Self. The available detail still follows
+        the source file or connected service, not a universal sport template.
+      </p>
+    </div>
+    <div class="support-level-grid">
+      @for (item of supportLevels; track item.title) {
+      <mat-card appearance="outlined" class="support-level-card">
+        <mat-card-header>
+          <div mat-card-avatar class="support-level-avatar">
+            <mat-icon aria-hidden="true">{{ item.icon }}</mat-icon>
+          </div>
+          <mat-card-title>{{ item.title }}</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <p>{{ item.copy }}</p>
+        </mat-card-content>
+      </mat-card>
+      }
+    </div>
+  </section>
+
+  <section class="content-section catalog-section" aria-labelledby="activity-catalog-title">
+    <div class="section-heading">
+      <p class="eyebrow">Canonical catalog</p>
+      <h2 id="activity-catalog-title">Find your activity type</h2>
+      <p>All families are expanded so you can scan the exact names recognized by the current catalog.</p>
+    </div>
+
+    <div class="catalog-toolbar">
+      <mat-form-field appearance="outline" class="activity-search">
+        <mat-label>Search activity types and families</mat-label>
+        <mat-icon matPrefix>search</mat-icon>
+        <input
+          #searchInput
+          matInput
+          type="search"
+          [value]="searchQuery()"
+          (input)="onSearchQueryChange(searchInput.value)">
+        @if (searchQuery()) {
+        <button mat-icon-button matSuffix type="button" aria-label="Clear activity search" (click)="clearSearch()">
+          <mat-icon>close</mat-icon>
+        </button>
+        }
+      </mat-form-field>
+      <p class="catalog-result-summary" aria-live="polite">{{ searchResultSummary() }}</p>
+    </div>
+
+    @if (filteredFamilies().length) {
+    <div class="family-grid">
+      @for (family of filteredFamilies(); track family.id) {
+      <mat-card appearance="outlined" class="family-card" [attr.data-family-id]="family.id" [style.border-top-color]="family.color">
+        <mat-card-header>
+          <div
+            mat-card-avatar
+            class="family-avatar"
+            [style.background]="family.gradient">
+            <mat-icon aria-hidden="true">{{ family.icon }}</mat-icon>
+          </div>
+          <mat-card-title>{{ family.label }}</mat-card-title>
+          <mat-card-subtitle>
+            {{ family.activityTypes.length }} recognized activity type{{ family.activityTypes.length === 1 ? '' : 's' }}
+          </mat-card-subtitle>
+        </mat-card-header>
+        <mat-card-content class="family-card-content">
+          @if (family.fallback) {
+          <p class="family-note">Recognized fallback types without a dedicated sport family. Available details remain source-dependent.</p>
+          }
+          <mat-chip-set [attr.aria-label]="family.label + ' activity types'">
+            @for (activityType of family.activityTypes; track activityType) {
+            <mat-chip>{{ activityType }}</mat-chip>
+            }
+          </mat-chip-set>
+        </mat-card-content>
+      </mat-card>
+      }
+    </div>
+    } @else {
+    <mat-card appearance="outlined" class="empty-search-card">
+      <mat-card-content>
+        <mat-icon aria-hidden="true">search_off</mat-icon>
+        <div>
+          <h3>No recognized activity types match</h3>
+          <p>Try a shorter name, a family such as Cycling, or a type such as Hand Cycle.</p>
+        </div>
+      </mat-card-content>
+    </mat-card>
+    }
+  </section>
+
+  <section class="content-section" aria-labelledby="event-details-title">
+    <div class="section-heading">
+      <p class="eyebrow">Event Details</p>
+      <h2 id="event-details-title">Family and chart recommendations are different</h2>
+      <p>
+        Exact activity types select the most relevant chart recommendations first. If a merged event contains multiple
+        related activities, it can use a shared family recommendation. Neither path creates a metric the source did not record.
+      </p>
+    </div>
+    <div class="presentation-grid">
+      @for (item of presentationNotes; track item.title) {
+      <mat-card appearance="outlined" class="presentation-card">
+        <mat-card-header>
+          <div mat-card-avatar class="support-level-avatar">
+            <mat-icon aria-hidden="true">{{ item.icon }}</mat-icon>
+          </div>
+          <mat-card-title>{{ item.title }}</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <p>{{ item.copy }}</p>
+        </mat-card-content>
+      </mat-card>
+      }
+    </div>
+  </section>
+
+  <section class="content-section diving-section" aria-labelledby="diving-support-title">
+    <div class="section-heading">
+      <p class="eyebrow">Specialized presentation</p>
+      <h2 id="diving-support-title">Diving is source-native by design</h2>
+      <p>
+        Diving, Scuba Diving, Free Diving, Snorkeling, and Mermaiding have specialized Event Details behavior when
+        their original source contains the relevant records.
+      </p>
+    </div>
+    <mat-card appearance="outlined" class="diving-card">
+      <mat-card-header>
+        <div mat-card-avatar class="diving-avatar"><mat-icon aria-hidden="true">scuba_diving</mat-icon></div>
+        <mat-card-title>Depth, gas, and tank records stay source-provided</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <p>
+          Continuous source depth enables Dive Profile. Depth, decompression, timing/rate, tissue-load, SAC/RMV, gas,
+          and tank details appear only when the original source provides them. Quantified Self never creates, names,
+          associates, or calculates missing gas and tank data.
+        </p>
+        <p>
+          Diving-only Events intentionally omit terrain altitude, ascent, descent, and grade summaries because dive
+          vertical movement is represented by depth. Mixed Events retain terrain summaries only from non-Diving activities.
+        </p>
+        <a mat-stroked-button routerLink="/help" fragment="supported-activities">
+          Read the supported activities Help guide
+          <mat-icon iconPositionEnd>arrow_forward</mat-icon>
+        </a>
+      </mat-card-content>
+    </mat-card>
+  </section>
+
+  <section class="content-section provider-section" aria-labelledby="provider-context-title">
+    <div class="section-heading">
+      <p class="eyebrow">Import context</p>
+      <h2 id="provider-context-title">Your source determines the detail</h2>
+      <p>
+        Garmin, Suunto, COROS, Wahoo, and uploaded FIT, GPX, TCX, JSON, or SML files can carry different activity
+        fields. Check the activity source and integration guidance when a metric is missing.
+      </p>
+    </div>
+    <div class="hero-actions">
+      <a mat-stroked-button routerLink="/integrations">Explore integrations</a>
+      <a mat-stroked-button routerLink="/help" fragment="uploads-and-imports">Uploads and imports Help</a>
+    </div>
+  </section>
+</main>

--- a/src/app/components/features/supported-activities-page.component.scss
+++ b/src/app/components/features/supported-activities-page.component.scss
@@ -1,0 +1,147 @@
+.supported-activities-page {
+  display: grid;
+  gap: clamp(2rem, 5vw, 4rem);
+  max-width: 76rem;
+  margin: 0 auto;
+  padding: clamp(2rem, 5vw, 4rem) clamp(1rem, 4vw, 2rem) 4rem;
+}
+
+.hero-section,
+.content-section,
+.section-heading,
+.catalog-toolbar,
+.family-card-content,
+.diving-card mat-card-content {
+  display: grid;
+  gap: 1rem;
+}
+
+.hero-section {
+  max-width: 54rem;
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--mat-sys-primary);
+  font: var(--mat-sys-label-large);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin: 0;
+}
+
+h1 {
+  font: var(--mat-sys-display-small);
+}
+
+h2 {
+  font: var(--mat-sys-headline-medium);
+}
+
+h3 {
+  font: var(--mat-sys-title-medium);
+}
+
+.hero-copy,
+.section-heading p,
+.family-note,
+.catalog-result-summary,
+.diving-card p {
+  color: var(--mat-sys-on-surface-variant);
+  font: var(--mat-sys-body-large);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.support-level-grid,
+.presentation-grid,
+.family-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.support-level-grid,
+.presentation-grid {
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+}
+
+.family-grid {
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+}
+
+.support-level-card,
+.presentation-card,
+.family-card {
+  height: 100%;
+}
+
+.family-card {
+  border-top-width: 0.25rem;
+}
+
+.support-level-avatar,
+.family-avatar,
+.diving-avatar {
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+}
+
+.support-level-avatar {
+  background: var(--mat-sys-primary-container);
+  color: var(--mat-sys-on-primary-container);
+}
+
+.family-avatar {
+  color: var(--mat-sys-on-primary);
+}
+
+.diving-avatar {
+  background: var(--mat-sys-tertiary-container);
+  color: var(--mat-sys-on-tertiary-container);
+}
+
+.family-note {
+  font: var(--mat-sys-body-medium);
+}
+
+.activity-search {
+  width: min(100%, 34rem);
+}
+
+.catalog-result-summary {
+  font: var(--mat-sys-body-medium);
+}
+
+.empty-search-card mat-card-content {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.empty-search-card mat-icon {
+  color: var(--mat-sys-primary);
+}
+
+@media (max-width: 37.5rem) {
+  .hero-actions {
+    display: grid;
+  }
+
+  .hero-actions > a {
+    width: 100%;
+  }
+
+  .family-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/src/app/components/features/supported-activities-page.component.spec.ts
+++ b/src/app/components/features/supported-activities-page.component.spec.ts
@@ -1,0 +1,55 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { describe, expect, it } from 'vitest';
+import { SupportedActivitiesPageComponent } from './supported-activities-page.component';
+
+describe('SupportedActivitiesPageComponent', () => {
+  it('renders all activity families and filters the expanded catalog by activity type', () => {
+    TestBed.configureTestingModule({
+      imports: [
+        SupportedActivitiesPageComponent,
+        RouterTestingModule.withRoutes([]),
+        NoopAnimationsModule,
+        MatIconTestingModule,
+      ],
+    });
+
+    const fixture: ComponentFixture<SupportedActivitiesPageComponent> = TestBed.createComponent(SupportedActivitiesPageComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('131 canonical activity types');
+    expect(fixture.nativeElement.querySelectorAll('.family-card')).toHaveLength(17);
+    expect(fixture.nativeElement.querySelector('[data-family-id="motorized_group"]')?.textContent).toContain('Boating');
+
+    fixture.componentInstance.onSearchQueryChange('wheel chair');
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelectorAll('.family-card')).toHaveLength(1);
+    expect(fixture.nativeElement.querySelector('[data-family-id="adaptive_mobility_group"]')?.textContent).toContain('Wheel Chair');
+    expect(fixture.nativeElement.textContent).toContain('1 activity type in 1 family match your search.');
+  });
+
+  it('explains that family membership does not replace exact chart recommendations', () => {
+    TestBed.configureTestingModule({
+      imports: [
+        SupportedActivitiesPageComponent,
+        RouterTestingModule.withRoutes([]),
+        NoopAnimationsModule,
+        MatIconTestingModule,
+      ],
+    });
+
+    const fixture: ComponentFixture<SupportedActivitiesPageComponent> = TestBed.createComponent(SupportedActivitiesPageComponent);
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent;
+    const helpLink = fixture.nativeElement.querySelector('a[routerlink="/help"], a[ng-reflect-router-link="/help"]');
+
+    expect(text).toContain('Boating is organized in Motorized');
+    expect(text).toContain('Wheel Chair is organized in Adaptive Mobility');
+    expect(text).toContain('never creates, names, associates, or calculates missing gas and tank data');
+    expect(helpLink).toBeTruthy();
+  });
+});

--- a/src/app/components/features/supported-activities-page.component.spec.ts
+++ b/src/app/components/features/supported-activities-page.component.spec.ts
@@ -28,7 +28,16 @@ describe('SupportedActivitiesPageComponent', () => {
 
     expect(fixture.nativeElement.querySelectorAll('.family-card')).toHaveLength(1);
     expect(fixture.nativeElement.querySelector('[data-family-id="adaptive_mobility_group"]')?.textContent).toContain('Wheel Chair');
-    expect(fixture.nativeElement.textContent).toContain('1 activity type in 1 family match your search.');
+    expect(fixture.nativeElement.textContent).toContain('Showing 1 recognized activity type across 1 matching family.');
+
+    fixture.componentInstance.onSearchQueryChange('cycling');
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-family-id="cycling_group"]')?.textContent).toContain('Hand Cycle');
+    expect(fixture.componentInstance.searchResultSummary()).toMatch(
+      /^Showing \d+ recognized activity types across \d+ matching families\.$/,
+    );
+    expect(fixture.nativeElement.textContent).not.toContain('activity types match your search.');
   });
 
   it('explains that family membership does not replace exact chart recommendations', () => {
@@ -49,6 +58,9 @@ describe('SupportedActivitiesPageComponent', () => {
 
     expect(text).toContain('Boating is organized in Motorized');
     expect(text).toContain('Wheel Chair is organized in Adaptive Mobility');
+    expect(text).toContain('Laps when selected activities contain lap data');
+    expect(text).toContain('Swim Lengths when their source includes per-length pool data');
+    expect(text).toContain('Jumps when selected activities contain jump events');
     expect(text).toContain('never creates, names, associates, or calculates missing gas and tank data');
     expect(helpLink).toBeTruthy();
   });

--- a/src/app/components/features/supported-activities-page.component.ts
+++ b/src/app/components/features/supported-activities-page.component.ts
@@ -10,6 +10,7 @@ import {
   SUPPORTED_ACTIVITIES_ROUTE_DATA,
   SUPPORTED_ACTIVITY_FAMILIES,
   SUPPORTED_ACTIVITY_PRESENTATION_NOTES,
+  SUPPORTED_ACTIVITY_SPECIALIZED_SURFACES,
   SUPPORTED_ACTIVITY_SUPPORT_LEVELS,
   SUPPORTED_ACTIVITY_TYPE_COUNT,
   type SupportedActivityFamily,
@@ -39,6 +40,7 @@ export class SupportedActivitiesPageComponent {
   readonly routeData = SUPPORTED_ACTIVITIES_ROUTE_DATA;
   readonly totalActivityTypeCount = SUPPORTED_ACTIVITY_TYPE_COUNT;
   readonly supportLevels = SUPPORTED_ACTIVITY_SUPPORT_LEVELS;
+  readonly specializedSurfaces = SUPPORTED_ACTIVITY_SPECIALIZED_SURFACES;
   readonly presentationNotes = SUPPORTED_ACTIVITY_PRESENTATION_NOTES;
   readonly searchQuery = signal('');
   readonly filteredFamilies = computed<readonly SupportedActivityFamily[]>(() => {
@@ -74,7 +76,7 @@ export class SupportedActivitiesPageComponent {
       return `${this.totalActivityTypeCount} recognized activity types across ${SUPPORTED_ACTIVITY_FAMILIES.length} families.`;
     }
 
-    return `${activityTypeCount} activity type${activityTypeCount === 1 ? '' : 's'} in ${familyCount} famil${familyCount === 1 ? 'y' : 'ies'} match your search.`;
+    return `Showing ${activityTypeCount} recognized activity type${activityTypeCount === 1 ? '' : 's'} across ${familyCount} matching famil${familyCount === 1 ? 'y' : 'ies'}.`;
   });
 
   onSearchQueryChange(query: string): void {

--- a/src/app/components/features/supported-activities-page.component.ts
+++ b/src/app/components/features/supported-activities-page.component.ts
@@ -1,0 +1,87 @@
+import { ChangeDetectionStrategy, Component, computed, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import {
+  SUPPORTED_ACTIVITIES_ROUTE_DATA,
+  SUPPORTED_ACTIVITY_FAMILIES,
+  SUPPORTED_ACTIVITY_PRESENTATION_NOTES,
+  SUPPORTED_ACTIVITY_SUPPORT_LEVELS,
+  SUPPORTED_ACTIVITY_TYPE_COUNT,
+  type SupportedActivityFamily,
+} from './supported-activities-page.content';
+
+function normalizeSearchValue(value: string): string {
+  return value.trim().toLocaleLowerCase();
+}
+
+@Component({
+  selector: 'app-supported-activities-page',
+  standalone: true,
+  imports: [
+    RouterLink,
+    MatButtonModule,
+    MatCardModule,
+    MatChipsModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+  ],
+  templateUrl: './supported-activities-page.component.html',
+  styleUrls: ['./supported-activities-page.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SupportedActivitiesPageComponent {
+  readonly routeData = SUPPORTED_ACTIVITIES_ROUTE_DATA;
+  readonly totalActivityTypeCount = SUPPORTED_ACTIVITY_TYPE_COUNT;
+  readonly supportLevels = SUPPORTED_ACTIVITY_SUPPORT_LEVELS;
+  readonly presentationNotes = SUPPORTED_ACTIVITY_PRESENTATION_NOTES;
+  readonly searchQuery = signal('');
+  readonly filteredFamilies = computed<readonly SupportedActivityFamily[]>(() => {
+    const normalizedQuery = normalizeSearchValue(this.searchQuery());
+    if (!normalizedQuery) {
+      return SUPPORTED_ACTIVITY_FAMILIES;
+    }
+
+    return SUPPORTED_ACTIVITY_FAMILIES.reduce<SupportedActivityFamily[]>((families, family) => {
+      const familyMatches = normalizeSearchValue(family.label).includes(normalizedQuery);
+      const matchingActivityTypes = family.activityTypes.filter(activityType => (
+        normalizeSearchValue(activityType).includes(normalizedQuery)
+      ));
+
+      if (!familyMatches && matchingActivityTypes.length === 0) {
+        return families;
+      }
+
+      families.push({
+        ...family,
+        activityTypes: familyMatches ? family.activityTypes : matchingActivityTypes,
+      });
+      return families;
+    }, []);
+  });
+  readonly visibleActivityTypeCount = computed(() => this.filteredFamilies()
+    .reduce((count, family) => count + family.activityTypes.length, 0));
+  readonly searchResultSummary = computed(() => {
+    const familyCount = this.filteredFamilies().length;
+    const activityTypeCount = this.visibleActivityTypeCount();
+
+    if (!this.searchQuery().trim()) {
+      return `${this.totalActivityTypeCount} recognized activity types across ${SUPPORTED_ACTIVITY_FAMILIES.length} families.`;
+    }
+
+    return `${activityTypeCount} activity type${activityTypeCount === 1 ? '' : 's'} in ${familyCount} famil${familyCount === 1 ? 'y' : 'ies'} match your search.`;
+  });
+
+  onSearchQueryChange(query: string): void {
+    this.searchQuery.set(query);
+  }
+
+  clearSearch(): void {
+    this.searchQuery.set('');
+  }
+}

--- a/src/app/components/features/supported-activities-page.content.spec.ts
+++ b/src/app/components/features/supported-activities-page.content.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { ActivityTypeGroups, ActivityTypes } from '@sports-alliance/sports-lib';
+import {
+  SUPPORTED_ACTIVITIES_PATH,
+  SUPPORTED_ACTIVITIES_ROUTE_DATA,
+  SUPPORTED_ACTIVITIES_URL,
+  SUPPORTED_ACTIVITY_FAMILIES,
+  SUPPORTED_ACTIVITY_TYPE_COUNT,
+} from './supported-activities-page.content';
+
+describe('supported-activities-page.content', () => {
+  it('derives a complete public catalog from canonical activity groups', () => {
+    const catalogTypes = SUPPORTED_ACTIVITY_FAMILIES.flatMap(family => family.activityTypes);
+    const unspecified = SUPPORTED_ACTIVITY_FAMILIES.find(family => family.id === ActivityTypeGroups.UnspecifiedGroup);
+
+    expect(SUPPORTED_ACTIVITY_FAMILIES).toHaveLength(17);
+    expect(SUPPORTED_ACTIVITY_TYPE_COUNT).toBe(131);
+    expect(new Set(catalogTypes).size).toBe(SUPPORTED_ACTIVITY_TYPE_COUNT);
+    expect(unspecified).toMatchObject({
+      label: 'Unspecified',
+      icon: 'category',
+      fallback: true,
+    });
+    expect(unspecified?.activityTypes).toContain(ActivityTypes.unknown);
+    expect(SUPPORTED_ACTIVITY_FAMILIES.find(family => family.id === ActivityTypeGroups.SkatingGroup)).toMatchObject({
+      icon: 'roller_skating',
+    });
+    expect(SUPPORTED_ACTIVITY_FAMILIES.find(family => family.id === ActivityTypeGroups.MotorizedGroup)).toMatchObject({
+      icon: 'directions_car',
+      color: '#546E7A',
+    });
+  });
+
+  it('defines discoverable route metadata without provider compatibility guarantees', () => {
+    expect(SUPPORTED_ACTIVITIES_PATH).toBe('features/supported-activities');
+    expect(SUPPORTED_ACTIVITIES_URL).toBe('https://quantified-self.io/features/supported-activities');
+    expect(SUPPORTED_ACTIVITIES_ROUTE_DATA).toMatchObject({
+      title: 'Supported Activities & Metrics',
+      preload: true,
+      animation: 'Features',
+    });
+    expect(SUPPORTED_ACTIVITIES_ROUTE_DATA.description).toContain('original activity source');
+    expect(SUPPORTED_ACTIVITIES_ROUTE_DATA.description).not.toContain('every provider');
+    expect(SUPPORTED_ACTIVITIES_ROUTE_DATA.jsonLd).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'WebPage',
+      url: SUPPORTED_ACTIVITIES_URL,
+      inLanguage: 'en',
+    });
+  });
+});

--- a/src/app/components/features/supported-activities-page.content.spec.ts
+++ b/src/app/components/features/supported-activities-page.content.spec.ts
@@ -5,6 +5,7 @@ import {
   SUPPORTED_ACTIVITIES_ROUTE_DATA,
   SUPPORTED_ACTIVITIES_URL,
   SUPPORTED_ACTIVITY_FAMILIES,
+  SUPPORTED_ACTIVITY_SPECIALIZED_SURFACES,
   SUPPORTED_ACTIVITY_TYPE_COUNT,
 } from './supported-activities-page.content';
 
@@ -15,7 +16,15 @@ describe('supported-activities-page.content', () => {
 
     expect(SUPPORTED_ACTIVITY_FAMILIES).toHaveLength(17);
     expect(SUPPORTED_ACTIVITY_TYPE_COUNT).toBe(131);
+    expect(SUPPORTED_ACTIVITY_FAMILIES.map(family => family.id).sort()).toEqual(
+      [...new Set(Object.values(ActivityTypeGroups))].sort(),
+    );
     expect(new Set(catalogTypes).size).toBe(SUPPORTED_ACTIVITY_TYPE_COUNT);
+    SUPPORTED_ACTIVITY_FAMILIES.forEach(family => {
+      expect(family.icon.trim()).not.toBe('');
+      expect(family.color).toMatch(/^#[0-9A-F]{6}$/i);
+      expect(family.gradient).toContain('linear-gradient(');
+    });
     expect(unspecified).toMatchObject({
       label: 'Unspecified',
       icon: 'category',
@@ -29,6 +38,16 @@ describe('supported-activities-page.content', () => {
       icon: 'directions_car',
       color: '#546E7A',
     });
+    expect(SUPPORTED_ACTIVITY_SPECIALIZED_SURFACES).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        title: 'Laps and swim lengths',
+        copy: expect.stringContaining('per-length pool data'),
+      }),
+      expect.objectContaining({
+        title: 'Recorded jump details',
+        copy: expect.stringContaining('jump events'),
+      }),
+    ]));
   });
 
   it('defines discoverable route metadata without provider compatibility guarantees', () => {

--- a/src/app/components/features/supported-activities-page.content.ts
+++ b/src/app/components/features/supported-activities-page.content.ts
@@ -74,6 +74,24 @@ export const SUPPORTED_ACTIVITY_SUPPORT_LEVELS: readonly SupportedActivityConten
   },
 ];
 
+export const SUPPORTED_ACTIVITY_SPECIALIZED_SURFACES: readonly SupportedActivityContentItem[] = [
+  {
+    icon: 'table_rows',
+    title: 'Laps and swim lengths',
+    copy: 'Event Details shows Laps when selected activities contain lap data. Swimming activities can show Swim Lengths when their source includes per-length pool data.',
+  },
+  {
+    icon: 'landscape',
+    title: 'Recorded jump details',
+    copy: 'Event Details shows Jumps when selected activities contain jump events. The visible columns follow the values actually recorded.',
+  },
+  {
+    icon: 'stacked_line_chart',
+    title: 'Charts from compatible samples',
+    copy: 'Charts and overlays need compatible source time series. Recommendations prioritize relevant recorded panels rather than adding a missing metric.',
+  },
+];
+
 export const SUPPORTED_ACTIVITY_PRESENTATION_NOTES: readonly SupportedActivityContentItem[] = [
   {
     icon: 'sailing',

--- a/src/app/components/features/supported-activities-page.content.ts
+++ b/src/app/components/features/supported-activities-page.content.ts
@@ -1,0 +1,125 @@
+import type { ActivityTypeGroup, ActivityTypes } from '@sports-alliance/sports-lib';
+import { ActivityTypeGroups } from '@sports-alliance/sports-lib';
+import { getActivityTypeGroupCatalog } from '@shared/activity-type-group.metadata';
+import { AppActivityTypeGroupColors } from '../../services/color/app.activity-type-group.colors';
+import { AppActivityTypeGroupGradients } from '../../services/color/app.activity-type-group.gradients';
+import { AppActivityTypeGroupIcons } from '../../services/color/app.activity-type-group.icons';
+import { SUPPORTED_ACTIVITIES_PATH } from './supported-activities-page.paths';
+
+export { SUPPORTED_ACTIVITIES_PATH } from './supported-activities-page.paths';
+
+export interface SupportedActivityFamily {
+  id: ActivityTypeGroup;
+  label: string;
+  activityTypes: readonly ActivityTypes[];
+  icon: string;
+  color: string;
+  gradient: string;
+  fallback: boolean;
+}
+
+export interface SupportedActivityContentItem {
+  icon: string;
+  title: string;
+  copy: string;
+}
+
+export interface SupportedActivitiesRouteData {
+  title: string;
+  preload: boolean;
+  animation: string;
+  description: string;
+  jsonLd: Record<string, unknown>;
+}
+
+export const SUPPORTED_ACTIVITIES_URL = `https://quantified-self.io/${SUPPORTED_ACTIVITIES_PATH}`;
+
+export const SUPPORTED_ACTIVITY_FAMILIES: readonly SupportedActivityFamily[] = getActivityTypeGroupCatalog().map((entry) => {
+  const gradient = AppActivityTypeGroupGradients[entry.id];
+
+  return {
+    id: entry.id,
+    label: entry.label,
+    activityTypes: entry.activityTypes,
+    icon: AppActivityTypeGroupIcons[entry.id],
+    color: AppActivityTypeGroupColors[entry.id],
+    gradient: `linear-gradient(135deg, ${gradient.start}, ${gradient.end})`,
+    fallback: entry.id === ActivityTypeGroups.UnspecifiedGroup,
+  };
+});
+
+export const SUPPORTED_ACTIVITY_TYPE_COUNT = SUPPORTED_ACTIVITY_FAMILIES
+  .reduce((count, family) => count + family.activityTypes.length, 0);
+
+export const SUPPORTED_ACTIVITY_SUPPORT_LEVELS: readonly SupportedActivityContentItem[] = [
+  {
+    icon: 'category',
+    title: 'Recognized activity type',
+    copy: 'The catalog lists the canonical activity types Quantified Self recognizes and the family used to organize them across the app.',
+  },
+  {
+    icon: 'query_stats',
+    title: 'Recorded metrics first',
+    copy: 'Distance, route, terrain, sensors, laps, lengths, jumps, charts, and sport-specific records appear only when an imported source provides compatible data.',
+  },
+  {
+    icon: 'stacked_line_chart',
+    title: 'Type-aware Event Details',
+    copy: 'An individual activity uses its exact type to recommend compatible charts. A family does not promise the same chart behavior for every member.',
+  },
+  {
+    icon: 'sync',
+    title: 'Source and provider dependent',
+    copy: 'Connected services, manual files, device models, and recording settings can all affect which fields arrive with an activity.',
+  },
+];
+
+export const SUPPORTED_ACTIVITY_PRESENTATION_NOTES: readonly SupportedActivityContentItem[] = [
+  {
+    icon: 'sailing',
+    title: 'Families organize; types recommend',
+    copy: 'Boating is organized in Motorized, while an individual Boating activity keeps Sailing chart recommendations. The family color and icon do not replace its exact type behavior.',
+  },
+  {
+    icon: 'accessible_forward',
+    title: 'Adaptive Mobility stays type-aware',
+    copy: 'Wheel Chair is organized in Adaptive Mobility and keeps Cycling chart recommendations when compatible source metrics are present. This does not make it a Cycling Training claim.',
+  },
+  {
+    icon: 'pedal_bike',
+    title: 'Cycling has expanded coverage',
+    copy: 'Hand Cycle and Velomobile are Cycling types. They use existing Cycling chart recommendations and can enter Cycling Training analysis only when current evidence rules are met.',
+  },
+];
+
+export const SUPPORTED_ACTIVITIES_ROUTE_DATA: SupportedActivitiesRouteData = {
+  title: 'Supported Activities & Metrics',
+  preload: true,
+  animation: 'Features',
+  description: 'Browse the canonical activity types Quantified Self recognizes, how they are grouped, and why available metrics and Event Details charts depend on the original activity source.',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: 'Supported Activities & Metrics',
+    description: 'Browse the canonical activity types Quantified Self recognizes, how they are grouped, and why available metrics and Event Details charts depend on the original activity source.',
+    url: SUPPORTED_ACTIVITIES_URL,
+    inLanguage: 'en',
+    isPartOf: {
+      '@type': 'WebSite',
+      name: 'Quantified Self',
+      url: 'https://quantified-self.io',
+    },
+    mainEntity: {
+      '@type': 'SoftwareApplication',
+      name: 'Quantified Self',
+      applicationCategory: 'HealthApplication',
+      operatingSystem: 'Web',
+      featureList: [
+        'Canonical activity type catalog',
+        'Source-dependent activity metrics',
+        'Type-aware Event Details chart recommendations',
+        'Source-native Diving presentation',
+      ],
+    },
+  },
+};

--- a/src/app/components/features/supported-activities-page.paths.ts
+++ b/src/app/components/features/supported-activities-page.paths.ts
@@ -1,0 +1,1 @@
+export const SUPPORTED_ACTIVITIES_PATH = 'features/supported-activities';

--- a/src/app/components/public-footer/public-footer.component.html
+++ b/src/app/components/public-footer/public-footer.component.html
@@ -13,6 +13,7 @@
       <ul>
         <li><a routerLink="/features/activity-calendar">Activity calendar</a></li>
         <li><a routerLink="/features/training-analysis">Training analysis</a></li>
+        <li><a routerLink="/features/supported-activities">Supported activities</a></li>
         <li><a routerLink="/features/mcp-server">MCP server</a></li>
         <li><a routerLink="/integrations">Integrations</a></li>
         <li><a routerLink="/integrations/wahoo">Wahoo integration</a></li>

--- a/src/app/components/public-seo/public-seo-pages.content.spec.ts
+++ b/src/app/components/public-seo/public-seo-pages.content.spec.ts
@@ -229,6 +229,7 @@ describe('public-seo-pages.content', () => {
 
     expect(featureHubLinks).toContain('/features/ai-insights');
     expect(featureHubLinks).toContain('/features/activity-calendar');
+    expect(featureHubLinks).toContain('/features/supported-activities');
     expect(featureHubLinks).toContain('/features/training-analysis');
     expect(featureHubLinks).toContain('/features/mcp-server');
     expect(featureHubLinks).toContain('/features/workout-data-comparison');

--- a/src/app/components/public-seo/public-seo-pages.content.ts
+++ b/src/app/components/public-seo/public-seo-pages.content.ts
@@ -92,10 +92,11 @@ export const PUBLIC_SEO_PAGES: Record<PublicSeoPageKey, PublicSeoPage> = {
     description: 'Explore an activity calendar, training analysis, the grounded Quantified Self Assistant, read-only MCP access, workout file comparison, FIT/GPX/TCX tools, sports watch benchmark reports, and a private dashboard.',
     h1: 'Features for endurance training data',
     intro: 'Use Quantified Self to centralize provider activities, uploaded files, and saved routes, review workout history in an activity calendar, analyze training context, compare recordings, benchmark devices, and ask questions through the built-in Assistant or an MCP client you explicitly authorize.',
-    chips: ['Activity calendar', 'Training analysis', 'Assistant', 'MCP server', 'Workout comparison', 'Route files', 'Benchmarks'],
+    chips: ['Activity calendar', 'Training analysis', 'Supported activities', 'Assistant', 'MCP server', 'Workout comparison', 'Route files', 'Benchmarks'],
     actions: [
       routeAction('Training Analysis', '/features/training-analysis', 'flat', 'arrow_forward'),
       routeAction('Activity Calendar', '/features/activity-calendar'),
+      routeAction('Supported Activities', '/features/supported-activities'),
       routeAction('MCP Server', '/features/mcp-server'),
       routeAction('Assistant', '/features/ai-insights'),
       routeAction('Workout Data Comparison', '/features/workout-data-comparison'),

--- a/src/app/helpers/activity-type-group.metadata.helper.spec.ts
+++ b/src/app/helpers/activity-type-group.metadata.helper.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ActivityTypeGroups, ActivityTypes, ActivityTypesHelper } from '@sports-alliance/sports-lib';
 import {
   getActivityTypeGroupLabel,
@@ -92,5 +92,16 @@ describe('activity-type-group.metadata', () => {
       ActivityTypes.Workout,
     ].sort());
     expect(getActivityTypesForGroup(ActivityTypeGroups.IndoorSportsGroup)).toContain(ActivityTypes.Yoga);
+  });
+
+  it('ignores malformed values from Sports Lib canonical activity lookup results', () => {
+    const canonicalTypesSpy = vi.spyOn(ActivityTypesHelper, 'getActivityTypesAsUniqueArray')
+      .mockReturnValue([ActivityTypes.Cycling, 'Not a canonical activity type']);
+
+    try {
+      expect(getActivityTypesForGroup(ActivityTypeGroups.CyclingGroup)).toEqual([ActivityTypes.Cycling]);
+    } finally {
+      canonicalTypesSpy.mockRestore();
+    }
   });
 });

--- a/src/app/helpers/activity-type-group.metadata.helper.spec.ts
+++ b/src/app/helpers/activity-type-group.metadata.helper.spec.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { ActivityTypeGroups, ActivityTypes, ActivityTypesHelper } from '@sports-alliance/sports-lib';
 import {
   getActivityTypeGroupLabel,
+  getActivityTypeGroupCatalog,
   getActivityTypesForGroup,
   isIndoorActivityType,
   isAmbiguousActivityTypeGroup,
@@ -70,18 +71,26 @@ describe('activity-type-group.metadata', () => {
     expect(isIndoorActivityType(ActivityTypes.Cycling)).toBe(false);
   });
 
-  it('falls back to per-activity group resolution when direct group-members helper is unavailable', () => {
-    const directHelperSpy = vi.spyOn(ActivityTypesHelper, 'getActivityTypesForActivityGroup')
-      .mockImplementation(() => {
-        throw new Error('helper unavailable');
-      });
+  it('creates a complete, deduplicated canonical catalog from Sports Lib group lookups', () => {
+    const catalog = getActivityTypeGroupCatalog();
+    const catalogTypes = catalog.flatMap(entry => entry.activityTypes);
+    const canonicalTypes = ActivityTypesHelper.getActivityTypesAsUniqueArray();
+    const unspecified = catalog.find(entry => entry.id === ActivityTypeGroups.UnspecifiedGroup);
 
-    try {
-      const indoorGroupActivityTypes = getActivityTypesForGroup(ActivityTypeGroups.IndoorSportsGroup);
-      expect(indoorGroupActivityTypes).toContain(ActivityTypes.Yoga);
-      expect(indoorGroupActivityTypes.length).toBeGreaterThan(0);
-    } finally {
-      directHelperSpy.mockRestore();
-    }
+    expect(catalog).toHaveLength(17);
+    expect(catalogTypes).toHaveLength(131);
+    expect(new Set(catalogTypes).size).toBe(catalogTypes.length);
+    expect([...catalogTypes].sort()).toEqual([...canonicalTypes].sort());
+    expect(unspecified?.activityTypes).toEqual([
+      ActivityTypes.Generic,
+      ActivityTypes.Match,
+      ActivityTypes.Other,
+      ActivityTypes.Route,
+      ActivityTypes.Tactical,
+      ActivityTypes.Transition,
+      ActivityTypes.unknown,
+      ActivityTypes.Workout,
+    ].sort());
+    expect(getActivityTypesForGroup(ActivityTypeGroups.IndoorSportsGroup)).toContain(ActivityTypes.Yoga);
   });
 });

--- a/src/app/shared/help.content.spec.ts
+++ b/src/app/shared/help.content.spec.ts
@@ -17,6 +17,8 @@ describe('help.content', () => {
 
     expect(supportedActivitiesSection?.content).toContain('[Supported Activities & Metrics page](/features/supported-activities)');
     expect(supportedActivitiesSection?.content).toContain('A chart recommendation prioritizes recorded data; it does not create a missing field.');
+    expect(supportedActivitiesSection?.content).toContain('Swim Lengths** when a swimming source includes per-length pool data');
+    expect(supportedActivitiesSection?.content).toContain('Jumps** when selected activities contain jump events');
     expect(supportedActivitiesSection?.content).toContain('Boating is organized in Motorized but keeps Sailing recommendations');
     expect(supportedActivitiesSection?.content).toContain('Wheel Chair is organized in Adaptive Mobility but keeps Cycling recommendations');
     expect(supportedActivitiesSection?.content).toContain('never creates, names, associates, or calculates missing gas and tank data');

--- a/src/app/shared/help.content.spec.ts
+++ b/src/app/shared/help.content.spec.ts
@@ -12,9 +12,26 @@ import {
 } from './policies.content';
 
 describe('help.content', () => {
+  it('documents the supported activity catalog without overpromising source data', () => {
+    const supportedActivitiesSection = HELP_SECTIONS.find(section => section.id === 'supported-activities');
+
+    expect(supportedActivitiesSection?.content).toContain('[Supported Activities & Metrics page](/features/supported-activities)');
+    expect(supportedActivitiesSection?.content).toContain('A chart recommendation prioritizes recorded data; it does not create a missing field.');
+    expect(supportedActivitiesSection?.content).toContain('Boating is organized in Motorized but keeps Sailing recommendations');
+    expect(supportedActivitiesSection?.content).toContain('Wheel Chair is organized in Adaptive Mobility but keeps Cycling recommendations');
+    expect(supportedActivitiesSection?.content).toContain('never creates, names, associates, or calculates missing gas and tank data');
+    expect(supportedActivitiesSection?.links).toContainEqual({
+      label: 'Supported Activities & Metrics',
+      icon: 'category',
+      kind: 'route',
+      target: '/features/supported-activities',
+    });
+  });
+
   it('should expose the expected ordered section ids', () => {
     expect(HELP_SECTIONS.map(section => section.id)).toEqual<HelpSectionId[]>([
       'getting-started',
+      'supported-activities',
       'activity-calendar',
       'training-analysis',
       'ai-insights',
@@ -26,8 +43,8 @@ describe('help.content', () => {
     ]);
   });
 
-  it('should define nine unique sections with complete content', () => {
-    expect(HELP_SECTIONS).toHaveLength(9);
+  it('should define ten unique sections with complete content', () => {
+    expect(HELP_SECTIONS).toHaveLength(10);
 
     const uniqueIds = new Set(HELP_SECTIONS.map(section => section.id));
     expect(uniqueIds.size).toBe(HELP_SECTIONS.length);

--- a/src/app/shared/help.content.ts
+++ b/src/app/shared/help.content.ts
@@ -12,6 +12,7 @@ import {
 
 export type HelpSectionId =
   | 'getting-started'
+  | 'supported-activities'
   | 'activity-calendar'
   | 'training-analysis'
   | 'ai-insights'
@@ -179,6 +180,7 @@ export const HELP_SECTIONS: HelpSection[] = [
 
 - **Dashboard** is your main activity overview.
 - **Calendar** shows activities in Week, Month, and Year views. Open the [Activity Calendar guide](/help#activity-calendar) for display and summary details, or read the public [Activity Calendar overview](/features/activity-calendar).
+- **Supported Activities & Metrics** lists the canonical activity types Quantified Self recognizes and explains why available detail follows the original source. Open the [Supported Activities guide](/help#supported-activities) or public [Supported Activities & Metrics page](/features/supported-activities).
 - **Training** is your fixed workspace for baseline comparisons, current readiness signals, load trajectory, training mix, capacity evidence, durability, sleep, and power interpretation. Open the [Training analysis guide](/help#training-analysis) for the detailed product guide, read the public [Training Analysis overview](/features/training-analysis) for the search-facing summary, or use its **Feedback** action to email support with Training-specific feedback.
 - **My Tracks** maps positional activities and supports date range, custom date, and activity type filters.
 - **Services** is where you connect Garmin, Suunto, COROS, and Wahoo.
@@ -407,6 +409,33 @@ export const HELP_SECTIONS: HelpSection[] = [
       { label: 'Training Analysis Overview', icon: 'monitoring', kind: 'route', target: '/features/training-analysis' },
       { label: 'Membership', icon: 'card_membership', kind: 'route', target: '/pricing' },
       { label: 'Release Notes', icon: 'campaign', kind: 'route', target: '/releases' },
+    ],
+  },
+  {
+    id: 'supported-activities',
+    icon: 'category',
+    title: 'Supported Activities & Metrics',
+    summary: 'Browse recognized activity types, source-dependent metric families, Event Details recommendations, and Diving behavior.',
+    content: `## Recognized activity types
+
+- Quantified Self recognizes canonical activity types and organizes them into activity families for labels, icons, colors, search, Calendar, and other product surfaces. A recognized type does not guarantee that every source, device, or provider records the same data.
+- Open the [Supported Activities & Metrics page](/features/supported-activities) to search every current canonical type and family.
+
+## Metrics and Event Details
+
+- Route, terrain, sensor, lap, length, jump, chart, and sport-specific details appear only when the imported source includes compatible records. A chart recommendation prioritizes recorded data; it does not create a missing field.
+- An individual activity uses its exact activity type for Event Details chart recommendations. A family is not a promise of a uniform chart profile: Boating is organized in Motorized but keeps Sailing recommendations, while Wheel Chair is organized in Adaptive Mobility but keeps Cycling recommendations.
+- Hand Cycle and Velomobile are canonical Cycling types. They use existing Cycling chart recommendations and can enter Cycling Training analysis only when the activity meets the current recorded-evidence and eligibility rules.
+
+## Diving
+
+- Diving, Scuba Diving, Free Diving, Snorkeling, and Mermaiding expose depth, decompression, timing/rate, tissue-load, SAC/RMV, gas, and tank records only when the original source provides them. Continuous depth samples enable Dive Profile.
+- Quantified Self never creates, names, associates, or calculates missing gas and tank data. Diving-only Events intentionally omit terrain altitude, ascent, descent, and grade summaries; mixed Events retain terrain summaries only from non-Diving activities.
+`,
+    links: [
+      { label: 'Supported Activities & Metrics', icon: 'category', kind: 'route', target: '/features/supported-activities' },
+      { label: 'Explore Integrations', icon: 'sync', kind: 'route', target: '/integrations' },
+      { label: 'Uploads & Imports', icon: 'upload_file', kind: 'route', target: '/help', fragment: 'uploads-and-imports' },
     ],
   },
   {

--- a/src/app/shared/help.content.ts
+++ b/src/app/shared/help.content.ts
@@ -424,6 +424,7 @@ export const HELP_SECTIONS: HelpSection[] = [
 ## Metrics and Event Details
 
 - Route, terrain, sensor, lap, length, jump, chart, and sport-specific details appear only when the imported source includes compatible records. A chart recommendation prioritizes recorded data; it does not create a missing field.
+- Event Details shows **Laps** when selected activities contain lap data, **Swim Lengths** when a swimming source includes per-length pool data, and **Jumps** when selected activities contain jump events. Charts and overlays likewise need compatible source time series.
 - An individual activity uses its exact activity type for Event Details chart recommendations. A family is not a promise of a uniform chart profile: Boating is organized in Motorized but keeps Sailing recommendations, while Wheel Chair is organized in Adaptive Mobility but keeps Cycling recommendations.
 - Hand Cycle and Velomobile are canonical Cycling types. They use existing Cycling chart recommendations and can enter Cycling Training analysis only when the activity meets the current recorded-evidence and eligibility rules.
 

--- a/src/app/shared/public-startup-route.spec.ts
+++ b/src/app/shared/public-startup-route.spec.ts
@@ -45,6 +45,7 @@ describe('public-startup-route', () => {
     expect(isPublicContentPath('/terms')).toBe(true);
     expect(isPublicContentPath('/releases?view=latest')).toBe(true);
     expect(isPublicContentPath('/features/activity-calendar')).toBe(true);
+    expect(isPublicContentPath('/features/supported-activities')).toBe(true);
     expect(isPublicContentPath('/features/mcp-server')).toBe(true);
     expect(isPublicContentPath('/guides/import-activities-to-suunto')).toBe(true);
     expect(isPublicContentPath('/guides/import-activities-to-wahoo')).toBe(true);

--- a/src/app/shared/public-startup-route.ts
+++ b/src/app/shared/public-startup-route.ts
@@ -21,6 +21,7 @@ const PUBLIC_CONTENT_PATHS = new Set([
   '/integrations/wahoo',
   '/features',
   '/features/workout-data-comparison',
+  '/features/supported-activities',
   '/features/activity-calendar',
   '/features/training-analysis',
   '/features/mcp-server',

--- a/src/firebase-hosting.config.spec.ts
+++ b/src/firebase-hosting.config.spec.ts
@@ -268,6 +268,7 @@ describe('Firebase Hosting configuration', () => {
     expect(sitemapLastmodForUrl(`${siteOrigin}/integrations/coros`)).toBe('2026-08-03');
     expect(sitemapLastmodForUrl(`${siteOrigin}/integrations/wahoo`)).toBe('2026-08-03');
     expect(sitemapLastmodForUrl(`${siteOrigin}/features/workout-data-comparison`)).toBe('2026-07-21');
+    expect(sitemapLastmodForUrl(`${siteOrigin}/features/supported-activities`)).toBe('2026-08-24');
     expect(sitemapLastmodForUrl(`${siteOrigin}/guides`)).toBe('2026-07-21');
     expect(sitemapLastmodForUrl(`${siteOrigin}/guides/import-activities-to-suunto`)).toBe('2026-07-28');
     expect(sitemapLastmodForUrl(`${siteOrigin}/guides/import-activities-to-wahoo`)).toBe('2026-07-28');

--- a/src/robots.txt
+++ b/src/robots.txt
@@ -13,6 +13,7 @@ Allow: /features
 Allow: /features/activity-calendar
 Allow: /features/mcp-server
 Allow: /features/workout-data-comparison
+Allow: /features/supported-activities
 Allow: /features/training-analysis
 Allow: /features/ai-insights
 Allow: /features/workout-file-comparison

--- a/src/sitemap.xml
+++ b/src/sitemap.xml
@@ -86,6 +86,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://quantified-self.io/features/supported-activities</loc>
+    <lastmod>2026-08-24</lastmod>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://quantified-self.io/features/training-analysis</loc>
     <lastmod>2026-08-07</lastmod>
     <priority>0.8</priority>

--- a/tools/verify-public-initial-output.mjs
+++ b/tools/verify-public-initial-output.mjs
@@ -14,6 +14,7 @@ const prerenderedPageSourcePatterns = [
   /^src\/app\/components\/integrations\/integrations-hub-page\.component\.ts$/,
   /^src\/app\/components\/integrations\/provider-integration-page\.component\.ts$/,
   /^src\/app\/components\/features\/workout-data-comparison-page\.component\.ts$/,
+  /^src\/app\/components\/features\/supported-activities-page\.component\.ts$/,
   /^src\/app\/components\/public-seo\/public-seo-page\.component\.ts$/,
   /^src\/app\/components\/tools\/tools-hub-page\.component\.ts$/,
   /^src\/app\/components\/tools\/tools-compare-page\.component\.ts$/,
@@ -44,7 +45,7 @@ const publicStartupSourceRecords = uniqueSourceRecords(publicStartupJavaScriptAs
 
 assertNoHomeStartupSource(
   'route-only public page content',
-  /^src\/app\/components\/(?:features\/workout-data-comparison-page|integrations\/integration-pages|public-seo\/public-seo-pages)\.content\.ts$/,
+  /^src\/app\/components\/(?:features\/(?:workout-data-comparison-page|supported-activities-page)|integrations\/integration-pages|public-seo\/public-seo-pages)\.content\.ts$/,
 );
 assertNoHomeStartupSource(
   'unused event data runtime',


### PR DESCRIPTION
## Summary

- add a searchable public Supported Activities & Metrics page derived from the complete canonical Sports Lib catalog, including all current families with existing icons, colors, and gradients
- clarify source-dependent metrics, exact-type Event Details recommendations, and source-native Diving behavior without overstating provider or record availability
- wire public routing, prerendering, SEO, sitemap, robots, Help, feature navigation, and maintenance documentation

## Validation

- npm test -- --run
- npm run lint
- npm run build-production

Closes #601