### PR TITLE
feat: add provider-neutral health data foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,11 @@ The hosted project uses Firestore TTL policies for short-lived operational data:
 
 These policies are infrastructure configuration; starting local emulators does not create or deploy production TTL policies.
 
+Unified health history under `users/{uid}/healthRecords` and `healthSampleChunks` has no time-based TTL. It is bounded per document, atomic replacement, and query; provider disconnect retains imported history, while recursive account deletion removes the complete user-scoped health subtree. See [Unified health data foundation](docs/unified-health-data.md).
+
 ## Architecture documentation
 
+- [Unified health data foundation](docs/unified-health-data.md)
 - [Provider integration implementation guide](docs/provider-integration-guide.md)
 - [COROS integration architecture and release checklist](docs/coros-integration.md)
 - [Wahoo integration architecture and release checklist](docs/wahoo-integration.md)

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ The hosted project uses Firestore TTL policies for short-lived operational data:
 
 These policies are infrastructure configuration; starting local emulators does not create or deploy production TTL policies.
 
-Unified health history under `users/{uid}/healthRecords` and `healthSampleChunks` has no time-based TTL. It is bounded per document, atomic replacement, and query; provider disconnect retains imported history, while recursive account deletion removes the complete user-scoped health subtree. See [Unified health data foundation](docs/unified-health-data.md).
+Unified health history under `users/{uid}/healthSourceRecords` and `healthSampleChunks` has no time-based TTL. It is bounded per document, atomic replacement, and query; provider disconnect retains imported history, while recursive account deletion removes the complete user-scoped health subtree. See [Unified health data foundation](docs/unified-health-data.md).
 
 ## Architecture documentation
 

--- a/docs/provider-integration-guide.md
+++ b/docs/provider-integration-guide.md
@@ -127,7 +127,7 @@ Separate state by trust boundary.
 | Safe connection status           | `users/{uid}/meta/<Provider>`               | Owner may read the limited projection; client does not write it    |
 | Queue and failed jobs            | Server-owned queue and DLQ collections      | No client writes; admin read only where the Rules model permits it |
 | Imported event and original file | Existing event/file model                   | Follow the established event and Storage access model              |
-| Imported health source record    | `users/{uid}/healthRecords`                  | Owner bounded read; server writes only                              |
+| Imported health source record    | `users/{uid}/healthSourceRecords`            | Owner bounded read; server writes only                              |
 | High-resolution health samples  | `users/{uid}/healthSampleChunks`             | Owner bounded read; server writes only                              |
 | Safe health sync status         | `users/{uid}/healthSyncState`                | Owner bounded read; server writes only                              |
 
@@ -138,7 +138,7 @@ For every new persistent write path:
 - Keep provider credentials and signed download URLs out of safe metadata, events, error text, analytics, logs, and admin responses.
 - Add Firestore Rules tests proving browser denial for token roots, optional mappings, queues, and backend-owned connection fields, plus owner read access for the safe projection.
 - Add indexes deliberately for scheduled scans, queue status, pending disconnect retries, and history leases. Check the emulator and deployed index requirements before launch.
-- Use deterministic opaque provider-account and record IDs for health data. Never persist the raw provider account ID, free-form provider error, or raw provider payload in the unified health collections.
+- Use deterministic opaque provider-account and source-record IDs for health data. Never persist the raw provider account ID, free-form provider error, or raw provider payload in the unified health collections.
 - Keep health sample documents and reads strictly bounded. Time-based retention is intentionally uncapped until product/privacy policy explicitly changes it; do not add ad hoc TTL in a provider adapter.
 
 ## 6. Ingestion: webhooks, history, and idempotent queues
@@ -284,7 +284,7 @@ Account deletion is not merely token deletion. Add provider identity discovery a
 
 Existing imported events are product-policy decisions. State explicitly whether disconnect, entitlement expiry, and account deletion each retain or remove them. Wahoo retains imported events on disconnect but removes account-associated data on account deletion.
 
-Unified health history is retained on provider disconnect and removed on account deletion. Its collections live below `users/{uid}`, so the configured recursive extension owns account cleanup; provider adapters must not delete historical health records during ordinary deauthorization.
+Unified health history is retained on provider disconnect and removed on account deletion. Its collections live below `users/{uid}`, so the configured recursive extension owns account cleanup; provider adapters must not delete historical health source records during ordinary deauthorization.
 
 ## 9. Frontend, help, public pages, and attribution
 

--- a/docs/provider-integration-guide.md
+++ b/docs/provider-integration-guide.md
@@ -47,6 +47,19 @@ Provider OAuth / webhook / history request
 
 This is preferred over processing partner payloads directly in a webhook or callable because provider requests can be retried, payloads may be incomplete, original files may need another download, and processing can exceed partner timeouts.
 
+Provider health/wellness data uses the separate [unified health foundation](unified-health-data.md):
+
+```text
+Provider webhook / polling / history work
+        -> provider-specific mapper
+        -> shared runtime validation
+        -> deletion-guarded revision replacement
+        -> bounded source records and sample chunks
+        -> shared direct/callable query projection
+```
+
+Do not put wellness records into activity events or create a second provider-specific health schema. Keep the existing normalized Sleep model canonical and use the foundation's allowlisted Sleep references when a relationship is needed.
+
 Add a provider-specific architecture document under `docs/` when the integration has meaningful protocol, data-flow, rollout, or operational detail. Link it from the Architecture Documentation section of `README.md`; Wahoo is the reference example.
 
 Use the existing provider structure before inventing a parallel abstraction:
@@ -69,6 +82,7 @@ Complete these shared changes early. Exhaustive unions and switch statements are
 5. Add the environment configuration in `functions/src/config.ts`. Match established providers by requiring credentials when the integration runs; add a feature gate only when an explicitly approved staged rollout or operational requirement needs one. Update the configuration table in `README.md` with names only—never values, secrets, or production URLs.
 6. Add approved SVG assets and register them through the existing icon/presentation path. Confirm partner brand requirements before release.
 7. Add or update Firestore indexes, Rules, Storage Rules, TTL policies, and Firebase configuration only when the provider data model needs them.
+8. For health/wellness support, add provider metric mappings to the unified health writer rather than expanding the stable catalog with provider field names. Record native semantics, coverage, quality, and revision behavior explicitly.
 
 ## 4. OAuth and provider identity
 
@@ -113,6 +127,9 @@ Separate state by trust boundary.
 | Safe connection status           | `users/{uid}/meta/<Provider>`               | Owner may read the limited projection; client does not write it    |
 | Queue and failed jobs            | Server-owned queue and DLQ collections      | No client writes; admin read only where the Rules model permits it |
 | Imported event and original file | Existing event/file model                   | Follow the established event and Storage access model              |
+| Imported health source record    | `users/{uid}/healthRecords`                  | Owner bounded read; server writes only                              |
+| High-resolution health samples  | `users/{uid}/healthSampleChunks`             | Owner bounded read; server writes only                              |
+| Safe health sync status         | `users/{uid}/healthSyncState`                | Owner bounded read; server writes only                              |
 
 For every new persistent write path:
 
@@ -121,6 +138,8 @@ For every new persistent write path:
 - Keep provider credentials and signed download URLs out of safe metadata, events, error text, analytics, logs, and admin responses.
 - Add Firestore Rules tests proving browser denial for token roots, optional mappings, queues, and backend-owned connection fields, plus owner read access for the safe projection.
 - Add indexes deliberately for scheduled scans, queue status, pending disconnect retries, and history leases. Check the emulator and deployed index requirements before launch.
+- Use deterministic opaque provider-account and record IDs for health data. Never persist the raw provider account ID, free-form provider error, or raw provider payload in the unified health collections.
+- Keep health sample documents and reads strictly bounded. Time-based retention is intentionally uncapped until product/privacy policy explicitly changes it; do not add ad hoc TTL in a provider adapter.
 
 ## 6. Ingestion: webhooks, history, and idempotent queues
 
@@ -265,6 +284,8 @@ Account deletion is not merely token deletion. Add provider identity discovery a
 
 Existing imported events are product-policy decisions. State explicitly whether disconnect, entitlement expiry, and account deletion each retain or remove them. Wahoo retains imported events on disconnect but removes account-associated data on account deletion.
 
+Unified health history is retained on provider disconnect and removed on account deletion. Its collections live below `users/{uid}`, so the configured recursive extension owns account cleanup; provider adapters must not delete historical health records during ordinary deauthorization.
+
 ## 9. Frontend, help, public pages, and attribution
 
 The frontend should reuse the Services and provider-presentation patterns rather than create a one-off integration page.
@@ -311,6 +332,7 @@ Add deterministic tests next to the code being changed. The minimum set for an a
 | Area             | Required assertions                                                                                                                                                                             |
 | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Shared contracts | Service enum/metadata, provider presentation, source icon, function manifest, and required configuration validation (plus any explicitly approved rollout gate).                                  |
+| Health/wellness  | Native/canonical semantics, source attribution, coverage, missing-data behavior, ordered revision replacement, bounded chunks/queries, conflict preservation, Sleep references, disconnect retention, and deletion guards. |
 | OAuth            | State binding, approved redirect, explicit provider denial, incomplete callback, token refresh/rotation, stable identity, duplicate handling, and disconnect after entitlement expiry.             |
 | API boundary     | Request timeout, input normalization, pagination, rate-limit mapping, secret redaction, and no unsafe retry behavior.                                                                           |
 | Webhook/history  | Health and delivery acknowledgement, authentication, entitlement/connection/deletion rejection, lossless 64-bit IDs, deterministic IDs, duplicate delivery, out-of-order or newer revision, inclusive/date-window boundaries, skip rules, and lease contention. |
@@ -362,6 +384,7 @@ Run commands from the appropriate checked-out worktree. Do not deploy, publish, 
 - **Trusting a partner URL.** Defend against SSRF, redirects, private addresses, oversized responses, invalid content, and unbounded requests.
 - **Checking account deletion only at ingress.** Deletion can begin during download or parsing. Guard before enqueue, processing, persistence, and transactional follow-up writes.
 - **Deleting a root document non-recursively.** Token roots and feature state can have subcollections. Use `recursiveDelete` for subtree-capable cleanup.
+- **Copying Sleep or flattening provider health into one preferred value.** Keep `sleepSessions` canonical, reference allowlisted aggregates, preserve every source observation, and make any future source-selection policy explicit.
 - **Making disconnect dependent on Pro.** Users must be able to revoke access after their plan changes. Separate connect/import authorization from disconnect authorization.
 - **Giving the client access to useful-looking operational fields.** Token roots, optional mappings, queues, retry state, and disconnect controls are backend-owned even when the browser shows a connection badge.
 - **Adding only the service card.** A provider is incomplete without help, policies, integration page/SEO where appropriate, attribution, Rules, admin visibility, cleanup, and tests.
@@ -382,6 +405,7 @@ Use this checklist in every provider integration PR or implementation handoff:
 - [ ] Queue dispatch, TTL, retry/DLQ, and scheduled safety net are wired.
 - [ ] Disconnect, entitlement, pending retry, account deletion, and recursive cleanup cover every owned collection.
 - [ ] Firestore/Storage Rules, indexes, TTL, configuration, and any approved feature gate are reviewed.
+- [ ] Health/wellness mappings use the unified model, bounded writer/query contracts, source-aware conflicts, and Sleep references without duplicating Sleep data.
 - [ ] Services UI, accessibility, icons, source/destination labels, Help, Policies, public integration page, metadata, sitemap, and internal links are updated as applicable.
 - [ ] Admin queue stats, DLQ analysis, user filtering/enrichment, and logos are updated.
 - [ ] Unit, Rules, frontend, admin, shared-library, and build verification passed.

--- a/docs/provider-integration-guide.md
+++ b/docs/provider-integration-guide.md
@@ -138,7 +138,7 @@ For every new persistent write path:
 - Keep provider credentials and signed download URLs out of safe metadata, events, error text, analytics, logs, and admin responses.
 - Add Firestore Rules tests proving browser denial for token roots, optional mappings, queues, and backend-owned connection fields, plus owner read access for the safe projection.
 - Add indexes deliberately for scheduled scans, queue status, pending disconnect retries, and history leases. Check the emulator and deployed index requirements before launch.
-- Use deterministic opaque provider-account and source-record IDs for health data. Never persist the raw provider account ID, free-form provider error, or raw provider payload in the unified health collections.
+- Use the shared health writer's deterministic opaque provider-account ID, source-record ID, account-scoped source-key hash, and hashed revision token. Never persist the raw provider account ID, raw provider record key or revision token, free-form provider error, or raw provider payload in the unified health collections.
 - Keep health sample documents and reads strictly bounded. Time-based retention is intentionally uncapped until product/privacy policy explicitly changes it; do not add ad hoc TTL in a provider adapter.
 
 ## 6. Ingestion: webhooks, history, and idempotent queues

--- a/docs/sleep-sync-operations.md
+++ b/docs/sleep-sync-operations.md
@@ -18,7 +18,7 @@ continue to use it.
 Future provider health adapters may create typed references to an existing Sleep document and an
 allowlisted aggregate field (duration, score, aggregate HR/HRV, maximum SpO₂, or average respiration).
 They must not copy Sleep sessions, stages, provider fields, or respiration/SpO₂/HRV sample arrays into
-`healthRecords` or `healthSampleChunks`. The reference validator requires the stable health metric ID
+`healthSourceRecords` or `healthSampleChunks`. The reference validator requires the stable health metric ID
 to match the referenced Sleep field. See [Unified health data foundation](unified-health-data.md).
 
 Provider disconnect retains both normalized Sleep sessions and imported unified health history.

--- a/docs/sleep-sync-operations.md
+++ b/docs/sleep-sync-operations.md
@@ -9,6 +9,21 @@ times, average sleep heart rate, resting heart rate, overnight HRV, and optional
 It does not provide sleep-stage intervals, so COROS sessions retain their duration as an
 unknown stage rather than inferred Light, Deep, REM, or Awake stages.
 
+## Unified Health Compatibility Boundary
+
+The unified health foundation does not replace or migrate this pipeline. `users/{uid}/sleepSessions`
+remains the canonical normalized Sleep store, and existing dashboard, Training, and MCP Sleep reads
+continue to use it.
+
+Future provider health adapters may create typed references to an existing Sleep document and an
+allowlisted aggregate field (duration, score, aggregate HR/HRV, maximum SpO₂, or average respiration).
+They must not copy Sleep sessions, stages, provider fields, or respiration/SpO₂/HRV sample arrays into
+`healthRecords` or `healthSampleChunks`. The reference validator requires the stable health metric ID
+to match the referenced Sleep field. See [Unified health data foundation](unified-health-data.md).
+
+Provider disconnect retains both normalized Sleep sessions and imported unified health history.
+Account deletion recursively removes both because they remain below `users/{uid}`.
+
 ## Provider Kill Switch
 
 Sleep provider disablement is source controlled in:

--- a/docs/unified-health-data.md
+++ b/docs/unified-health-data.md
@@ -103,7 +103,7 @@ The record ID is a deterministic SHA-256 identifier derived from the Firebase UI
 
 ### Sample chunks
 
-`users/{uid}/healthSampleChunks/{chunkId}` stores compact arrays for one provider, record, metric, semantic variant, and series. Offsets are relative to the chunk start. Native, canonical, and optional quality arrays must align exactly.
+`users/{uid}/healthSampleChunks/{chunkId}` stores compact arrays for one provider, record, metric, semantic variant, and series. Offsets and value arrays are chunk-local and must align exactly. Coverage is repeated series-level metadata, so its `sampleCount` is the validated total across the source series rather than the current chunk length. Each chunk retains the provider receipt time so sample freshness does not substitute a local write timestamp.
 
 Chunks are permanent leaf documents by schema. Firestore Rules do not grant access to descendants, which makes document-only deletion safe when a higher provider revision replaces stale chunks.
 
@@ -122,15 +122,21 @@ Bounds protect Firestore document size, transaction limits, client reads, and pr
 | Metrics per source record | 128 |
 | Sample points per chunk | 1,440 |
 | Sample chunks per record | 200 |
-| Estimated document payload | 900 KiB |
-| Estimated atomic replacement payload | 8 MiB |
+| Estimated source-record payload | 256 KiB |
+| Estimated sample-chunk payload | 900 KiB |
+| Estimated payload per revision | 4 MiB |
+| Worst-case old + new replacement data | 8 MiB before index/protocol overhead |
 | Summary query range | 366 calendar days |
 | Sampled query range | 31 calendar days |
-| Public record page | 1–1,000 records; default 250 |
+| Public record page | 1–32 records; default 32 |
 | Firestore record fetch | Public page plus one look-ahead record |
-| Public chunk page | 1–500 chunks; default 100 |
+| Public chunk page | 1–8 chunks; default 8 |
 | Firestore chunk fetch | Public page plus one look-ahead chunk |
-| Sample points returned | 1,440–50,000; default 25,000 |
+| Sample points returned | 1,440–11,520; default 10,000 |
+
+The per-revision payload stays below half Firestore's 10 MiB transaction request limit because replacing a record can both write the new revision and delete the previous revision. The largest combined record/chunk fetch, including both look-ahead documents, is under 17 MiB. That leaves material serialization and projection headroom below the 32 MB non-streaming response limit for a second-generation HTTP function. See the official [Firestore quotas](https://firebase.google.com/docs/firestore/quotas) and [Cloud Functions quotas](https://firebase.google.com/docs/functions/quotas).
+
+Automatic indexes are disabled for every health collection except the date field needed by unfiltered range reads; the four explicit provider/metric/date composites remain available. This leaves write-request headroom for index entries and protocol overhead.
 
 Sample projection never splits a stored chunk to fit a point budget. It returns only complete matching chunks and reports truncation. The chunk cursor identifies the last consumed source chunk, which also lets sparse provider-first pages advance when their matching result is empty.
 
@@ -156,22 +162,26 @@ The query accepts inclusive `YYYY-MM-DD` boundaries, provider and metric filters
 
 Only one provider-or-metric predicate is used per Firestore collection to avoid a combinatorial index surface. Provider filtering takes precedence when both are supplied; the shared projector applies the remaining metric filter to the bounded source page. Paging is therefore source-page based: a page can contain fewer observations or chunks than its limit, including an empty matching sample page. Callers follow the corresponding cursor until its truncation flag is false.
 
+Daily summaries, discovery, coverage, freshness, and conflicts describe the current source page. `recordAggregateComplete` and `sampleAggregateComplete` are true only when the corresponding result was produced without an input cursor and has no later page. A paged consumer combines observations/chunks across every page before presenting range-wide aggregates; `findHealthConflicts()` recomputes conflicts across record-page boundaries. Each observation carries effective record-or-entry coverage and device attribution for this purpose.
+
 The result contains:
 
 - source-aware observations with native/canonical metric entries;
 - complete sample chunks when requested;
 - per-date observation and Sleep-reference IDs;
-- metric discovery with providers, value types, canonical units, semantic variants, first/last dates, and sample availability;
-- per-provider coverage, including requested, recorded, and partial day counts;
-- freshness with observed/received timestamps and explicit fresh, stale, or unknown state;
-- conflicts between overlapping observations with identical canonical semantics but differing values;
+- metric discovery with providers, value types, canonical units, aggregations, semantic variants, origins, recording methods, first/last dates, and sample availability;
+- per-provider/account and semantic-series coverage, including requested, recorded, missing, partial, and unknown day counts;
+- per-provider/account semantic-series freshness with observed/received timestamps and explicit fresh, stale, or unknown state;
+- conflicts between overlapping observations with identical canonical semantics but differing values, including origin, deterministic provider/account source pairs, and involved recording methods;
 - independent record/chunk cursors and truncation flags.
 
 The projector never fills gaps. A metric recorded on one of seven requested days reports one recorded day, not seven values with six zeroes.
 
 ### Direct and server reads
 
-`AppHealthService.watchRange()` is the default Health Hub path. It uses owner-scoped Firestore listeners, then runs the shared projector in the app. `AppHealthService.queryRangeViaServer()` calls `queryHealthRange` for consumers that need an authenticated server read.
+`AppHealthService.watchRange()` is the default Health Hub path. It uses owner-scoped Firestore listeners, then runs the shared projector in the app. Separate record/chunk listeners can emit one side of an atomic replacement first; the projector suppresses any chunk whose revision disagrees with a parent record present in the same source page, reports `sampleRevisionMismatchCount`, and marks the sample aggregate incomplete until the listeners converge.
+
+`AppHealthService.queryRangeViaServer()` calls `queryHealthRange` for consumers that need an authenticated server read. The server executes record and chunk queries in one read-only Firestore transaction so both snapshots share one consistent read time.
 
 The callable derives the data owner exclusively from `request.auth.uid`, requires App Check, validates every bound, logs only a safe error class, and returns the same `HealthRangeResult` shape.
 

--- a/docs/unified-health-data.md
+++ b/docs/unified-health-data.md
@@ -97,9 +97,9 @@ Every value or reference includes:
 
 ### Source records
 
-`users/{uid}/healthSourceRecords/{sourceRecordId}` stores one provider source record. A source record contains its calendar date and interval, source type/key, opaque account key, ordered revision, coverage, device, metric entries, searchable `metricIds`, and sample-chunk IDs.
+`users/{uid}/healthSourceRecords/{sourceRecordId}` stores one provider source record. A source record contains its calendar date and interval, source type, opaque source key, opaque account key, ordered revision, coverage, device, metric entries, searchable `metricIds`, and sample-chunk IDs.
 
-The source-record ID is a deterministic SHA-256 identifier derived from the Firebase UID, provider, raw provider account ID, provider record type, and provider record key. The account key is a separate deterministic hash. The raw provider account ID is validated for identity calculation and is never persisted or logged.
+The source-record ID is a deterministic SHA-256 identifier derived from the Firebase UID, provider, raw provider account ID, provider record type, and provider record key. The account key is a separate deterministic hash. The persisted source key is another account-scoped deterministic hash of the provider record key, and the persisted revision token is a source-record-scoped hash of the adapter token. Raw provider account IDs, record keys, and revision tokens remain in writer memory only for identity, revision, and digest calculation; none is persisted or logged.
 
 ### Sample chunks
 
@@ -134,6 +134,8 @@ Bounds protect Firestore document size, transaction limits, client reads, and pr
 | Firestore chunk fetch | Public page plus one look-ahead chunk |
 | Sample points returned | 1,440–11,520; default 10,000 |
 
+The validator counts recognized input JSON-escaped UTF-8 bytes cumulatively while walking aligned metric/sample values, charges raw sample strings before trimming, and stops before retaining the element that would cross 4 MiB. The writer then cleans, measures, and retains one sample chunk at a time with the same cumulative ceiling before applying the exact final source-record-plus-chunks check. This bounds validation and construction amplification; the final estimate remains authoritative because repeated chunk metadata changes the persisted size.
+
 The per-revision payload stays below half Firestore's 10 MiB transaction request limit because replacing a source record can both write the new revision and delete the previous revision. The largest combined source-record/chunk fetch, including both look-ahead documents, is under 17 MiB. That leaves material serialization and projection headroom below the 32 MB non-streaming response limit for a second-generation HTTP function. See the official [Firestore quotas](https://firebase.google.com/docs/firestore/quotas) and [Cloud Functions quotas](https://firebase.google.com/docs/functions/quotas).
 
 Automatic indexes are disabled for every health collection except the date field needed by unfiltered range reads; the four explicit provider/metric/date composites remain available. This leaves write-request headroom for index entries and protocol overhead.
@@ -142,7 +144,7 @@ Sample projection never splits a stored chunk to fit a point budget. It returns 
 
 ## Revision and replacement contract
 
-Provider adapters must supply a non-negative ordered revision and a bounded opaque token. The writer calculates the content digest itself, excluding receipt/write timestamps so an exact redelivery remains idempotent.
+Provider adapters must supply a non-negative ordered revision and a bounded stable token. The writer hashes that token before persistence and calculates the content digest itself, excluding receipt/write timestamps so an exact redelivery remains idempotent.
 
 | Incoming revision | Result |
 | --- | --- |
@@ -212,7 +214,7 @@ The validator also requires the health metric ID to match the referenced Sleep f
 - Firestore Rules permit owners to get their own health documents and issue only explicitly bounded list queries.
 - All browser writes are denied. Provider adapters use the Admin SDK writer.
 - The callable requires Firebase Authentication and App Check and ignores any caller-supplied UID.
-- Provider account IDs are hashed before persistence. Credentials, raw payloads, raw values in logs, signed URLs, and free-form provider errors are prohibited.
+- Provider account IDs, provider source-record keys, and provider revision tokens are hashed before persistence. Credentials, raw payloads, raw values in logs, signed URLs, and free-form provider errors are prohibited.
 - Large metric/sample arrays are excluded from automatic Firestore indexes.
 - Health source records, sample chunks, and sync state live below `users/{uid}`, so the configured recursive Delete User Data extension removes them with the account.
 - Background and transactional writes no-op when the user is missing or deletion is active.
@@ -231,7 +233,7 @@ Issues #611–#613 should implement each provider independently against this fou
 
 1. Confirm the documented API family, delivery mode, history/range limits, sampling cadence, permission/scopes, and revision behavior.
 2. Map only documented fields. Preserve the exact provider field/unit and semantic variant.
-3. Supply a stable provider account ID, record type/key, ordered revision, and opaque provider revision token. A revision token is an identifier such as an ETag or version marker, never an OAuth/access credential.
+3. Supply a stable provider account ID, record type/key, ordered revision, and stable provider revision token. The shared writer derives account-scoped opaque persisted identities from the raw account ID and record key and hashes the revision token before storage. A revision token is an identifier such as an ETag or version marker, never an OAuth/access credential.
 4. Normalize units only where conversion is defensible; otherwise use `native_only` or `not_comparable`.
 5. Preserve recorded/provider-calculated/manual origin, device, quality, and partial coverage.
 6. Send bounded aligned sample series to the shared writer; never hand-build chunk documents.

--- a/docs/unified-health-data.md
+++ b/docs/unified-health-data.md
@@ -1,0 +1,249 @@
+# Unified Health Data Foundation
+
+This document is the source of truth for the cross-provider health foundation introduced by issue #610. It defines the shared model and storage/query boundary that Garmin, Suunto, COROS, and Wahoo adapters can target without pretending that every provider exposes the same measurements or semantics.
+
+Provider-specific mapping remains in issues #611–#613. The Health Hub product surface remains in #614. This foundation does not start provider ingestion, backfill existing data, or change the current Sleep, Training, MCP, or activity pipelines by itself.
+
+## Goals
+
+- Give provider adapters one typed model for daily health summaries, interval summaries, point measurements, profile snapshots, and bounded high-resolution samples.
+- Preserve provider attribution, native meaning, recording method, device attribution, quality, and coverage.
+- Normalize only values with a defensible canonical meaning and unit.
+- Keep missing data missing; never turn an absent day or unsupported metric into zero.
+- Preserve conflicting source observations instead of silently selecting or averaging one.
+- Give the Angular app and an authenticated callable the same query, projection, paging, and result contracts.
+- Reuse the existing normalized `sleepSessions` model through typed references instead of copying sleep sessions or raw sleep samples.
+
+## Non-goals
+
+- No Garmin, Suunto, COROS, or Wahoo health adapter is wired in this issue.
+- No cross-provider deduplication, ranking, or source-preference policy is applied.
+- No medical interpretation or diagnosis is produced.
+- No provider payload, credential, raw provider account ID, or signed URL is stored in the health model.
+- No new MCP tool, Training metric, normalized Sleep field, dashboard tile, or public page is added.
+- No time-based retention or Firestore TTL policy is enabled for health records or sample chunks.
+
+## Architecture
+
+```text
+provider adapter (#611–#613)
+        │
+        ├─ exact provider/native semantics
+        ├─ canonical conversion only when defensible
+        └─ ordered provider revision
+        │
+        ▼
+runtime validation
+        │
+        ▼
+deletion-guarded atomic replacement
+        ├─ users/{uid}/healthRecords/{recordId}
+        ├─ users/{uid}/healthSampleChunks/{chunkId}
+        └─ users/{uid}/healthSyncState/{provider}
+        │
+        ├───────────────┬────────────────────┐
+        ▼               ▼                    ▼
+direct Firestore   queryHealthRange     account deletion
+(default app path) (auth + App Check)   (recursive user root)
+        └───────────────┬────────────────────┘
+                        ▼
+           shared query plan + projector
+                        ▼
+                 HealthRangeResult
+```
+
+The shared implementation is split intentionally:
+
+- `shared/health.ts` defines the schema, stable metric catalog, bounds, and public query/result types.
+- `shared/health-query.ts` validates range requests and projects source records into observations, discovery, coverage, freshness, daily references, conflicts, and cursors.
+- `shared/health-firestore-query.ts` creates the environment-neutral bounded Firestore plan.
+- `functions/src/health/validation.ts` validates untrusted adapter input at runtime.
+- `functions/src/health/writer.ts` owns opaque IDs, revisions, sample chunking, replacement, deletion guards, and sync state.
+- `functions/src/health/query.ts` and `functions/src/health/callable.ts` provide the server adapter.
+- `src/app/services/app.health.service.ts` provides the default direct listener and explicit callable alternative.
+
+## Stable metric catalog
+
+Metric IDs describe stable product semantics. A provider name or native field name must never become a metric ID. Provider-specific meaning belongs in `native.metric`, `semanticVariant`, native units, qualifiers, and source metadata.
+
+| Category | Stable metric IDs |
+| --- | --- |
+| Movement | `steps`, `wheelchair_pushes`, `distance`, `wheelchair_push_distance`, `floors_climbed`, `active_duration`, `moderate_intensity_duration`, `vigorous_intensity_duration`, `altitude` |
+| Energy | `active_energy`, `basal_energy`, `total_energy` |
+| Cardiovascular | `heart_rate`, `resting_heart_rate`, `heart_rate_variability`, `blood_oxygen_saturation`, `respiration_rate`, `blood_pressure_systolic`, `blood_pressure_diastolic`, `pulse_rate` |
+| Wellness | `stress_level`, `stress_state`, `stress_duration`, `body_energy`, `body_energy_change`, `recovery_score` |
+| Body | `body_weight`, `body_mass_index`, `body_fat`, `body_water`, `muscle_mass`, `bone_mass`, `skin_temperature_deviation` |
+| Fitness | `vo2_max`, `fitness_age` |
+| Sleep references | `sleep_duration`, `sleep_score` plus the applicable cardiovascular metric IDs for referenced Sleep vitals |
+
+Each catalog entry fixes its value type and canonical unit. The current canonical units are count, meters, seconds, kilocalories, beats/minute, milliseconds, percentage, breaths/minute, kilograms, kg/m², mmHg, Celsius, ml/kg/min, years, score, and category.
+
+### Metric semantics
+
+Every value or reference includes:
+
+- `aggregation`, such as total, average, minimum, maximum, latest, or sample;
+- `semanticVariant`, which distinguishes meanings that must not be combined, such as a provider daily total and a ten-minute bucket total;
+- `origin`: recorded, provider summary, or Quantified Self derived;
+- `recordingMethod`: device, manual, provider calculated, Quantified Self calculated, or unknown;
+- quality and coverage metadata;
+- optional device attribution;
+- a native metric/value/unit representation;
+- a canonical value only when `normalizationStatus` is `canonical`.
+
+`native_only` and `not_comparable` entries deliberately omit a canonical value. The runtime validator rejects a canonical unit or value that disagrees with the catalog.
+
+## Firestore model
+
+### Source records
+
+`users/{uid}/healthRecords/{recordId}` stores one provider source record. A record contains its calendar date and interval, source type/key, opaque account key, ordered revision, coverage, device, metric entries, searchable `metricIds`, and sample-chunk IDs.
+
+The record ID is a deterministic SHA-256 identifier derived from the Firebase UID, provider, raw provider account ID, provider record type, and provider record key. The account key is a separate deterministic hash. The raw provider account ID is validated for identity calculation and is never persisted or logged.
+
+### Sample chunks
+
+`users/{uid}/healthSampleChunks/{chunkId}` stores compact arrays for one provider, record, metric, semantic variant, and series. Offsets are relative to the chunk start. Native, canonical, and optional quality arrays must align exactly.
+
+Chunks are permanent leaf documents by schema. Firestore Rules do not grant access to descendants, which makes document-only deletion safe when a higher provider revision replaces stale chunks.
+
+### Sync state
+
+`users/{uid}/healthSyncState/{provider}` stores the safe aggregate state needed by a future Health Hub: ready, permission missing, reconnect required, failed, unsupported, or disconnected, plus bounded timestamps and an opaque error code. Raw error messages and payload excerpts are rejected.
+
+This collection is not the OAuth connection source of truth. Provider credentials and stable raw account identity remain in their existing server-owned integration stores.
+
+## Hard bounds
+
+Bounds protect Firestore document size, transaction limits, client reads, and projection memory. They are not a time-based retention policy.
+
+| Boundary | Limit |
+| --- | ---: |
+| Metrics per source record | 128 |
+| Sample points per chunk | 1,440 |
+| Sample chunks per record | 200 |
+| Estimated document payload | 900 KiB |
+| Estimated atomic replacement payload | 8 MiB |
+| Summary query range | 366 calendar days |
+| Sampled query range | 31 calendar days |
+| Public record page | 1–1,000 records; default 250 |
+| Firestore record fetch | Public page plus one look-ahead record |
+| Public chunk page | 1–500 chunks; default 100 |
+| Firestore chunk fetch | Public page plus one look-ahead chunk |
+| Sample points returned | 1,440–50,000; default 25,000 |
+
+Sample projection never splits a stored chunk to fit a point budget. It returns only complete matching chunks and reports truncation. The chunk cursor identifies the last consumed source chunk, which also lets sparse provider-first pages advance when their matching result is empty.
+
+## Revision and replacement contract
+
+Provider adapters must supply a non-negative ordered revision and a bounded opaque token. The writer calculates the content digest itself, excluding receipt/write timestamps so an exact redelivery remains idempotent.
+
+| Incoming revision | Result |
+| --- | --- |
+| No stored record | Write the record and all chunks atomically |
+| Lower order | Return `stale`; write nothing |
+| Same order, token, and digest | Return `unchanged`; write nothing |
+| Same order with different token or content | Throw `HealthRevisionConflictError`; write nothing |
+| Higher order | Atomically replace the record, write current chunks, and delete stale leaf chunks |
+
+Every transaction rechecks the account-deletion tombstone and user root through `getUserDeletionGuardStateInTransaction` before reading or writing feature data.
+
+## Query and projection contract
+
+`HealthRangeQuery -> HealthRangeResult` is the only public health range contract.
+
+The query accepts inclusive `YYYY-MM-DD` boundaries, provider and metric filters, sample inclusion, page limits, point limits, and stable `{ calendarDate, id }` cursors. Both the browser and Functions validate the same limits and create the same Firestore plan.
+
+Only one provider-or-metric predicate is used per Firestore collection to avoid a combinatorial index surface. Provider filtering takes precedence when both are supplied; the shared projector applies the remaining metric filter to the bounded source page. Paging is therefore source-page based: a page can contain fewer observations or chunks than its limit, including an empty matching sample page. Callers follow the corresponding cursor until its truncation flag is false.
+
+The result contains:
+
+- source-aware observations with native/canonical metric entries;
+- complete sample chunks when requested;
+- per-date observation and Sleep-reference IDs;
+- metric discovery with providers, value types, canonical units, semantic variants, first/last dates, and sample availability;
+- per-provider coverage, including requested, recorded, and partial day counts;
+- freshness with observed/received timestamps and explicit fresh, stale, or unknown state;
+- conflicts between overlapping observations with identical canonical semantics but differing values;
+- independent record/chunk cursors and truncation flags.
+
+The projector never fills gaps. A metric recorded on one of seven requested days reports one recorded day, not seven values with six zeroes.
+
+### Direct and server reads
+
+`AppHealthService.watchRange()` is the default Health Hub path. It uses owner-scoped Firestore listeners, then runs the shared projector in the app. `AppHealthService.queryRangeViaServer()` calls `queryHealthRange` for consumers that need an authenticated server read.
+
+The callable derives the data owner exclusively from `request.auth.uid`, requires App Check, validates every bound, logs only a safe error class, and returns the same `HealthRangeResult` shape.
+
+## Conflict policy
+
+Records remain source-aware. The foundation does not pick a preferred provider, blend values, or hide duplicates.
+
+A conflict is emitted only when canonical entries share metric ID, calendar date, aggregation, semantic variant, origin, canonical unit, and overlapping time intervals, come from different provider/account sources, and contain different scalar values. Native-only entries and different semantic variants are not declared conflicts.
+
+A future product layer may define an explicit source-selection policy, but it must operate on these preserved observations and expose that policy to the user.
+
+## Sleep compatibility boundary
+
+`users/{uid}/sleepSessions` remains the canonical normalized Sleep model and current Sleep query path. Unified health records must not copy a Sleep session, stage intervals, provider fields, or respiration/SpO₂/HRV sample arrays.
+
+When a health source record needs a Sleep relationship, it stores a typed `sleep_reference` containing the existing Sleep document ID and one allowlisted aggregate field:
+
+- duration or score;
+- average, minimum, or resting heart rate;
+- average or overnight HRV;
+- maximum SpO₂;
+- average respiration.
+
+The validator also requires the health metric ID to match the referenced Sleep field. For example, `durationSeconds` maps to `sleep_duration`, while `vitals.averageHeartRateBpm` maps to `heart_rate`. The referenced value is resolved by the Sleep consumer; it is not copied into the health record.
+
+## Security and privacy
+
+- Firestore Rules permit owners to get their own health documents and issue only explicitly bounded list queries.
+- All browser writes are denied. Provider adapters use the Admin SDK writer.
+- The callable requires Firebase Authentication and App Check and ignores any caller-supplied UID.
+- Provider account IDs are hashed before persistence. Credentials, raw payloads, raw values in logs, signed URLs, and free-form provider errors are prohibited.
+- Large metric/sample arrays are excluded from automatic Firestore indexes.
+- Health records, sample chunks, and sync state live below `users/{uid}`, so the configured recursive Delete User Data extension removes them with the account.
+- Background and transactional writes no-op when the user is missing or deletion is active.
+
+## Retention and disconnect
+
+Disconnect stops future provider access and changes safe sync state; it does not delete already imported health history. This matches the existing retained-import model and prevents a connection toggle from silently erasing historical analysis.
+
+Account deletion removes all health records, chunks, and sync state through recursive deletion of `users/{uid}`. There are no top-level unified-health collections that require a separate cleanup query.
+
+Time-based health retention is intentionally uncapped for now. No `expireAt` field or TTL override exists for `healthRecords` or `healthSampleChunks`. Storage remains bounded per document, replacement, and query. Revisit time-based retention only with an explicit product/privacy decision and measured storage data.
+
+## Provider adapter checklist
+
+Issues #611–#613 should implement each provider independently against this foundation:
+
+1. Confirm the documented API family, delivery mode, history/range limits, sampling cadence, permission/scopes, and revision behavior.
+2. Map only documented fields. Preserve the exact provider field/unit and semantic variant.
+3. Supply a stable provider account ID, record type/key, ordered revision, and opaque provider revision token. A revision token is an identifier such as an ETag or version marker, never an OAuth/access credential.
+4. Normalize units only where conversion is defensible; otherwise use `native_only` or `not_comparable`.
+5. Preserve recorded/provider-calculated/manual origin, device, quality, and partial coverage.
+6. Send bounded aligned sample series to the shared writer; never hand-build chunk documents.
+7. Update safe sync state with opaque error codes only.
+8. Recheck connection, entitlement, permissions, and account deletion at ingress and again before persistence.
+9. Test duplicates, stale/newer revisions, missing fields, partial days, timezone boundaries, unit conversion, sample bounds, and disconnect retention.
+10. Update this document, the provider guide, provider Help/policy/integration pages where behavior becomes user-visible, and provider-specific operational documentation.
+
+## Operational and release notes
+
+The foundation is inert until provider adapters call the writer and the Health Hub calls `AppHealthService`. There is no migration or backfill in #610.
+
+A release that begins using these collections must apply compatible Firestore indexes and Rules before enabling provider writes or Health Hub reads, then deploy the `queryHealthRange` callable and application through the normal release workflow. This implementation does not deploy or mutate production infrastructure.
+
+Useful local verification:
+
+```bash
+npx vitest run src/app/shared/health.shared.spec.ts src/app/services/app.health.service.spec.ts --reporter=verbose
+npm --prefix functions test -- src/health/validation.spec.ts src/health/writer.spec.ts src/health/query.spec.ts src/health/callable.spec.ts src/health/lifecycle.spec.ts src/firestore-indexes.spec.ts
+npm run test:rules
+npm --prefix functions run build
+npm run build
+```
+
+The in-app Help content was reviewed for this foundation. No Help copy changes are required until provider health ingestion or the Health Hub becomes user-visible in #611–#614.

--- a/docs/unified-health-data.md
+++ b/docs/unified-health-data.md
@@ -21,7 +21,7 @@ Provider-specific mapping remains in issues #611–#613. The Health Hub product 
 - No medical interpretation or diagnosis is produced.
 - No provider payload, credential, raw provider account ID, or signed URL is stored in the health model.
 - No new MCP tool, Training metric, normalized Sleep field, dashboard tile, or public page is added.
-- No time-based retention or Firestore TTL policy is enabled for health records or sample chunks.
+- No time-based retention or Firestore TTL policy is enabled for health source records or sample chunks.
 
 ## Architecture
 
@@ -37,7 +37,7 @@ runtime validation
         │
         ▼
 deletion-guarded atomic replacement
-        ├─ users/{uid}/healthRecords/{recordId}
+        ├─ users/{uid}/healthSourceRecords/{sourceRecordId}
         ├─ users/{uid}/healthSampleChunks/{chunkId}
         └─ users/{uid}/healthSyncState/{provider}
         │
@@ -97,13 +97,13 @@ Every value or reference includes:
 
 ### Source records
 
-`users/{uid}/healthRecords/{recordId}` stores one provider source record. A record contains its calendar date and interval, source type/key, opaque account key, ordered revision, coverage, device, metric entries, searchable `metricIds`, and sample-chunk IDs.
+`users/{uid}/healthSourceRecords/{sourceRecordId}` stores one provider source record. A source record contains its calendar date and interval, source type/key, opaque account key, ordered revision, coverage, device, metric entries, searchable `metricIds`, and sample-chunk IDs.
 
-The record ID is a deterministic SHA-256 identifier derived from the Firebase UID, provider, raw provider account ID, provider record type, and provider record key. The account key is a separate deterministic hash. The raw provider account ID is validated for identity calculation and is never persisted or logged.
+The source-record ID is a deterministic SHA-256 identifier derived from the Firebase UID, provider, raw provider account ID, provider record type, and provider record key. The account key is a separate deterministic hash. The raw provider account ID is validated for identity calculation and is never persisted or logged.
 
 ### Sample chunks
 
-`users/{uid}/healthSampleChunks/{chunkId}` stores compact arrays for one provider, record, metric, semantic variant, and series. Offsets and value arrays are chunk-local and must align exactly. Coverage is repeated series-level metadata, so its `sampleCount` is the validated total across the source series rather than the current chunk length. Each chunk retains the provider receipt time so sample freshness does not substitute a local write timestamp.
+`users/{uid}/healthSampleChunks/{chunkId}` stores compact arrays for one provider source record, metric, semantic variant, and series. Offsets and value arrays are chunk-local and must align exactly. Coverage is repeated series-level metadata, so its `sampleCount` is the validated total across the source series rather than the current chunk length. Each chunk retains the provider receipt time so sample freshness does not substitute a local write timestamp.
 
 Chunks are permanent leaf documents by schema. Firestore Rules do not grant access to descendants, which makes document-only deletion safe when a higher provider revision replaces stale chunks.
 
@@ -121,20 +121,20 @@ Bounds protect Firestore document size, transaction limits, client reads, and pr
 | --- | ---: |
 | Metrics per source record | 128 |
 | Sample points per chunk | 1,440 |
-| Sample chunks per record | 200 |
+| Sample chunks per source record | 200 |
 | Estimated source-record payload | 256 KiB |
 | Estimated sample-chunk payload | 900 KiB |
 | Estimated payload per revision | 4 MiB |
 | Worst-case old + new replacement data | 8 MiB before index/protocol overhead |
 | Summary query range | 366 calendar days |
 | Sampled query range | 31 calendar days |
-| Public record page | 1–32 records; default 32 |
-| Firestore record fetch | Public page plus one look-ahead record |
+| Public source-record page | 1–32 source records; default 32 |
+| Firestore source-record fetch | Public page plus one look-ahead source record |
 | Public chunk page | 1–8 chunks; default 8 |
 | Firestore chunk fetch | Public page plus one look-ahead chunk |
 | Sample points returned | 1,440–11,520; default 10,000 |
 
-The per-revision payload stays below half Firestore's 10 MiB transaction request limit because replacing a record can both write the new revision and delete the previous revision. The largest combined record/chunk fetch, including both look-ahead documents, is under 17 MiB. That leaves material serialization and projection headroom below the 32 MB non-streaming response limit for a second-generation HTTP function. See the official [Firestore quotas](https://firebase.google.com/docs/firestore/quotas) and [Cloud Functions quotas](https://firebase.google.com/docs/functions/quotas).
+The per-revision payload stays below half Firestore's 10 MiB transaction request limit because replacing a source record can both write the new revision and delete the previous revision. The largest combined source-record/chunk fetch, including both look-ahead documents, is under 17 MiB. That leaves material serialization and projection headroom below the 32 MB non-streaming response limit for a second-generation HTTP function. See the official [Firestore quotas](https://firebase.google.com/docs/firestore/quotas) and [Cloud Functions quotas](https://firebase.google.com/docs/functions/quotas).
 
 Automatic indexes are disabled for every health collection except the date field needed by unfiltered range reads; the four explicit provider/metric/date composites remain available. This leaves write-request headroom for index entries and protocol overhead.
 
@@ -146,11 +146,11 @@ Provider adapters must supply a non-negative ordered revision and a bounded opaq
 
 | Incoming revision | Result |
 | --- | --- |
-| No stored record | Write the record and all chunks atomically |
+| No stored source record | Write the source record and all chunks atomically |
 | Lower order | Return `stale`; write nothing |
 | Same order, token, and digest | Return `unchanged`; write nothing |
-| Same order with different token or content | Throw `HealthRevisionConflictError`; write nothing |
-| Higher order | Atomically replace the record, write current chunks, and delete stale leaf chunks |
+| Same order with different token or content | Throw `HealthSourceRecordRevisionConflictError`; write nothing |
+| Higher order | Atomically replace the source record, write current chunks, and delete stale leaf chunks |
 
 Every transaction rechecks the account-deletion tombstone and user root through `getUserDeletionGuardStateInTransaction` before reading or writing feature data.
 
@@ -162,7 +162,7 @@ The query accepts inclusive `YYYY-MM-DD` boundaries, provider and metric filters
 
 Only one provider-or-metric predicate is used per Firestore collection to avoid a combinatorial index surface. Provider filtering takes precedence when both are supplied; the shared projector applies the remaining metric filter to the bounded source page. Paging is therefore source-page based: a page can contain fewer observations or chunks than its limit, including an empty matching sample page. Callers follow the corresponding cursor until its truncation flag is false.
 
-Daily summaries, discovery, coverage, freshness, and conflicts describe the current source page. `recordAggregateComplete` and `sampleAggregateComplete` are true only when the corresponding result was produced without an input cursor and has no later page. A paged consumer combines observations/chunks across every page before presenting range-wide aggregates; `findHealthConflicts()` recomputes conflicts across record-page boundaries. Each observation carries effective record-or-entry coverage and device attribution for this purpose.
+Daily summaries, discovery, coverage, freshness, and conflicts describe the current source page. `sourceRecordAggregateComplete` and `sampleAggregateComplete` are true only when the corresponding result was produced without an input cursor and has no later page. A paged consumer combines observations/chunks across every page before presenting range-wide aggregates; `findHealthConflicts()` recomputes conflicts across source-record page boundaries. Each observation carries effective source-record-or-entry coverage and device attribution for this purpose.
 
 The result contains:
 
@@ -173,21 +173,21 @@ The result contains:
 - per-provider/account and semantic-series coverage, including requested, recorded, missing, partial, and unknown day counts;
 - per-provider/account semantic-series freshness with observed/received timestamps and explicit fresh, stale, or unknown state;
 - conflicts between overlapping observations with identical canonical semantics but differing values, including origin, deterministic provider/account source pairs, and involved recording methods;
-- independent record/chunk cursors and truncation flags.
+- independent source-record/chunk cursors and truncation flags.
 
 The projector never fills gaps. A metric recorded on one of seven requested days reports one recorded day, not seven values with six zeroes.
 
 ### Direct and server reads
 
-`AppHealthService.watchRange()` is the default Health Hub path. It uses owner-scoped Firestore listeners, then runs the shared projector in the app. Separate record/chunk listeners can emit one side of an atomic replacement first; the projector suppresses any chunk whose revision disagrees with a parent record present in the same source page, reports `sampleRevisionMismatchCount`, and marks the sample aggregate incomplete until the listeners converge.
+`AppHealthService.watchRange()` is the default Health Hub path. It uses owner-scoped Firestore listeners, then runs the shared projector in the app. Separate source-record/chunk listeners can emit one side of an atomic replacement first; the projector suppresses any chunk whose revision disagrees with a parent source record present in the same source page, reports `sampleRevisionMismatchCount`, and marks the sample aggregate incomplete until the listeners converge.
 
-`AppHealthService.queryRangeViaServer()` calls `queryHealthRange` for consumers that need an authenticated server read. The server executes record and chunk queries in one read-only Firestore transaction so both snapshots share one consistent read time.
+`AppHealthService.queryRangeViaServer()` calls `queryHealthRange` for consumers that need an authenticated server read. The server executes source-record and chunk queries in one read-only Firestore transaction so both snapshots share one consistent read time.
 
 The callable derives the data owner exclusively from `request.auth.uid`, requires App Check, validates every bound, logs only a safe error class, and returns the same `HealthRangeResult` shape.
 
 ## Conflict policy
 
-Records remain source-aware. The foundation does not pick a preferred provider, blend values, or hide duplicates.
+Source records remain source-aware. The foundation does not pick a preferred provider, blend values, or hide duplicates.
 
 A conflict is emitted only when canonical entries share metric ID, calendar date, aggregation, semantic variant, origin, canonical unit, and overlapping time intervals, come from different provider/account sources, and contain different scalar values. Native-only entries and different semantic variants are not declared conflicts.
 
@@ -195,7 +195,7 @@ A future product layer may define an explicit source-selection policy, but it mu
 
 ## Sleep compatibility boundary
 
-`users/{uid}/sleepSessions` remains the canonical normalized Sleep model and current Sleep query path. Unified health records must not copy a Sleep session, stage intervals, provider fields, or respiration/SpO₂/HRV sample arrays.
+`users/{uid}/sleepSessions` remains the canonical normalized Sleep model and current Sleep query path. Unified health source records must not copy a Sleep session, stage intervals, provider fields, or respiration/SpO₂/HRV sample arrays.
 
 When a health source record needs a Sleep relationship, it stores a typed `sleep_reference` containing the existing Sleep document ID and one allowlisted aggregate field:
 
@@ -205,7 +205,7 @@ When a health source record needs a Sleep relationship, it stores a typed `sleep
 - maximum SpO₂;
 - average respiration.
 
-The validator also requires the health metric ID to match the referenced Sleep field. For example, `durationSeconds` maps to `sleep_duration`, while `vitals.averageHeartRateBpm` maps to `heart_rate`. The referenced value is resolved by the Sleep consumer; it is not copied into the health record.
+The validator also requires the health metric ID to match the referenced Sleep field. For example, `durationSeconds` maps to `sleep_duration`, while `vitals.averageHeartRateBpm` maps to `heart_rate`. The referenced value is resolved by the Sleep consumer; it is not copied into the health source record.
 
 ## Security and privacy
 
@@ -214,16 +214,16 @@ The validator also requires the health metric ID to match the referenced Sleep f
 - The callable requires Firebase Authentication and App Check and ignores any caller-supplied UID.
 - Provider account IDs are hashed before persistence. Credentials, raw payloads, raw values in logs, signed URLs, and free-form provider errors are prohibited.
 - Large metric/sample arrays are excluded from automatic Firestore indexes.
-- Health records, sample chunks, and sync state live below `users/{uid}`, so the configured recursive Delete User Data extension removes them with the account.
+- Health source records, sample chunks, and sync state live below `users/{uid}`, so the configured recursive Delete User Data extension removes them with the account.
 - Background and transactional writes no-op when the user is missing or deletion is active.
 
 ## Retention and disconnect
 
 Disconnect stops future provider access and changes safe sync state; it does not delete already imported health history. This matches the existing retained-import model and prevents a connection toggle from silently erasing historical analysis.
 
-Account deletion removes all health records, chunks, and sync state through recursive deletion of `users/{uid}`. There are no top-level unified-health collections that require a separate cleanup query.
+Account deletion removes all health source records, chunks, and sync state through recursive deletion of `users/{uid}`. There are no top-level unified-health collections that require a separate cleanup query.
 
-Time-based health retention is intentionally uncapped for now. No `expireAt` field or TTL override exists for `healthRecords` or `healthSampleChunks`. Storage remains bounded per document, replacement, and query. Revisit time-based retention only with an explicit product/privacy decision and measured storage data.
+Time-based health retention is intentionally uncapped for now. No `expireAt` field or TTL override exists for `healthSourceRecords` or `healthSampleChunks`. Storage remains bounded per document, replacement, and query. Revisit time-based retention only with an explicit product/privacy decision and measured storage data.
 
 ## Provider adapter checklist
 

--- a/docs/unified-health-data.md
+++ b/docs/unified-health-data.md
@@ -221,7 +221,7 @@ The validator also requires the health metric ID to match the referenced Sleep f
 
 Disconnect stops future provider access and changes safe sync state; it does not delete already imported health history. This matches the existing retained-import model and prevents a connection toggle from silently erasing historical analysis.
 
-Account deletion removes all health source records, chunks, and sync state through recursive deletion of `users/{uid}`. There are no top-level unified-health collections that require a separate cleanup query.
+Account deletion writes the deletion tombstone before deleting the Firebase Auth user; if that marker cannot be stored, deletion fails closed and the account remains so recursive cleanup cannot begin without a writer-visible deletion signal. After Auth deletion, the configured extension removes all health source records, chunks, and sync state through recursive deletion of `users/{uid}`. There are no top-level unified-health collections that require a separate cleanup query.
 
 Time-based health retention is intentionally uncapped for now. No `expireAt` field or TTL override exists for `healthSourceRecords` or `healthSampleChunks`. Storage remains bounded per document, replacement, and query. Revisit time-based retention only with an explicit product/privacy decision and measured storage data.
 

--- a/docs/user-deletion-workflow.html
+++ b/docs/user-deletion-workflow.html
@@ -229,7 +229,7 @@
                     </tr>
                     <tr>
                         <td><strong>Sleep &amp; Unified Health</strong></td>
-                        <td><code>users/{uid}/sleepSessions/*</code><br><code>users/{uid}/sleepSyncState/*</code><br><code>users/{uid}/healthRecords/*</code><br><code>users/{uid}/healthSampleChunks/*</code><br><code>users/{uid}/healthSyncState/*</code></td>
+                        <td><code>users/{uid}/sleepSessions/*</code><br><code>users/{uid}/sleepSyncState/*</code><br><code>users/{uid}/healthSourceRecords/*</code><br><code>users/{uid}/healthSampleChunks/*</code><br><code>users/{uid}/healthSyncState/*</code></td>
                         <td>Extension</td>
                         <td>All records remain in the recursively deleted user subtree. Provider disconnect retains imported history; account deletion removes it. Deletion-guarded writers cannot recreate records once deletion starts.</td>
                     </tr>

--- a/docs/user-deletion-workflow.html
+++ b/docs/user-deletion-workflow.html
@@ -228,6 +228,12 @@
                         <td>The extension removes saved routes during account deletion; <code>cleanupRouteFiles</code> covers normal route deletes, route metadata, route-scoped original files, and route quota reconciliation while skipping Firestore-owned work when account deletion is already in progress</td>
                     </tr>
                     <tr>
+                        <td><strong>Sleep &amp; Unified Health</strong></td>
+                        <td><code>users/{uid}/sleepSessions/*</code><br><code>users/{uid}/sleepSyncState/*</code><br><code>users/{uid}/healthRecords/*</code><br><code>users/{uid}/healthSampleChunks/*</code><br><code>users/{uid}/healthSyncState/*</code></td>
+                        <td>Extension</td>
+                        <td>All records remain in the recursively deleted user subtree. Provider disconnect retains imported history; account deletion removes it. Deletion-guarded writers cannot recreate records once deletion starts.</td>
+                    </tr>
+                    <tr>
                         <td><strong>Stripe Data</strong></td>
                         <td><code>customers/{uid}</code><br><code>customers/{uid}/subscriptions/*</code></td>
                         <td>Extension</td>

--- a/docs/user-deletion-workflow.html
+++ b/docs/user-deletion-workflow.html
@@ -155,10 +155,12 @@
 
                 subgraph Backend["☁️ Backend Services"]
                 DeleteFn["Cloud Function: deleteSelf"]
+                Tombstone["Firestore deletion tombstone"]
                 Auth["Firebase Auth"]
 
                 Service -->|Call| DeleteFn
-                DeleteFn -->|Admin SDK| Auth
+                DeleteFn -->|"1. Write fail-closed marker"| Tombstone
+                Tombstone -->|"2. Marker stored"| Auth
                 end
 
                 subgraph Triggers["⚡ Parallel Cleanup Triggers"]
@@ -194,6 +196,9 @@
                 style CustomCleanup fill:#161b22,stroke:#d29922,stroke-width:2px,stroke-dasharray: 5 5
                 style ExtensionCleanup fill:#161b22,stroke:#238636,stroke-width:2px,stroke-dasharray: 5 5
             </div>
+            <p><code>deleteSelf</code> deletes the Firebase Auth user only after the deletion tombstone is stored. If
+                that write fails, deletion aborts so guarded background writers cannot race recursive cleanup without a
+                deletion signal.</p>
         </div>
 
         <div class="card">

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1398,7 +1398,7 @@
       "density": "SPARSE_ALL"
     },
     {
-      "collectionGroup": "healthRecords",
+      "collectionGroup": "healthSourceRecords",
       "queryScope": "COLLECTION",
       "fields": [
         {
@@ -1417,7 +1417,7 @@
       "density": "SPARSE_ALL"
     },
     {
-      "collectionGroup": "healthRecords",
+      "collectionGroup": "healthSourceRecords",
       "queryScope": "COLLECTION",
       "fields": [
         {
@@ -2165,13 +2165,13 @@
       "indexes": []
     },
     {
-      "collectionGroup": "healthRecords",
+      "collectionGroup": "healthSourceRecords",
       "fieldPath": "*",
       "ttl": false,
       "indexes": []
     },
     {
-      "collectionGroup": "healthRecords",
+      "collectionGroup": "healthSourceRecords",
       "fieldPath": "calendarDate",
       "ttl": false,
       "indexes": [

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -2166,37 +2166,49 @@
     },
     {
       "collectionGroup": "healthRecords",
-      "fieldPath": "metrics",
+      "fieldPath": "*",
       "ttl": false,
       "indexes": []
     },
     {
       "collectionGroup": "healthRecords",
-      "fieldPath": "sampleChunkIds",
+      "fieldPath": "calendarDate",
+      "ttl": false,
+      "indexes": [
+        {
+          "order": "ASCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "order": "DESCENDING",
+          "queryScope": "COLLECTION"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "healthSampleChunks",
+      "fieldPath": "*",
       "ttl": false,
       "indexes": []
     },
     {
       "collectionGroup": "healthSampleChunks",
-      "fieldPath": "offsetMs",
+      "fieldPath": "calendarDate",
       "ttl": false,
-      "indexes": []
+      "indexes": [
+        {
+          "order": "ASCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "order": "DESCENDING",
+          "queryScope": "COLLECTION"
+        }
+      ]
     },
     {
-      "collectionGroup": "healthSampleChunks",
-      "fieldPath": "nativeValues",
-      "ttl": false,
-      "indexes": []
-    },
-    {
-      "collectionGroup": "healthSampleChunks",
-      "fieldPath": "canonicalValues",
-      "ttl": false,
-      "indexes": []
-    },
-    {
-      "collectionGroup": "healthSampleChunks",
-      "fieldPath": "qualityCodes",
+      "collectionGroup": "healthSyncState",
+      "fieldPath": "*",
       "ttl": false,
       "indexes": []
     }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1396,6 +1396,82 @@
         }
       ],
       "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "healthRecords",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "source.provider",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "calendarDate",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "healthRecords",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "metricIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "calendarDate",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "healthSampleChunks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "provider",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "calendarDate",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "healthSampleChunks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "metricId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "calendarDate",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
     }
   ],
   "fieldOverrides": [
@@ -2086,6 +2162,42 @@
       "collectionGroup": "wahooAPIWorkoutQueue",
       "fieldPath": "expireAt",
       "ttl": true,
+      "indexes": []
+    },
+    {
+      "collectionGroup": "healthRecords",
+      "fieldPath": "metrics",
+      "ttl": false,
+      "indexes": []
+    },
+    {
+      "collectionGroup": "healthRecords",
+      "fieldPath": "sampleChunkIds",
+      "ttl": false,
+      "indexes": []
+    },
+    {
+      "collectionGroup": "healthSampleChunks",
+      "fieldPath": "offsetMs",
+      "ttl": false,
+      "indexes": []
+    },
+    {
+      "collectionGroup": "healthSampleChunks",
+      "fieldPath": "nativeValues",
+      "ttl": false,
+      "indexes": []
+    },
+    {
+      "collectionGroup": "healthSampleChunks",
+      "fieldPath": "canonicalValues",
+      "ttl": false,
+      "indexes": []
+    },
+    {
+      "collectionGroup": "healthSampleChunks",
+      "fieldPath": "qualityCodes",
+      "ttl": false,
       "indexes": []
     }
   ]

--- a/firestore.rules
+++ b/firestore.rules
@@ -332,7 +332,7 @@ service cloud.firestore {
 
         // Unified health source records are private owner-readable, server-written data.
         // List reads must carry the public page limit plus one look-ahead document.
-        match /healthRecords/{recordID} {
+        match /healthSourceRecords/{sourceRecordID} {
           allow get: if isOwner();
           allow list: if isOwner()
             && request.query.limit != null

--- a/firestore.rules
+++ b/firestore.rules
@@ -330,6 +330,34 @@ service cloud.firestore {
           allow write: if false;
         }
 
+        // Unified health source records are private owner-readable, server-written data.
+        // List reads must carry the public page limit plus one look-ahead document.
+        match /healthRecords/{recordID} {
+          allow get: if isOwner();
+          allow list: if isOwner()
+            && request.query.limit != null
+            && request.query.limit <= 1001;
+          allow write: if false;
+        }
+
+        // Sample chunks are permanent leaf documents. Nested documents are not
+        // matched, preserving the writer's document-only stale-chunk delete invariant.
+        match /healthSampleChunks/{chunkID} {
+          allow get: if isOwner();
+          allow list: if isOwner()
+            && request.query.limit != null
+            && request.query.limit <= 501;
+          allow write: if false;
+        }
+
+        match /healthSyncState/{providerID} {
+          allow get: if isOwner();
+          allow list: if isOwner()
+            && request.query.limit != null
+            && request.query.limit <= 6;
+          allow write: if false;
+        }
+
         // MCP connection summaries and all credential state are server-owned.
         // The app uses authenticated, App-Check-protected callables to list
         // and revoke connections without exposing token material.

--- a/firestore.rules
+++ b/firestore.rules
@@ -336,7 +336,7 @@ service cloud.firestore {
           allow get: if isOwner();
           allow list: if isOwner()
             && request.query.limit != null
-            && request.query.limit <= 1001;
+            && request.query.limit <= 33;
           allow write: if false;
         }
 
@@ -346,7 +346,7 @@ service cloud.firestore {
           allow get: if isOwner();
           allow list: if isOwner()
             && request.query.limit != null
-            && request.query.limit <= 501;
+            && request.query.limit <= 9;
           allow write: if false;
         }
 

--- a/functions/src/firestore-indexes.spec.ts
+++ b/functions/src/firestore-indexes.spec.ts
@@ -553,4 +553,70 @@ describe('firestore indexes', () => {
             density: 'SPARSE_ALL',
         });
     });
+
+    it('keeps unified health reads deployable without indexing sample payload arrays or enabling TTL', () => {
+        const config = loadFirestoreIndexes();
+
+        expect(config.indexes).toEqual(expect.arrayContaining([
+            {
+                collectionGroup: 'healthRecords',
+                queryScope: 'COLLECTION',
+                fields: [
+                    { fieldPath: 'source.provider', order: 'ASCENDING' },
+                    { fieldPath: 'calendarDate', order: 'ASCENDING' },
+                    { fieldPath: '__name__', order: 'ASCENDING' },
+                ],
+                density: 'SPARSE_ALL',
+            },
+            {
+                collectionGroup: 'healthRecords',
+                queryScope: 'COLLECTION',
+                fields: [
+                    { fieldPath: 'metricIds', arrayConfig: 'CONTAINS' },
+                    { fieldPath: 'calendarDate', order: 'ASCENDING' },
+                    { fieldPath: '__name__', order: 'ASCENDING' },
+                ],
+                density: 'SPARSE_ALL',
+            },
+            {
+                collectionGroup: 'healthSampleChunks',
+                queryScope: 'COLLECTION',
+                fields: [
+                    { fieldPath: 'provider', order: 'ASCENDING' },
+                    { fieldPath: 'calendarDate', order: 'ASCENDING' },
+                    { fieldPath: '__name__', order: 'ASCENDING' },
+                ],
+                density: 'SPARSE_ALL',
+            },
+            {
+                collectionGroup: 'healthSampleChunks',
+                queryScope: 'COLLECTION',
+                fields: [
+                    { fieldPath: 'metricId', order: 'ASCENDING' },
+                    { fieldPath: 'calendarDate', order: 'ASCENDING' },
+                    { fieldPath: '__name__', order: 'ASCENDING' },
+                ],
+                density: 'SPARSE_ALL',
+            },
+        ]));
+        for (const [collectionGroup, fieldPath] of [
+            ['healthRecords', 'metrics'],
+            ['healthRecords', 'sampleChunkIds'],
+            ['healthSampleChunks', 'offsetMs'],
+            ['healthSampleChunks', 'nativeValues'],
+            ['healthSampleChunks', 'canonicalValues'],
+            ['healthSampleChunks', 'qualityCodes'],
+        ]) {
+            expect(config.fieldOverrides).toContainEqual({
+                collectionGroup,
+                fieldPath,
+                ttl: false,
+                indexes: [],
+            });
+        }
+        expect(config.fieldOverrides.some(override => (
+            (override.collectionGroup === 'healthRecords' || override.collectionGroup === 'healthSampleChunks')
+            && override.ttl === true
+        ))).toBe(false);
+    });
 });

--- a/functions/src/firestore-indexes.spec.ts
+++ b/functions/src/firestore-indexes.spec.ts
@@ -559,7 +559,7 @@ describe('firestore indexes', () => {
 
         expect(config.indexes).toEqual(expect.arrayContaining([
             {
-                collectionGroup: 'healthRecords',
+                collectionGroup: 'healthSourceRecords',
                 queryScope: 'COLLECTION',
                 fields: [
                     { fieldPath: 'source.provider', order: 'ASCENDING' },
@@ -569,7 +569,7 @@ describe('firestore indexes', () => {
                 density: 'SPARSE_ALL',
             },
             {
-                collectionGroup: 'healthRecords',
+                collectionGroup: 'healthSourceRecords',
                 queryScope: 'COLLECTION',
                 fields: [
                     { fieldPath: 'metricIds', arrayConfig: 'CONTAINS' },
@@ -601,13 +601,13 @@ describe('firestore indexes', () => {
         ]));
         expect(config.fieldOverrides).toEqual(expect.arrayContaining([
             {
-                collectionGroup: 'healthRecords',
+                collectionGroup: 'healthSourceRecords',
                 fieldPath: '*',
                 ttl: false,
                 indexes: [],
             },
             {
-                collectionGroup: 'healthRecords',
+                collectionGroup: 'healthSourceRecords',
                 fieldPath: 'calendarDate',
                 ttl: false,
                 indexes: [
@@ -638,7 +638,7 @@ describe('firestore indexes', () => {
             },
         ]));
         expect(config.fieldOverrides.some(override => (
-            (override.collectionGroup === 'healthRecords'
+            (override.collectionGroup === 'healthSourceRecords'
                 || override.collectionGroup === 'healthSampleChunks'
                 || override.collectionGroup === 'healthSyncState')
             && override.ttl === true

--- a/functions/src/firestore-indexes.spec.ts
+++ b/functions/src/firestore-indexes.spec.ts
@@ -554,7 +554,7 @@ describe('firestore indexes', () => {
         });
     });
 
-    it('keeps unified health reads deployable without indexing sample payload arrays or enabling TTL', () => {
+    it('keeps only the automatic health indexes needed for bounded date reads and disables TTL', () => {
         const config = loadFirestoreIndexes();
 
         expect(config.indexes).toEqual(expect.arrayContaining([
@@ -599,23 +599,48 @@ describe('firestore indexes', () => {
                 density: 'SPARSE_ALL',
             },
         ]));
-        for (const [collectionGroup, fieldPath] of [
-            ['healthRecords', 'metrics'],
-            ['healthRecords', 'sampleChunkIds'],
-            ['healthSampleChunks', 'offsetMs'],
-            ['healthSampleChunks', 'nativeValues'],
-            ['healthSampleChunks', 'canonicalValues'],
-            ['healthSampleChunks', 'qualityCodes'],
-        ]) {
-            expect(config.fieldOverrides).toContainEqual({
-                collectionGroup,
-                fieldPath,
+        expect(config.fieldOverrides).toEqual(expect.arrayContaining([
+            {
+                collectionGroup: 'healthRecords',
+                fieldPath: '*',
                 ttl: false,
                 indexes: [],
-            });
-        }
+            },
+            {
+                collectionGroup: 'healthRecords',
+                fieldPath: 'calendarDate',
+                ttl: false,
+                indexes: [
+                    { order: 'ASCENDING', queryScope: 'COLLECTION' },
+                    { order: 'DESCENDING', queryScope: 'COLLECTION' },
+                ],
+            },
+            {
+                collectionGroup: 'healthSampleChunks',
+                fieldPath: '*',
+                ttl: false,
+                indexes: [],
+            },
+            {
+                collectionGroup: 'healthSampleChunks',
+                fieldPath: 'calendarDate',
+                ttl: false,
+                indexes: [
+                    { order: 'ASCENDING', queryScope: 'COLLECTION' },
+                    { order: 'DESCENDING', queryScope: 'COLLECTION' },
+                ],
+            },
+            {
+                collectionGroup: 'healthSyncState',
+                fieldPath: '*',
+                ttl: false,
+                indexes: [],
+            },
+        ]));
         expect(config.fieldOverrides.some(override => (
-            (override.collectionGroup === 'healthRecords' || override.collectionGroup === 'healthSampleChunks')
+            (override.collectionGroup === 'healthRecords'
+                || override.collectionGroup === 'healthSampleChunks'
+                || override.collectionGroup === 'healthSyncState')
             && override.ttl === true
         ))).toBe(false);
     });

--- a/functions/src/health/callable.spec.ts
+++ b/functions/src/health/callable.spec.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { HealthQueryValidationError } from '../../../shared/health-query';
+
+const hoisted = vi.hoisted(() => ({
+    enforceAppCheck: vi.fn(),
+    readHealthRange: vi.fn(),
+    loggerError: vi.fn(),
+}));
+
+vi.mock('firebase-functions/v2/https', () => ({
+    HttpsError: class MockHttpsError extends Error {
+        constructor(public readonly code: string, message: string) {
+            super(message);
+        }
+    },
+    onCall: (_options: unknown, handler: unknown) => handler,
+}));
+vi.mock('firebase-functions/logger', () => ({
+    error: hoisted.loggerError,
+}));
+vi.mock('../../../shared/functions-manifest', () => ({
+    FUNCTIONS_MANIFEST: { queryHealthRange: { region: 'europe-west2' } },
+}));
+vi.mock('../utils', () => ({ enforceAppCheck: hoisted.enforceAppCheck }));
+vi.mock('./query', () => ({ readHealthRange: hoisted.readHealthRange }));
+
+import { queryHealthRange } from './callable';
+
+describe('queryHealthRange callable', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        hoisted.readHealthRange.mockResolvedValue({ observations: [] });
+    });
+
+    it('requires authentication before App Check or Firestore access', async () => {
+        await expect((queryHealthRange as never as (request: unknown) => Promise<unknown>)({ data: {} }))
+            .rejects.toMatchObject({ code: 'unauthenticated' });
+        expect(hoisted.enforceAppCheck).not.toHaveBeenCalled();
+        expect(hoisted.readHealthRange).not.toHaveBeenCalled();
+    });
+
+    it('enforces App Check before querying health data', async () => {
+        hoisted.enforceAppCheck.mockImplementationOnce(() => {
+            throw new Error('App Check verification failed.');
+        });
+        await expect((queryHealthRange as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'user-1' },
+            data: {},
+        })).rejects.toThrow('App Check verification failed');
+        expect(hoisted.readHealthRange).not.toHaveBeenCalled();
+    });
+
+    it('derives ownership exclusively from the authenticated UID', async () => {
+        const data = { startDate: '2026-01-01', endDate: '2026-01-02', userID: 'attacker-user' };
+        await (queryHealthRange as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'owner-user' },
+            app: { appId: 'app-check' },
+            data,
+        });
+
+        expect(hoisted.readHealthRange).toHaveBeenCalledWith('owner-user', data);
+    });
+
+    it('maps bounded-query validation failures to invalid-argument', async () => {
+        hoisted.readHealthRange.mockRejectedValueOnce(new HealthQueryValidationError('range is too large'));
+        await expect((queryHealthRange as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'user-1' }, app: {}, data: {},
+        })).rejects.toMatchObject({ code: 'invalid-argument', message: 'range is too large' });
+        expect(hoisted.loggerError).not.toHaveBeenCalled();
+    });
+
+    it('does not expose unexpected storage errors', async () => {
+        hoisted.readHealthRange.mockRejectedValueOnce(new Error('sensitive Firestore detail'));
+        await expect((queryHealthRange as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'user-1' }, app: {}, data: {},
+        })).rejects.toMatchObject({ code: 'internal', message: 'Unable to query health data.' });
+        expect(hoisted.loggerError).toHaveBeenCalledWith(
+            '[HealthQuery] Bounded health query failed.',
+            { errorName: 'Error' },
+        );
+    });
+});

--- a/functions/src/health/callable.ts
+++ b/functions/src/health/callable.ts
@@ -1,0 +1,32 @@
+import { HttpsError, onCall } from 'firebase-functions/v2/https';
+import * as logger from 'firebase-functions/logger';
+import { FUNCTIONS_MANIFEST } from '../../../shared/functions-manifest';
+import { HealthRangeResult } from '../../../shared/health';
+import { HealthQueryValidationError } from '../../../shared/health-query';
+import { enforceAppCheck } from '../utils';
+import { readHealthRange } from './query';
+
+export const queryHealthRange = onCall({
+    region: FUNCTIONS_MANIFEST.queryHealthRange.region,
+    cors: true,
+    timeoutSeconds: 30,
+    memory: '256MiB',
+    maxInstances: 100,
+}, async (request): Promise<HealthRangeResult> => {
+    if (!request.auth?.uid) {
+        throw new HttpsError('unauthenticated', 'The function must be called while authenticated.');
+    }
+    enforceAppCheck(request);
+
+    try {
+        return await readHealthRange(request.auth.uid, request.data);
+    } catch (error) {
+        if (error instanceof HealthQueryValidationError) {
+            throw new HttpsError('invalid-argument', error.message);
+        }
+        logger.error('[HealthQuery] Bounded health query failed.', {
+            errorName: error instanceof Error ? error.name : 'UnknownError',
+        });
+        throw new HttpsError('internal', 'Unable to query health data.');
+    }
+});

--- a/functions/src/health/lifecycle.spec.ts
+++ b/functions/src/health/lifecycle.spec.ts
@@ -11,7 +11,7 @@ describe('unified health account lifecycle', () => {
 
         expect(extensionEnvironment).toMatch(/^FIRESTORE_DELETE_MODE=recursive$/m);
         expect(extensionEnvironment).toMatch(/^FIRESTORE_PATHS=users\/\{UID\},customers\/\{UID\}$/m);
-        expect(extensionEnvironment).not.toContain('healthRecords');
+        expect(extensionEnvironment).not.toContain('healthSourceRecords');
         expect(extensionEnvironment).not.toContain('healthSampleChunks');
         expect(extensionEnvironment).not.toContain('healthSyncState');
     });

--- a/functions/src/health/lifecycle.spec.ts
+++ b/functions/src/health/lifecycle.spec.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('unified health account lifecycle', () => {
+    it('keeps all health collections beneath the recursively deleted user root', () => {
+        const extensionEnvironment = readFileSync(
+            resolve(__dirname, '../../../extensions/delete-user-data.env'),
+            'utf8',
+        );
+
+        expect(extensionEnvironment).toMatch(/^FIRESTORE_DELETE_MODE=recursive$/m);
+        expect(extensionEnvironment).toMatch(/^FIRESTORE_PATHS=users\/\{UID\},customers\/\{UID\}$/m);
+        expect(extensionEnvironment).not.toContain('healthRecords');
+        expect(extensionEnvironment).not.toContain('healthSampleChunks');
+        expect(extensionEnvironment).not.toContain('healthSyncState');
+    });
+});

--- a/functions/src/health/query.spec.ts
+++ b/functions/src/health/query.spec.ts
@@ -56,6 +56,9 @@ function fakeDatabase(recordDocs: HealthSourceRecord[]) {
                 collection: vi.fn((collectionId: string) => makeQuery(collectionId)),
             })),
         })),
+        runTransaction: vi.fn(async (runner: (transaction: { get: (query: { get: () => unknown }) => unknown }) => unknown) => runner({
+            get: (query: { get: () => unknown }) => query.get(),
+        })),
     };
     return { db, operations };
 }
@@ -118,6 +121,7 @@ describe('server health range reader', () => {
             { method: 'limit', args: [11] },
         ]));
         expect(fake.operations.has('healthSampleChunks')).toBe(false);
+        expect(fake.db.runTransaction).toHaveBeenCalledWith(expect.any(Function), { readOnly: true });
     });
 
     it('applies the stable date/id cursor and separately bounds sample chunks', async () => {
@@ -128,7 +132,7 @@ describe('server health range reader', () => {
             includeSamples: true,
             recordCursor: { calendarDate: '2026-01-02', id: 'record-2' },
             chunkCursor: { calendarDate: '2026-01-03', id: 'chunk-3' },
-            chunkLimit: 20,
+            chunkLimit: 8,
         }, { db: fake.db as never });
 
         expect(fake.operations.get('healthRecords')).toEqual(expect.arrayContaining([
@@ -136,7 +140,7 @@ describe('server health range reader', () => {
         ]));
         expect(fake.operations.get('healthSampleChunks')).toEqual(expect.arrayContaining([
             { method: 'startAfter', args: ['2026-01-03', 'chunk-3'] },
-            { method: 'limit', args: [21] },
+            { method: 'limit', args: [9] },
         ]));
     });
 });

--- a/functions/src/health/query.spec.ts
+++ b/functions/src/health/query.spec.ts
@@ -6,7 +6,7 @@ import {
     HEALTH_PROVIDERS,
     HEALTH_QUALITY_STATUSES,
     HEALTH_RECORDING_METHODS,
-    HEALTH_RECORD_KINDS,
+    HEALTH_SOURCE_RECORD_KINDS,
     HEALTH_SCHEMA_VERSION,
     HEALTH_UNITS,
     HEALTH_VALUE_ORIGINS,
@@ -20,7 +20,7 @@ interface Operation {
     args: unknown[];
 }
 
-function fakeDatabase(recordDocs: HealthSourceRecord[]) {
+function fakeDatabase(sourceRecordDocs: HealthSourceRecord[]) {
     const operations = new Map<string, Operation[]>();
     const makeQuery = (collectionId: string) => {
         const queryOperations: Operation[] = [];
@@ -43,8 +43,11 @@ function fakeDatabase(recordDocs: HealthSourceRecord[]) {
                 return query;
             }),
             get: vi.fn(async () => ({
-                docs: collectionId === 'healthRecords'
-                    ? recordDocs.map(record => ({ id: record.id, data: () => record }))
+                docs: collectionId === 'healthSourceRecords'
+                    ? sourceRecordDocs.map(sourceRecord => ({
+                        id: sourceRecord.id,
+                        data: () => sourceRecord,
+                    }))
                     : [],
             })),
         };
@@ -63,13 +66,13 @@ function fakeDatabase(recordDocs: HealthSourceRecord[]) {
     return { db, operations };
 }
 
-function record(): HealthSourceRecord {
+function sourceRecord(): HealthSourceRecord {
     const startTimeMs = Date.parse('2026-01-01T00:00:00.000Z');
     return {
         schemaVersion: HEALTH_SCHEMA_VERSION,
         id: 'record-1',
         userID: 'user-1',
-        kind: HEALTH_RECORD_KINDS.DailySummary,
+        kind: HEALTH_SOURCE_RECORD_KINDS.DailySummary,
         source: {
             provider: HEALTH_PROVIDERS.GarminAPI,
             accountKey: 'opaque-account',
@@ -103,18 +106,18 @@ function record(): HealthSourceRecord {
 }
 
 describe('server health range reader', () => {
-    it('executes the shared bounded plan and projects stored records', async () => {
-        const fake = fakeDatabase([record()]);
+    it('executes the shared bounded plan and projects stored source records', async () => {
+        const fake = fakeDatabase([sourceRecord()]);
         const result = await readHealthRange('user-1', {
             startDate: '2026-01-01',
             endDate: '2026-01-07',
             providers: [HEALTH_PROVIDERS.GarminAPI],
             metricIds: [HEALTH_METRIC_IDS.Steps],
-            recordLimit: 10,
+            sourceRecordLimit: 10,
         }, { db: fake.db as never, nowMs: Date.parse('2026-01-02T00:00:00.000Z') });
 
         expect(result.observations).toHaveLength(1);
-        expect(fake.operations.get('healthRecords')).toEqual(expect.arrayContaining([
+        expect(fake.operations.get('healthSourceRecords')).toEqual(expect.arrayContaining([
             { method: 'where', args: ['calendarDate', '>=', '2026-01-01'] },
             { method: 'where', args: ['calendarDate', '<=', '2026-01-07'] },
             { method: 'where', args: ['source.provider', '==', HEALTH_PROVIDERS.GarminAPI] },
@@ -130,12 +133,12 @@ describe('server health range reader', () => {
             startDate: '2026-01-01',
             endDate: '2026-01-07',
             includeSamples: true,
-            recordCursor: { calendarDate: '2026-01-02', id: 'record-2' },
+            sourceRecordCursor: { calendarDate: '2026-01-02', id: 'record-2' },
             chunkCursor: { calendarDate: '2026-01-03', id: 'chunk-3' },
             chunkLimit: 8,
         }, { db: fake.db as never });
 
-        expect(fake.operations.get('healthRecords')).toEqual(expect.arrayContaining([
+        expect(fake.operations.get('healthSourceRecords')).toEqual(expect.arrayContaining([
             { method: 'startAfter', args: ['2026-01-02', 'record-2'] },
         ]));
         expect(fake.operations.get('healthSampleChunks')).toEqual(expect.arrayContaining([

--- a/functions/src/health/query.spec.ts
+++ b/functions/src/health/query.spec.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    HEALTH_COVERAGE_STATUSES,
+    HEALTH_METRIC_IDS,
+    HEALTH_NORMALIZATION_STATUSES,
+    HEALTH_PROVIDERS,
+    HEALTH_QUALITY_STATUSES,
+    HEALTH_RECORDING_METHODS,
+    HEALTH_RECORD_KINDS,
+    HEALTH_SCHEMA_VERSION,
+    HEALTH_UNITS,
+    HEALTH_VALUE_ORIGINS,
+    HEALTH_VALUE_TYPES,
+    HealthSourceRecord,
+} from '../../../shared/health';
+import { readHealthRange } from './query';
+
+interface Operation {
+    method: string;
+    args: unknown[];
+}
+
+function fakeDatabase(recordDocs: HealthSourceRecord[]) {
+    const operations = new Map<string, Operation[]>();
+    const makeQuery = (collectionId: string) => {
+        const queryOperations: Operation[] = [];
+        operations.set(collectionId, queryOperations);
+        const query = {
+            where: vi.fn((...args: unknown[]) => {
+                queryOperations.push({ method: 'where', args });
+                return query;
+            }),
+            orderBy: vi.fn((...args: unknown[]) => {
+                queryOperations.push({ method: 'orderBy', args });
+                return query;
+            }),
+            startAfter: vi.fn((...args: unknown[]) => {
+                queryOperations.push({ method: 'startAfter', args });
+                return query;
+            }),
+            limit: vi.fn((...args: unknown[]) => {
+                queryOperations.push({ method: 'limit', args });
+                return query;
+            }),
+            get: vi.fn(async () => ({
+                docs: collectionId === 'healthRecords'
+                    ? recordDocs.map(record => ({ id: record.id, data: () => record }))
+                    : [],
+            })),
+        };
+        return query;
+    };
+    const db = {
+        collection: vi.fn(() => ({
+            doc: vi.fn(() => ({
+                collection: vi.fn((collectionId: string) => makeQuery(collectionId)),
+            })),
+        })),
+    };
+    return { db, operations };
+}
+
+function record(): HealthSourceRecord {
+    const startTimeMs = Date.parse('2026-01-01T00:00:00.000Z');
+    return {
+        schemaVersion: HEALTH_SCHEMA_VERSION,
+        id: 'record-1',
+        userID: 'user-1',
+        kind: HEALTH_RECORD_KINDS.DailySummary,
+        source: {
+            provider: HEALTH_PROVIDERS.GarminAPI,
+            accountKey: 'opaque-account',
+            sourceRecordType: 'daily',
+            sourceRecordKey: '2026-01-01',
+            revision: { order: 1, token: 'one', digest: 'digest' },
+            receivedAtMs: startTimeMs + 1000,
+        },
+        calendarDate: '2026-01-01',
+        startTimeMs,
+        endTimeMs: startTimeMs + 86_399_999,
+        metrics: [{
+            kind: 'value',
+            metricId: HEALTH_METRIC_IDS.Steps,
+            valueType: HEALTH_VALUE_TYPES.Number,
+            aggregation: 'total',
+            semanticVariant: 'provider_daily_summary',
+            origin: HEALTH_VALUE_ORIGINS.ProviderSummary,
+            recordingMethod: HEALTH_RECORDING_METHODS.ProviderCalculated,
+            quality: { status: HEALTH_QUALITY_STATUSES.Valid },
+            normalizationStatus: HEALTH_NORMALIZATION_STATUSES.Canonical,
+            native: { metric: 'steps', value: 100 },
+            canonical: { value: 100, unit: HEALTH_UNITS.Count },
+        }],
+        metricIds: [HEALTH_METRIC_IDS.Steps],
+        coverage: { status: HEALTH_COVERAGE_STATUSES.Complete },
+        sampleChunkIds: [],
+        createdAtMs: startTimeMs,
+        updatedAtMs: startTimeMs,
+    };
+}
+
+describe('server health range reader', () => {
+    it('executes the shared bounded plan and projects stored records', async () => {
+        const fake = fakeDatabase([record()]);
+        const result = await readHealthRange('user-1', {
+            startDate: '2026-01-01',
+            endDate: '2026-01-07',
+            providers: [HEALTH_PROVIDERS.GarminAPI],
+            metricIds: [HEALTH_METRIC_IDS.Steps],
+            recordLimit: 10,
+        }, { db: fake.db as never, nowMs: Date.parse('2026-01-02T00:00:00.000Z') });
+
+        expect(result.observations).toHaveLength(1);
+        expect(fake.operations.get('healthRecords')).toEqual(expect.arrayContaining([
+            { method: 'where', args: ['calendarDate', '>=', '2026-01-01'] },
+            { method: 'where', args: ['calendarDate', '<=', '2026-01-07'] },
+            { method: 'where', args: ['source.provider', '==', HEALTH_PROVIDERS.GarminAPI] },
+            { method: 'limit', args: [11] },
+        ]));
+        expect(fake.operations.has('healthSampleChunks')).toBe(false);
+    });
+
+    it('applies the stable date/id cursor and separately bounds sample chunks', async () => {
+        const fake = fakeDatabase([]);
+        await readHealthRange('user-1', {
+            startDate: '2026-01-01',
+            endDate: '2026-01-07',
+            includeSamples: true,
+            recordCursor: { calendarDate: '2026-01-02', id: 'record-2' },
+            chunkCursor: { calendarDate: '2026-01-03', id: 'chunk-3' },
+            chunkLimit: 20,
+        }, { db: fake.db as never });
+
+        expect(fake.operations.get('healthRecords')).toEqual(expect.arrayContaining([
+            { method: 'startAfter', args: ['2026-01-02', 'record-2'] },
+        ]));
+        expect(fake.operations.get('healthSampleChunks')).toEqual(expect.arrayContaining([
+            { method: 'startAfter', args: ['2026-01-03', 'chunk-3'] },
+            { method: 'limit', args: [21] },
+        ]));
+    });
+});

--- a/functions/src/health/query.ts
+++ b/functions/src/health/query.ts
@@ -51,15 +51,18 @@ export async function readHealthRange(
 ): Promise<HealthRangeResult> {
     const db = dependencies.db || admin.firestore();
     const plans = planHealthFirestoreQueries(queryValue);
-    const recordQuery = applyQueryPlan(userCollection(db, userID, plans.records.collectionId), plans.records);
+    const sourceRecordQuery = applyQueryPlan(
+        userCollection(db, userID, plans.sourceRecords.collectionId),
+        plans.sourceRecords,
+    );
     const chunkQuery = plans.chunks
         ? applyQueryPlan(userCollection(db, userID, plans.chunks.collectionId), plans.chunks)
         : null;
-    const [recordSnapshot, chunkSnapshot] = await db.runTransaction(async transaction => Promise.all([
-        transaction.get(recordQuery),
+    const [sourceRecordSnapshot, chunkSnapshot] = await db.runTransaction(async transaction => Promise.all([
+        transaction.get(sourceRecordQuery),
         chunkQuery ? transaction.get(chunkQuery) : Promise.resolve(null),
     ]), { readOnly: true });
-    const records = recordSnapshot.docs.map(snapshot => ({
+    const sourceRecords = sourceRecordSnapshot.docs.map(snapshot => ({
         ...snapshot.data(),
         id: snapshot.id,
     }) as HealthSourceRecord);
@@ -67,5 +70,5 @@ export async function readHealthRange(
         ...snapshot.data(),
         id: snapshot.id,
     }) as HealthSampleChunk);
-    return projectHealthRange(records, chunks, plans.query, dependencies.nowMs);
+    return projectHealthRange(sourceRecords, chunks, plans.query, dependencies.nowMs);
 }

--- a/functions/src/health/query.ts
+++ b/functions/src/health/query.ts
@@ -1,0 +1,71 @@
+import * as admin from 'firebase-admin';
+import { FieldPath } from 'firebase-admin/firestore';
+import {
+    HealthRangeQuery,
+    HealthRangeResult,
+    HealthSampleChunk,
+    HealthSourceRecord,
+} from '../../../shared/health';
+import {
+    HealthFirestoreQueryPlan,
+    planHealthFirestoreQueries,
+} from '../../../shared/health-firestore-query';
+import { projectHealthRange } from '../../../shared/health-query';
+
+export interface HealthQueryDependencies {
+    db?: admin.firestore.Firestore;
+    nowMs?: number;
+}
+
+function applyQueryPlan(
+    collection: admin.firestore.CollectionReference,
+    plan: HealthFirestoreQueryPlan,
+): admin.firestore.Query {
+    let query: admin.firestore.Query = collection
+        .where('calendarDate', '>=', plan.startDate)
+        .where('calendarDate', '<=', plan.endDate);
+    if (plan.filter) {
+        query = query.where(plan.filter.field, plan.filter.operator, plan.filter.value);
+    }
+    query = query
+        .orderBy('calendarDate', 'asc')
+        .orderBy(FieldPath.documentId(), 'asc');
+    if (plan.cursor) {
+        query = query.startAfter(plan.cursor.calendarDate, plan.cursor.id);
+    }
+    return query.limit(plan.fetchLimit);
+}
+
+function userCollection(
+    db: admin.firestore.Firestore,
+    userID: string,
+    collectionId: string,
+): admin.firestore.CollectionReference {
+    return db.collection('users').doc(userID).collection(collectionId);
+}
+
+export async function readHealthRange(
+    userID: string,
+    queryValue: HealthRangeQuery | unknown,
+    dependencies: HealthQueryDependencies = {},
+): Promise<HealthRangeResult> {
+    const db = dependencies.db || admin.firestore();
+    const plans = planHealthFirestoreQueries(queryValue);
+    const recordQuery = applyQueryPlan(userCollection(db, userID, plans.records.collectionId), plans.records);
+    const chunkQuery = plans.chunks
+        ? applyQueryPlan(userCollection(db, userID, plans.chunks.collectionId), plans.chunks)
+        : null;
+    const [recordSnapshot, chunkSnapshot] = await Promise.all([
+        recordQuery.get(),
+        chunkQuery?.get() || Promise.resolve(null),
+    ]);
+    const records = recordSnapshot.docs.map(snapshot => ({
+        ...snapshot.data(),
+        id: snapshot.id,
+    }) as HealthSourceRecord);
+    const chunks = (chunkSnapshot?.docs || []).map(snapshot => ({
+        ...snapshot.data(),
+        id: snapshot.id,
+    }) as HealthSampleChunk);
+    return projectHealthRange(records, chunks, plans.query, dependencies.nowMs);
+}

--- a/functions/src/health/query.ts
+++ b/functions/src/health/query.ts
@@ -55,10 +55,10 @@ export async function readHealthRange(
     const chunkQuery = plans.chunks
         ? applyQueryPlan(userCollection(db, userID, plans.chunks.collectionId), plans.chunks)
         : null;
-    const [recordSnapshot, chunkSnapshot] = await Promise.all([
-        recordQuery.get(),
-        chunkQuery?.get() || Promise.resolve(null),
-    ]);
+    const [recordSnapshot, chunkSnapshot] = await db.runTransaction(async transaction => Promise.all([
+        transaction.get(recordQuery),
+        chunkQuery ? transaction.get(chunkQuery) : Promise.resolve(null),
+    ]), { readOnly: true });
     const records = recordSnapshot.docs.map(snapshot => ({
         ...snapshot.data(),
         id: snapshot.id,

--- a/functions/src/health/validation.spec.ts
+++ b/functions/src/health/validation.spec.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+import {
+    HEALTH_COVERAGE_STATUSES,
+    HEALTH_METRIC_IDS,
+    HEALTH_NORMALIZATION_STATUSES,
+    HEALTH_PROVIDERS,
+    HEALTH_QUALITY_STATUSES,
+    HEALTH_RECORDING_METHODS,
+    HEALTH_RECORD_KINDS,
+    HEALTH_UNITS,
+    HEALTH_VALUE_ORIGINS,
+    HEALTH_VALUE_TYPES,
+} from '../../../shared/health';
+import { HealthWriteValidationError, validateHealthSourceRecordInput } from './validation';
+
+function validInput(): Record<string, unknown> {
+    return {
+        provider: HEALTH_PROVIDERS.GarminAPI,
+        providerAccountId: 'provider-account-1',
+        sourceRecordType: 'daily-summary',
+        sourceRecordKey: '2026-01-01',
+        revision: { order: 1, token: 'revision-1' },
+        receivedAtMs: Date.parse('2026-01-02T00:00:00.000Z'),
+        kind: HEALTH_RECORD_KINDS.DailySummary,
+        calendarDate: '2026-01-01',
+        startTimeMs: Date.parse('2026-01-01T00:00:00.000Z'),
+        endTimeMs: Date.parse('2026-01-01T23:59:59.999Z'),
+        timezoneOffsetSeconds: 0,
+        metrics: [{
+            kind: 'value',
+            metricId: HEALTH_METRIC_IDS.Steps,
+            valueType: HEALTH_VALUE_TYPES.Number,
+            aggregation: 'total',
+            semanticVariant: 'provider_daily_summary',
+            origin: HEALTH_VALUE_ORIGINS.ProviderSummary,
+            recordingMethod: HEALTH_RECORDING_METHODS.ProviderCalculated,
+            quality: { status: HEALTH_QUALITY_STATUSES.Valid },
+            normalizationStatus: HEALTH_NORMALIZATION_STATUSES.Canonical,
+            native: { metric: 'steps', value: 1234, unit: 'count' },
+            canonical: { value: 1234, unit: HEALTH_UNITS.Count },
+            goal: {
+                native: { metric: 'stepGoal', value: 10_000, unit: 'count' },
+                canonical: { value: 10_000, unit: HEALTH_UNITS.Count },
+            },
+        }],
+        coverage: { status: HEALTH_COVERAGE_STATUSES.Complete },
+        sampleSeries: [{
+            seriesKey: 'heart-rate',
+            metricId: HEALTH_METRIC_IDS.HeartRate,
+            valueType: HEALTH_VALUE_TYPES.Number,
+            aggregation: 'sample',
+            semanticVariant: 'device_sample',
+            origin: HEALTH_VALUE_ORIGINS.Recorded,
+            recordingMethod: HEALTH_RECORDING_METHODS.Device,
+            normalizationStatus: HEALTH_NORMALIZATION_STATUSES.Canonical,
+            nativeMetric: 'heartRate',
+            nativeUnit: 'bpm',
+            canonicalUnit: HEALTH_UNITS.BeatsPerMinute,
+            offsetMs: [0, 60_000],
+            nativeValues: [60, 61],
+            canonicalValues: [60, 61],
+            qualityCodes: ['valid', 'valid'],
+            coverage: { status: HEALTH_COVERAGE_STATUSES.Complete, sampleCount: 2 },
+        }],
+    };
+}
+
+describe('health write validation', () => {
+    it('returns a sanitized typed provider record', () => {
+        const result = validateHealthSourceRecordInput(validInput());
+
+        expect(result).toMatchObject({
+            provider: HEALTH_PROVIDERS.GarminAPI,
+            providerAccountId: 'provider-account-1',
+            revision: { order: 1, token: 'revision-1' },
+        });
+        expect(result.metrics[0]).toMatchObject({
+            metricId: HEALTH_METRIC_IDS.Steps,
+            canonical: { value: 1234, unit: HEALTH_UNITS.Count },
+            goal: { canonical: { value: 10_000, unit: HEALTH_UNITS.Count } },
+        });
+        expect(result.sampleSeries[0].offsetMs).toEqual([0, 60_000]);
+    });
+
+    it.each([
+        ['providerAccountId', '   ', 'providerAccountId'],
+        ['calendarDate', '2026-02-30', 'valid YYYY-MM-DD'],
+        ['timezoneOffsetSeconds', 70_000, 'outside the supported range'],
+    ])('rejects invalid %s', (field, value, message) => {
+        const input = validInput();
+        input[field] = value;
+        expect(() => validateHealthSourceRecordInput(input)).toThrowError(new RegExp(message));
+        expect(() => validateHealthSourceRecordInput(input)).toThrow(HealthWriteValidationError);
+    });
+
+    it('rejects a canonical unit that disagrees with the catalog', () => {
+        const input = validInput();
+        const metrics = input.metrics as Array<Record<string, unknown>>;
+        metrics[0].canonical = { value: 1234, unit: HEALTH_UNITS.Meter };
+
+        expect(() => validateHealthSourceRecordInput(input)).toThrow('canonical.unit must match the metric catalog');
+    });
+
+    it('rejects non-finite numbers before they can reach Firestore', () => {
+        const input = validInput();
+        const metrics = input.metrics as Array<Record<string, unknown>>;
+        metrics[0].native = { metric: 'steps', value: Number.NaN };
+
+        expect(() => validateHealthSourceRecordInput(input)).toThrow('native.value must be a finite number');
+    });
+
+    it('requires aligned, strictly increasing sample arrays', () => {
+        const input = validInput();
+        const sampleSeries = input.sampleSeries as Array<Record<string, unknown>>;
+        sampleSeries[0].offsetMs = [0, 60_000, 60_000];
+        sampleSeries[0].nativeValues = [60, 61, 62];
+        sampleSeries[0].canonicalValues = [60, 61, 62];
+        sampleSeries[0].qualityCodes = ['valid', 'valid', 'valid'];
+
+        expect(() => validateHealthSourceRecordInput(input)).toThrow('offsetMs must be strictly increasing');
+    });
+
+    it('never accepts canonical sample values without the catalog unit', () => {
+        const input = validInput();
+        const sampleSeries = input.sampleSeries as Array<Record<string, unknown>>;
+        delete sampleSeries[0].canonicalUnit;
+
+        expect(() => validateHealthSourceRecordInput(input)).toThrow('canonicalUnit must match the metric catalog');
+    });
+
+    it('rejects a goal whose canonical unit disagrees with the metric catalog', () => {
+        const input = validInput();
+        const metrics = input.metrics as Array<Record<string, unknown>>;
+        metrics[0].goal = { canonical: { value: 10_000, unit: HEALTH_UNITS.Meter } };
+
+        expect(() => validateHealthSourceRecordInput(input)).toThrow('goal.canonical.unit must match the metric catalog');
+    });
+
+    it('rejects reserved or duplicate normalized qualifier keys', () => {
+        const reserved = validInput();
+        const reservedMetric = (reserved.metrics as Array<Record<string, unknown>>)[0];
+        const reservedNative = reservedMetric.native as Record<string, unknown>;
+        reservedNative.qualifiers = JSON.parse('{"__proto__":"unsafe"}');
+        expect(() => validateHealthSourceRecordInput(reserved)).toThrow('reserved qualifier key');
+
+        const duplicate = validInput();
+        const duplicateMetric = (duplicate.metrics as Array<Record<string, unknown>>)[0];
+        const duplicateNative = duplicateMetric.native as Record<string, unknown>;
+        duplicateNative.qualifiers = { ' source ': 'one', source: 'two' };
+        expect(() => validateHealthSourceRecordInput(duplicate)).toThrow('duplicate normalized qualifier keys');
+    });
+
+    it('rejects an unbounded number of sample series before walking their points', () => {
+        const input = validInput();
+        const sample = (input.sampleSeries as unknown[])[0];
+        input.sampleSeries = Array.from({ length: 201 }, () => sample);
+
+        expect(() => validateHealthSourceRecordInput(input)).toThrow('cannot contain more than 200 series');
+    });
+
+    it('accepts sleep references only to the existing allowlisted sleep model', () => {
+        const input = validInput();
+        input.sampleSeries = [];
+        input.metrics = [{
+            kind: 'sleep_reference',
+            metricId: HEALTH_METRIC_IDS.HeartRate,
+            valueType: HEALTH_VALUE_TYPES.Number,
+            aggregation: 'average',
+            semanticVariant: 'sleep_session',
+            origin: HEALTH_VALUE_ORIGINS.ProviderSummary,
+            recordingMethod: HEALTH_RECORDING_METHODS.ProviderCalculated,
+            quality: { status: HEALTH_QUALITY_STATUSES.Valid },
+            reference: {
+                domain: 'sleep',
+                documentId: 'sleep-session-1',
+                field: 'vitals.averageHeartRateBpm',
+            },
+        }];
+
+        expect(validateHealthSourceRecordInput(input).metrics[0]).toMatchObject({
+            kind: 'sleep_reference',
+            reference: { documentId: 'sleep-session-1', field: 'vitals.averageHeartRateBpm' },
+        });
+
+        const metrics = input.metrics as Array<Record<string, unknown>>;
+        metrics[0].reference = { domain: 'sleep', documentId: 'sleep-session-1', field: 'providerFields.raw' };
+        expect(() => validateHealthSourceRecordInput(input)).toThrow('reference.field is not supported');
+
+        metrics[0].reference = { domain: 'sleep', documentId: 'sleep-session-1', field: 'durationSeconds' };
+        expect(() => validateHealthSourceRecordInput(input)).toThrow('metricId does not match the referenced sleep field');
+    });
+});

--- a/functions/src/health/validation.spec.ts
+++ b/functions/src/health/validation.spec.ts
@@ -11,7 +11,11 @@ import {
     HEALTH_VALUE_ORIGINS,
     HEALTH_VALUE_TYPES,
 } from '../../../shared/health';
-import { HealthWriteValidationError, validateHealthSourceRecordInput } from './validation';
+import {
+    HealthWriteSizeError,
+    HealthWriteValidationError,
+    validateHealthSourceRecordInput,
+} from './validation';
 
 function validInput(): Record<string, unknown> {
     return {
@@ -105,12 +109,12 @@ describe('health write validation', () => {
         expect(() => validateHealthSourceRecordInput(input)).toThrow('canonical.unit must match the metric catalog');
     });
 
-    it('does not allow the raw provider account ID to become persisted source-record metadata', () => {
+    it('preserves provider source identity for writer-side opaque hashing', () => {
         const input = validInput();
-        input.sourceRecordKey = input.providerAccountId;
+        input.sourceRecordKey = 'provider-account-1:daily:2026-01-01';
 
-        expect(() => validateHealthSourceRecordInput(input)).toThrow(
-            'sourceRecordKey must not expose the raw provider account ID',
+        expect(validateHealthSourceRecordInput(input).sourceRecordKey).toBe(
+            'provider-account-1:daily:2026-01-01',
         );
     });
 
@@ -219,6 +223,113 @@ describe('health write validation', () => {
         input.sampleSeries = Array.from({ length: 201 }, () => sample);
 
         expect(() => validateHealthSourceRecordInput(input)).toThrow('cannot contain more than 200 series');
+    });
+
+    it('stops cloning category samples when their cumulative JSON UTF-8 budget is exhausted', () => {
+        const input = validInput();
+        const pointCount = 3_000;
+        const offsets = Array.from({ length: pointCount }, (_, index) => index * 1_000);
+        const largeMultibyteValue = '💣'.repeat(256);
+        const firstSeries = {
+            ...(input.sampleSeries as Array<Record<string, unknown>>)[0],
+            seriesKey: 'stress-state-primary',
+            metricId: HEALTH_METRIC_IDS.StressState,
+            valueType: HEALTH_VALUE_TYPES.Category,
+            normalizationStatus: HEALTH_NORMALIZATION_STATUSES.NativeOnly,
+            nativeMetric: 'stressState',
+            nativeUnit: null,
+            canonicalUnit: null,
+            offsetMs: offsets,
+            nativeValues: Array(pointCount).fill(largeMultibyteValue),
+            canonicalValues: null,
+            qualityCodes: null,
+            coverage: { status: HEALTH_COVERAGE_STATUSES.Complete, sampleCount: pointCount },
+        };
+        const secondValues = new Proxy(Array(pointCount).fill(largeMultibyteValue), {
+            get(target, property, receiver) {
+                if (typeof property === 'string' && /^\d+$/.test(property) && Number(property) >= 2_000) {
+                    throw new Error('validator read beyond the cumulative UTF-8 budget');
+                }
+                return Reflect.get(target, property, receiver);
+            },
+        });
+        input.sampleSeries = [firstSeries, {
+            ...firstSeries,
+            seriesKey: 'stress-state-secondary',
+            nativeValues: secondValues,
+        }];
+
+        expect(() => validateHealthSourceRecordInput(input)).toThrow(HealthWriteSizeError);
+        expect(() => validateHealthSourceRecordInput(input)).toThrow('cumulative JSON UTF-8 budget');
+    });
+
+    it('counts multibyte quality codes in the same cumulative JSON UTF-8 budget', () => {
+        const input = validInput();
+        const pointCount = 12_500;
+        const sampleSeries = input.sampleSeries as Array<Record<string, unknown>>;
+        sampleSeries[0].offsetMs = Array.from({ length: pointCount }, (_, index) => index * 1_000);
+        sampleSeries[0].nativeValues = Array(pointCount).fill(60);
+        sampleSeries[0].canonicalValues = Array(pointCount).fill(60);
+        sampleSeries[0].qualityCodes = new Proxy(Array(pointCount).fill('✓'.repeat(128)), {
+            get(target, property, receiver) {
+                if (typeof property === 'string' && /^\d+$/.test(property) && Number(property) >= 11_500) {
+                    throw new Error('validator read beyond the cumulative UTF-8 budget');
+                }
+                return Reflect.get(target, property, receiver);
+            },
+        });
+        sampleSeries[0].coverage = { status: HEALTH_COVERAGE_STATUSES.Complete, sampleCount: pointCount };
+
+        expect(() => validateHealthSourceRecordInput(input)).toThrow(HealthWriteSizeError);
+        expect(() => validateHealthSourceRecordInput(input)).toThrow('cumulative JSON UTF-8 budget');
+    });
+
+    it('rejects an oversized raw string before trimming it into a small accepted value', () => {
+        const input = validInput();
+        const sampleSeries = input.sampleSeries as Array<Record<string, unknown>>;
+        sampleSeries[0].metricId = HEALTH_METRIC_IDS.StressState;
+        sampleSeries[0].valueType = HEALTH_VALUE_TYPES.Category;
+        sampleSeries[0].normalizationStatus = HEALTH_NORMALIZATION_STATUSES.NativeOnly;
+        sampleSeries[0].nativeMetric = 'stressState';
+        sampleSeries[0].nativeUnit = null;
+        sampleSeries[0].canonicalUnit = null;
+        sampleSeries[0].offsetMs = [0];
+        sampleSeries[0].nativeValues = [`${' '.repeat(5 * 1024 * 1024)}ok`];
+        sampleSeries[0].canonicalValues = null;
+        sampleSeries[0].qualityCodes = null;
+        sampleSeries[0].coverage = { status: HEALTH_COVERAGE_STATUSES.Complete, sampleCount: 1 };
+
+        expect(() => validateHealthSourceRecordInput(input)).toThrow(
+            'nativeValues[0] must be a bounded non-empty string',
+        );
+    });
+
+    it('counts bounded raw string padding before normalized sample values are retained', () => {
+        const input = validInput();
+        const pointCount = 10_000;
+        const paddedValue = `${' '.repeat(510)}x`;
+        const sampleSeries = input.sampleSeries as Array<Record<string, unknown>>;
+        sampleSeries[0].metricId = HEALTH_METRIC_IDS.StressState;
+        sampleSeries[0].valueType = HEALTH_VALUE_TYPES.Category;
+        sampleSeries[0].normalizationStatus = HEALTH_NORMALIZATION_STATUSES.NativeOnly;
+        sampleSeries[0].nativeMetric = 'stressState';
+        sampleSeries[0].nativeUnit = null;
+        sampleSeries[0].canonicalUnit = null;
+        sampleSeries[0].offsetMs = Array.from({ length: pointCount }, (_, index) => index * 1_000);
+        sampleSeries[0].nativeValues = new Proxy(Array(pointCount).fill(paddedValue), {
+            get(target, property, receiver) {
+                if (typeof property === 'string' && /^\d+$/.test(property) && Number(property) >= 9_000) {
+                    throw new Error('validator read beyond the raw UTF-8 budget');
+                }
+                return Reflect.get(target, property, receiver);
+            },
+        });
+        sampleSeries[0].canonicalValues = null;
+        sampleSeries[0].qualityCodes = null;
+        sampleSeries[0].coverage = { status: HEALTH_COVERAGE_STATUSES.Complete, sampleCount: pointCount };
+
+        expect(() => validateHealthSourceRecordInput(input)).toThrow(HealthWriteSizeError);
+        expect(() => validateHealthSourceRecordInput(input)).toThrow('cumulative JSON UTF-8 budget');
     });
 
     it('accepts sleep references only to the existing allowlisted sleep model', () => {

--- a/functions/src/health/validation.spec.ts
+++ b/functions/src/health/validation.spec.ts
@@ -6,7 +6,7 @@ import {
     HEALTH_PROVIDERS,
     HEALTH_QUALITY_STATUSES,
     HEALTH_RECORDING_METHODS,
-    HEALTH_RECORD_KINDS,
+    HEALTH_SOURCE_RECORD_KINDS,
     HEALTH_UNITS,
     HEALTH_VALUE_ORIGINS,
     HEALTH_VALUE_TYPES,
@@ -21,7 +21,7 @@ function validInput(): Record<string, unknown> {
         sourceRecordKey: '2026-01-01',
         revision: { order: 1, token: 'revision-1' },
         receivedAtMs: Date.parse('2026-01-02T00:00:00.000Z'),
-        kind: HEALTH_RECORD_KINDS.DailySummary,
+        kind: HEALTH_SOURCE_RECORD_KINDS.DailySummary,
         calendarDate: '2026-01-01',
         startTimeMs: Date.parse('2026-01-01T00:00:00.000Z'),
         endTimeMs: Date.parse('2026-01-01T23:59:59.999Z'),
@@ -66,7 +66,11 @@ function validInput(): Record<string, unknown> {
 }
 
 describe('health write validation', () => {
-    it('returns a sanitized typed provider record', () => {
+    it('uses a write-wide error code shared by source-record and sync-state validation', () => {
+        expect(new HealthWriteValidationError('invalid').code).toBe('invalid_health_write');
+    });
+
+    it('returns a sanitized typed health source record', () => {
         const result = validateHealthSourceRecordInput(validInput());
 
         expect(result).toMatchObject({
@@ -101,7 +105,7 @@ describe('health write validation', () => {
         expect(() => validateHealthSourceRecordInput(input)).toThrow('canonical.unit must match the metric catalog');
     });
 
-    it('does not allow the raw provider account ID to become persisted record metadata', () => {
+    it('does not allow the raw provider account ID to become persisted source-record metadata', () => {
         const input = validInput();
         input.sourceRecordKey = input.providerAccountId;
 

--- a/functions/src/health/validation.spec.ts
+++ b/functions/src/health/validation.spec.ts
@@ -101,12 +101,38 @@ describe('health write validation', () => {
         expect(() => validateHealthSourceRecordInput(input)).toThrow('canonical.unit must match the metric catalog');
     });
 
+    it('does not allow the raw provider account ID to become persisted record metadata', () => {
+        const input = validInput();
+        input.sourceRecordKey = input.providerAccountId;
+
+        expect(() => validateHealthSourceRecordInput(input)).toThrow(
+            'sourceRecordKey must not expose the raw provider account ID',
+        );
+    });
+
     it('rejects non-finite numbers before they can reach Firestore', () => {
         const input = validInput();
         const metrics = input.metrics as Array<Record<string, unknown>>;
         metrics[0].native = { metric: 'steps', value: Number.NaN };
 
         expect(() => validateHealthSourceRecordInput(input)).toThrow('native.value must be a finite number');
+    });
+
+    it('requires ordered integer coverage boundaries and counts', () => {
+        const reversed = validInput();
+        reversed.coverage = {
+            status: HEALTH_COVERAGE_STATUSES.Partial,
+            expectedStartTimeMs: 2_000,
+            expectedEndTimeMs: 1_000,
+        };
+        expect(() => validateHealthSourceRecordInput(reversed)).toThrow('expectedEndTimeMs must be on or after');
+
+        const fractionalCount = validInput();
+        fractionalCount.coverage = {
+            status: HEALTH_COVERAGE_STATUSES.Partial,
+            sampleCount: 1.5,
+        };
+        expect(() => validateHealthSourceRecordInput(fractionalCount)).toThrow('sampleCount must be a safe integer');
     });
 
     it('requires aligned, strictly increasing sample arrays', () => {
@@ -118,6 +144,39 @@ describe('health write validation', () => {
         sampleSeries[0].qualityCodes = ['valid', 'valid', 'valid'];
 
         expect(() => validateHealthSourceRecordInput(input)).toThrow('offsetMs must be strictly increasing');
+    });
+
+    it('derives and validates series-level sample coverage counts', () => {
+        const derived = validInput();
+        const derivedSeries = derived.sampleSeries as Array<Record<string, unknown>>;
+        derivedSeries[0].coverage = { status: HEALTH_COVERAGE_STATUSES.Complete };
+        expect(validateHealthSourceRecordInput(derived).sampleSeries[0].coverage.sampleCount).toBe(2);
+
+        const mismatched = validInput();
+        const mismatchedSeries = mismatched.sampleSeries as Array<Record<string, unknown>>;
+        mismatchedSeries[0].coverage = { status: HEALTH_COVERAGE_STATUSES.Complete, sampleCount: 1 };
+        expect(() => validateHealthSourceRecordInput(mismatched)).toThrow(
+            'coverage.sampleCount must match the aligned sample arrays',
+        );
+    });
+
+    it('rejects sparse adapter arrays instead of letting holes reach Firestore', () => {
+        const sparseMetrics = validInput();
+        sparseMetrics.metrics = new Array(1);
+        expect(() => validateHealthSourceRecordInput(sparseMetrics)).toThrow('metrics[0] must be an object');
+
+        const sparseOffsets = validInput();
+        const sampleSeries = sparseOffsets.sampleSeries as Array<Record<string, unknown>>;
+        sampleSeries[0].offsetMs = new Array(2);
+        expect(() => validateHealthSourceRecordInput(sparseOffsets)).toThrow('offsetMs[0] must be a finite number');
+    });
+
+    it('rejects empty sample quality codes', () => {
+        const input = validInput();
+        const sampleSeries = input.sampleSeries as Array<Record<string, unknown>>;
+        sampleSeries[0].qualityCodes = ['valid', '   '];
+
+        expect(() => validateHealthSourceRecordInput(input)).toThrow('qualityCodes[1] must be a bounded non-empty string');
     });
 
     it('never accepts canonical sample values without the catalog unit', () => {
@@ -188,5 +247,9 @@ describe('health write validation', () => {
 
         metrics[0].reference = { domain: 'sleep', documentId: 'sleep-session-1', field: 'durationSeconds' };
         expect(() => validateHealthSourceRecordInput(input)).toThrow('metricId does not match the referenced sleep field');
+
+        metrics[0].metricId = HEALTH_METRIC_IDS.SleepDuration;
+        metrics[0].reference = { domain: 'sleep', documentId: 'nested/sleep-session', field: 'durationSeconds' };
+        expect(() => validateHealthSourceRecordInput(input)).toThrow('safe bounded document ID');
     });
 });

--- a/functions/src/health/validation.ts
+++ b/functions/src/health/validation.ts
@@ -31,6 +31,7 @@ import {
 } from '../../../shared/health';
 
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const SAFE_DOCUMENT_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
 const MAX_ACCOUNT_ID_LENGTH = 512;
 const MAX_SOURCE_KEY_LENGTH = 512;
 const MAX_LABEL_LENGTH = 128;
@@ -119,6 +120,14 @@ function nullableBoundedString(value: unknown, field: string, maximum: number): 
     return boundedString(value, field, maximum);
 }
 
+function safeDocumentId(value: unknown, field: string): string {
+    const documentId = boundedString(value, field, 128);
+    if (!SAFE_DOCUMENT_ID_PATTERN.test(documentId)) {
+        throw new HealthWriteValidationError(`${field} must be a safe bounded document ID.`);
+    }
+    return documentId;
+}
+
 function finiteNumber(value: unknown, field: string): number {
     if (typeof value !== 'number' || !Number.isFinite(value)) {
         throw new HealthWriteValidationError(`${field} must be a finite number.`);
@@ -142,6 +151,17 @@ function nullableNonNegativeNumber(value: unknown, field: string): number | null
         return null;
     }
     const normalized = finiteNumber(value, field);
+    if (normalized < 0) {
+        throw new HealthWriteValidationError(`${field} cannot be negative.`);
+    }
+    return normalized;
+}
+
+function nullableNonNegativeSafeInteger(value: unknown, field: string): number | null | undefined {
+    if (value === undefined || value === null) {
+        return value as null | undefined;
+    }
+    const normalized = safeInteger(value, field);
     if (normalized < 0) {
         throw new HealthWriteValidationError(`${field} cannot be negative.`);
     }
@@ -205,16 +225,22 @@ function validateQuality(value: unknown, field: string): HealthQuality {
 
 function validateCoverage(value: unknown, field: string): HealthCoverage {
     const input = objectValue(value, field);
-    return {
+    const coverage: HealthCoverage = {
         status: enumValue(input.status, Object.values(HEALTH_COVERAGE_STATUSES), `${field}.status`),
-        expectedStartTimeMs: nullableNonNegativeNumber(input.expectedStartTimeMs, `${field}.expectedStartTimeMs`),
-        expectedEndTimeMs: nullableNonNegativeNumber(input.expectedEndTimeMs, `${field}.expectedEndTimeMs`),
+        expectedStartTimeMs: nullableNonNegativeSafeInteger(input.expectedStartTimeMs, `${field}.expectedStartTimeMs`),
+        expectedEndTimeMs: nullableNonNegativeSafeInteger(input.expectedEndTimeMs, `${field}.expectedEndTimeMs`),
         observedDurationSeconds: nullableNonNegativeNumber(input.observedDurationSeconds, `${field}.observedDurationSeconds`),
         expectedDurationSeconds: nullableNonNegativeNumber(input.expectedDurationSeconds, `${field}.expectedDurationSeconds`),
-        sampleCount: nullableNonNegativeNumber(input.sampleCount, `${field}.sampleCount`),
-        expectedSampleCount: nullableNonNegativeNumber(input.expectedSampleCount, `${field}.expectedSampleCount`),
-        expectedUpdateIntervalMs: nullableNonNegativeNumber(input.expectedUpdateIntervalMs, `${field}.expectedUpdateIntervalMs`),
+        sampleCount: nullableNonNegativeSafeInteger(input.sampleCount, `${field}.sampleCount`),
+        expectedSampleCount: nullableNonNegativeSafeInteger(input.expectedSampleCount, `${field}.expectedSampleCount`),
+        expectedUpdateIntervalMs: nullableNonNegativeSafeInteger(input.expectedUpdateIntervalMs, `${field}.expectedUpdateIntervalMs`),
     };
+    if (typeof coverage.expectedStartTimeMs === 'number'
+        && typeof coverage.expectedEndTimeMs === 'number'
+        && coverage.expectedEndTimeMs < coverage.expectedStartTimeMs) {
+        throw new HealthWriteValidationError(`${field}.expectedEndTimeMs must be on or after expectedStartTimeMs.`);
+    }
+    return coverage;
 }
 
 function validateMetricIdentity(input: Record<string, unknown>, field: string): {
@@ -347,7 +373,7 @@ function validateMetricEntry(value: unknown, index: number): HealthMetricEntry {
             kind: 'sleep_reference',
             reference: {
                 domain: 'sleep',
-                documentId: boundedString(reference.documentId, `${field}.reference.documentId`, MAX_SOURCE_KEY_LENGTH),
+                documentId: safeDocumentId(reference.documentId, `${field}.reference.documentId`),
                 field: referenceField,
             },
         };
@@ -424,7 +450,7 @@ function validateSampleSeries(
         throw new HealthWriteValidationError(`${field}.offsetMs must contain a bounded set of sample offsets.`);
     }
     let previousOffsetMs = -1;
-    const offsetMs = input.offsetMs.map((offset, offsetIndex) => {
+    const offsetMs = Array.from(input.offsetMs).map((offset, offsetIndex) => {
         const normalized = safeInteger(offset, `${field}.offsetMs[${offsetIndex}]`);
         if (normalized < 0 || normalized > recordDurationMs) {
             throw new HealthWriteValidationError(`${field}.offsetMs[${offsetIndex}] is outside the record interval.`);
@@ -438,7 +464,7 @@ function validateSampleSeries(
     if (!Array.isArray(input.nativeValues) || input.nativeValues.length !== offsetMs.length) {
         throw new HealthWriteValidationError(`${field}.nativeValues must align with offsetMs.`);
     }
-    const nativeValues = input.nativeValues.map((item, itemIndex) => validateScalar(
+    const nativeValues = Array.from(input.nativeValues).map((item, itemIndex) => validateScalar(
         item,
         identity.valueType,
         `${field}.nativeValues[${itemIndex}]`,
@@ -450,7 +476,7 @@ function validateSampleSeries(
         if (!Array.isArray(input.canonicalValues) || input.canonicalValues.length !== offsetMs.length) {
             throw new HealthWriteValidationError(`${field}.canonicalValues must align with offsetMs.`);
         }
-        canonicalValues = input.canonicalValues.map((item, itemIndex) => validateScalar(
+        canonicalValues = Array.from(input.canonicalValues).map((item, itemIndex) => validateScalar(
             item,
             identity.valueType,
             `${field}.canonicalValues[${itemIndex}]`,
@@ -469,12 +495,15 @@ function validateSampleSeries(
         if (!Array.isArray(input.qualityCodes) || input.qualityCodes.length !== offsetMs.length) {
             throw new HealthWriteValidationError(`${field}.qualityCodes must align with offsetMs.`);
         }
-        qualityCodes = input.qualityCodes.map((code, codeIndex) => boundedString(
+        qualityCodes = Array.from(input.qualityCodes).map((code, codeIndex) => boundedString(
             code,
             `${field}.qualityCodes[${codeIndex}]`,
             MAX_LABEL_LENGTH,
-            true,
         ));
+    }
+    const coverage = validateCoverage(input.coverage, `${field}.coverage`);
+    if (typeof coverage.sampleCount === 'number' && coverage.sampleCount !== offsetMs.length) {
+        throw new HealthWriteValidationError(`${field}.coverage.sampleCount must match the aligned sample arrays.`);
     }
     return {
         ...identity,
@@ -487,7 +516,7 @@ function validateSampleSeries(
         nativeValues,
         canonicalValues,
         qualityCodes,
-        coverage: validateCoverage(input.coverage, `${field}.coverage`),
+        coverage: { ...coverage, sampleCount: offsetMs.length },
         device: validateDevice(input.device, `${field}.device`),
     };
 }
@@ -505,7 +534,7 @@ export function validateHealthSourceRecordInput(value: unknown): HealthSourceRec
     if (!Array.isArray(input.metrics) || input.metrics.length > HEALTH_MAX_METRICS_PER_RECORD) {
         throw new HealthWriteValidationError(`metrics must contain at most ${HEALTH_MAX_METRICS_PER_RECORD} entries.`);
     }
-    const metrics = input.metrics.map(validateMetricEntry);
+    const metrics = Array.from(input.metrics).map(validateMetricEntry);
     const rawSampleSeries = input.sampleSeries === undefined ? [] : input.sampleSeries;
     if (!Array.isArray(rawSampleSeries)) {
         throw new HealthWriteValidationError('sampleSeries must be an array.');
@@ -515,7 +544,7 @@ export function validateHealthSourceRecordInput(value: unknown): HealthSourceRec
     }
     const sampleSeries: HealthSampleSeriesInput[] = [];
     let sampleChunkCount = 0;
-    rawSampleSeries.forEach((series, index) => {
+    Array.from(rawSampleSeries).forEach((series, index) => {
         const validatedSeries = validateSampleSeries(series, index, endTimeMs - startTimeMs);
         sampleChunkCount += Math.ceil(validatedSeries.offsetMs.length / HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK);
         if (sampleChunkCount > HEALTH_MAX_SAMPLE_CHUNKS_PER_RECORD) {
@@ -544,12 +573,17 @@ export function validateHealthSourceRecordInput(value: unknown): HealthSourceRec
             throw new HealthWriteValidationError('timezoneOffsetSeconds is outside the supported range.');
         }
     }
+    const providerAccountId = boundedString(input.providerAccountId, 'providerAccountId', MAX_ACCOUNT_ID_LENGTH);
+    const sourceRecordKey = boundedString(input.sourceRecordKey, 'sourceRecordKey', MAX_SOURCE_KEY_LENGTH);
+    if (sourceRecordKey === providerAccountId) {
+        throw new HealthWriteValidationError('sourceRecordKey must not expose the raw provider account ID.');
+    }
 
     return {
         provider: input.provider,
-        providerAccountId: boundedString(input.providerAccountId, 'providerAccountId', MAX_ACCOUNT_ID_LENGTH),
+        providerAccountId,
         sourceRecordType: boundedString(input.sourceRecordType, 'sourceRecordType', MAX_LABEL_LENGTH),
-        sourceRecordKey: boundedString(input.sourceRecordKey, 'sourceRecordKey', MAX_SOURCE_KEY_LENGTH),
+        sourceRecordKey,
         revision: {
             order: revisionOrder,
             token: boundedString(revision.token, 'revision.token', MAX_SOURCE_KEY_LENGTH),

--- a/functions/src/health/validation.ts
+++ b/functions/src/health/validation.ts
@@ -1,12 +1,12 @@
 import {
     HEALTH_COVERAGE_STATUSES,
-    HEALTH_MAX_METRICS_PER_RECORD,
-    HEALTH_MAX_SAMPLE_CHUNKS_PER_RECORD,
+    HEALTH_MAX_METRICS_PER_SOURCE_RECORD,
+    HEALTH_MAX_SAMPLE_CHUNKS_PER_SOURCE_RECORD,
     HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK,
     HEALTH_NORMALIZATION_STATUSES,
     HEALTH_QUALITY_STATUSES,
     HEALTH_RECORDING_METHODS,
-    HEALTH_RECORD_KINDS,
+    HEALTH_SOURCE_RECORD_KINDS,
     HEALTH_SLEEP_REFERENCE_FIELDS,
     HEALTH_SLEEP_REFERENCE_METRIC_IDS,
     HEALTH_UNITS,
@@ -19,7 +19,7 @@ import {
     HealthMetricId,
     HealthProvider,
     HealthQuality,
-    HealthRecordKind,
+    HealthSourceRecordKind,
     HealthRecordingMethod,
     HealthScalar,
     HealthUnit,
@@ -37,12 +37,13 @@ const MAX_SOURCE_KEY_LENGTH = 512;
 const MAX_LABEL_LENGTH = 128;
 const MAX_NATIVE_VALUE_LENGTH = 512;
 const MAX_QUALIFIERS = 16;
-const MAX_SAMPLE_POINTS_PER_RECORD = HEALTH_MAX_SAMPLE_CHUNKS_PER_RECORD * HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK;
+const MAX_SAMPLE_POINTS_PER_SOURCE_RECORD = HEALTH_MAX_SAMPLE_CHUNKS_PER_SOURCE_RECORD
+    * HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK;
 const RESERVED_QUALIFIER_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 export class HealthWriteValidationError extends Error {
     public readonly name: string = 'HealthWriteValidationError';
-    public readonly code = 'invalid_health_record';
+    public readonly code = 'invalid_health_write';
 
     constructor(message: string) {
         super(message);
@@ -81,7 +82,7 @@ export interface HealthSourceRecordInput {
     sourceRecordKey: string;
     revision: HealthSourceRevisionInput;
     receivedAtMs: number;
-    kind: HealthRecordKind;
+    kind: HealthSourceRecordKind;
     calendarDate: string;
     startTimeMs: number;
     endTimeMs: number;
@@ -426,7 +427,7 @@ function validateMetricEntry(value: unknown, index: number): HealthMetricEntry {
 function validateSampleSeries(
     value: unknown,
     index: number,
-    recordDurationMs: number,
+    sourceRecordDurationMs: number,
 ): HealthSampleSeriesInput {
     const field = `sampleSeries[${index}]`;
     const input = objectValue(value, field);
@@ -446,14 +447,16 @@ function validateSampleSeries(
     if (normalizationStatus !== HEALTH_NORMALIZATION_STATUSES.Canonical && canonicalUnit) {
         throw new HealthWriteValidationError(`${field}.canonicalUnit must be omitted for non-canonical samples.`);
     }
-    if (!Array.isArray(input.offsetMs) || input.offsetMs.length === 0 || input.offsetMs.length > MAX_SAMPLE_POINTS_PER_RECORD) {
+    if (!Array.isArray(input.offsetMs)
+        || input.offsetMs.length === 0
+        || input.offsetMs.length > MAX_SAMPLE_POINTS_PER_SOURCE_RECORD) {
         throw new HealthWriteValidationError(`${field}.offsetMs must contain a bounded set of sample offsets.`);
     }
     let previousOffsetMs = -1;
     const offsetMs = Array.from(input.offsetMs).map((offset, offsetIndex) => {
         const normalized = safeInteger(offset, `${field}.offsetMs[${offsetIndex}]`);
-        if (normalized < 0 || normalized > recordDurationMs) {
-            throw new HealthWriteValidationError(`${field}.offsetMs[${offsetIndex}] is outside the record interval.`);
+        if (normalized < 0 || normalized > sourceRecordDurationMs) {
+            throw new HealthWriteValidationError(`${field}.offsetMs[${offsetIndex}] is outside the source-record interval.`);
         }
         if (offsetIndex > 0 && normalized <= previousOffsetMs) {
             throw new HealthWriteValidationError(`${field}.offsetMs must be strictly increasing.`);
@@ -522,7 +525,7 @@ function validateSampleSeries(
 }
 
 export function validateHealthSourceRecordInput(value: unknown): HealthSourceRecordInput {
-    const input = objectValue(value, 'healthRecord');
+    const input = objectValue(value, 'healthSourceRecord');
     if (!isHealthProvider(input.provider)) {
         throw new HealthWriteValidationError('provider is not supported.');
     }
@@ -531,33 +534,39 @@ export function validateHealthSourceRecordInput(value: unknown): HealthSourceRec
     if (endTimeMs < startTimeMs) {
         throw new HealthWriteValidationError('endTimeMs must be on or after startTimeMs.');
     }
-    if (!Array.isArray(input.metrics) || input.metrics.length > HEALTH_MAX_METRICS_PER_RECORD) {
-        throw new HealthWriteValidationError(`metrics must contain at most ${HEALTH_MAX_METRICS_PER_RECORD} entries.`);
+    if (!Array.isArray(input.metrics) || input.metrics.length > HEALTH_MAX_METRICS_PER_SOURCE_RECORD) {
+        throw new HealthWriteValidationError(
+            `metrics must contain at most ${HEALTH_MAX_METRICS_PER_SOURCE_RECORD} entries.`,
+        );
     }
     const metrics = Array.from(input.metrics).map(validateMetricEntry);
     const rawSampleSeries = input.sampleSeries === undefined ? [] : input.sampleSeries;
     if (!Array.isArray(rawSampleSeries)) {
         throw new HealthWriteValidationError('sampleSeries must be an array.');
     }
-    if (rawSampleSeries.length > HEALTH_MAX_SAMPLE_CHUNKS_PER_RECORD) {
-        throw new HealthWriteValidationError(`sampleSeries cannot contain more than ${HEALTH_MAX_SAMPLE_CHUNKS_PER_RECORD} series.`);
+    if (rawSampleSeries.length > HEALTH_MAX_SAMPLE_CHUNKS_PER_SOURCE_RECORD) {
+        throw new HealthWriteValidationError(
+            `sampleSeries cannot contain more than ${HEALTH_MAX_SAMPLE_CHUNKS_PER_SOURCE_RECORD} series.`,
+        );
     }
     const sampleSeries: HealthSampleSeriesInput[] = [];
     let sampleChunkCount = 0;
     Array.from(rawSampleSeries).forEach((series, index) => {
         const validatedSeries = validateSampleSeries(series, index, endTimeMs - startTimeMs);
         sampleChunkCount += Math.ceil(validatedSeries.offsetMs.length / HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK);
-        if (sampleChunkCount > HEALTH_MAX_SAMPLE_CHUNKS_PER_RECORD) {
-            throw new HealthWriteValidationError(`sampleSeries exceeds the ${HEALTH_MAX_SAMPLE_CHUNKS_PER_RECORD}-chunk record limit.`);
+        if (sampleChunkCount > HEALTH_MAX_SAMPLE_CHUNKS_PER_SOURCE_RECORD) {
+            throw new HealthWriteValidationError(
+                `sampleSeries exceeds the ${HEALTH_MAX_SAMPLE_CHUNKS_PER_SOURCE_RECORD}-chunk source-record limit.`,
+            );
         }
         sampleSeries.push(validatedSeries);
     });
     const seriesKeys = new Set(sampleSeries.map(series => series.seriesKey));
     if (seriesKeys.size !== sampleSeries.length) {
-        throw new HealthWriteValidationError('sampleSeries seriesKey values must be unique per record.');
+        throw new HealthWriteValidationError('sampleSeries seriesKey values must be unique per source record.');
     }
     if (metrics.length === 0 && sampleSeries.length === 0) {
-        throw new HealthWriteValidationError('A health record must contain metrics or sampleSeries.');
+        throw new HealthWriteValidationError('A health source record must contain metrics or sampleSeries.');
     }
     const revision = objectValue(input.revision, 'revision');
     const revisionOrder = safeInteger(revision.order, 'revision.order');
@@ -595,7 +604,7 @@ export function validateHealthSourceRecordInput(value: unknown): HealthSourceRec
             }
             return receivedAtMs;
         })(),
-        kind: enumValue(input.kind, Object.values(HEALTH_RECORD_KINDS), 'kind'),
+        kind: enumValue(input.kind, Object.values(HEALTH_SOURCE_RECORD_KINDS), 'kind'),
         calendarDate: validateCalendarDate(input.calendarDate),
         startTimeMs,
         endTimeMs,

--- a/functions/src/health/validation.ts
+++ b/functions/src/health/validation.ts
@@ -1,0 +1,574 @@
+import {
+    HEALTH_COVERAGE_STATUSES,
+    HEALTH_MAX_METRICS_PER_RECORD,
+    HEALTH_MAX_SAMPLE_CHUNKS_PER_RECORD,
+    HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK,
+    HEALTH_NORMALIZATION_STATUSES,
+    HEALTH_QUALITY_STATUSES,
+    HEALTH_RECORDING_METHODS,
+    HEALTH_RECORD_KINDS,
+    HEALTH_SLEEP_REFERENCE_FIELDS,
+    HEALTH_SLEEP_REFERENCE_METRIC_IDS,
+    HEALTH_UNITS,
+    HEALTH_VALUE_ORIGINS,
+    HEALTH_VALUE_TYPES,
+    HealthCoverage,
+    HealthDeviceAttribution,
+    HealthMetricEntry,
+    HealthMetricGoal,
+    HealthMetricId,
+    HealthProvider,
+    HealthQuality,
+    HealthRecordKind,
+    HealthRecordingMethod,
+    HealthScalar,
+    HealthUnit,
+    HealthValueOrigin,
+    HealthValueType,
+    getHealthMetricDefinition,
+    isHealthMetricId,
+    isHealthProvider,
+} from '../../../shared/health';
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const MAX_ACCOUNT_ID_LENGTH = 512;
+const MAX_SOURCE_KEY_LENGTH = 512;
+const MAX_LABEL_LENGTH = 128;
+const MAX_NATIVE_VALUE_LENGTH = 512;
+const MAX_QUALIFIERS = 16;
+const MAX_SAMPLE_POINTS_PER_RECORD = HEALTH_MAX_SAMPLE_CHUNKS_PER_RECORD * HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK;
+const RESERVED_QUALIFIER_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+export class HealthWriteValidationError extends Error {
+    public readonly name: string = 'HealthWriteValidationError';
+    public readonly code = 'invalid_health_record';
+
+    constructor(message: string) {
+        super(message);
+    }
+}
+
+export interface HealthSourceRevisionInput {
+    order: number;
+    token: string;
+}
+
+export interface HealthSampleSeriesInput {
+    seriesKey: string;
+    metricId: HealthMetricId;
+    valueType: HealthValueType;
+    aggregation: string;
+    semanticVariant: string;
+    origin: HealthValueOrigin;
+    recordingMethod: HealthRecordingMethod;
+    normalizationStatus: 'canonical' | 'native_only' | 'not_comparable';
+    nativeMetric: string;
+    nativeUnit?: string | null;
+    canonicalUnit?: HealthUnit | null;
+    offsetMs: number[];
+    nativeValues: HealthScalar[];
+    canonicalValues?: HealthScalar[] | null;
+    qualityCodes?: string[] | null;
+    coverage: HealthCoverage;
+    device?: HealthDeviceAttribution | null;
+}
+
+export interface HealthSourceRecordInput {
+    provider: HealthProvider;
+    providerAccountId: string;
+    sourceRecordType: string;
+    sourceRecordKey: string;
+    revision: HealthSourceRevisionInput;
+    receivedAtMs: number;
+    kind: HealthRecordKind;
+    calendarDate: string;
+    startTimeMs: number;
+    endTimeMs: number;
+    timezoneOffsetSeconds?: number | null;
+    metrics: HealthMetricEntry[];
+    coverage: HealthCoverage;
+    device?: HealthDeviceAttribution | null;
+    sampleSeries: HealthSampleSeriesInput[];
+}
+
+function objectValue(value: unknown, field: string): Record<string, unknown> {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new HealthWriteValidationError(`${field} must be an object.`);
+    }
+    return value as Record<string, unknown>;
+}
+
+function boundedString(value: unknown, field: string, maximum: number, allowEmpty = false): string {
+    if (typeof value !== 'string') {
+        throw new HealthWriteValidationError(`${field} must be a string.`);
+    }
+    const normalized = value.trim();
+    if ((!allowEmpty && normalized.length === 0) || normalized.length > maximum) {
+        throw new HealthWriteValidationError(`${field} must be a bounded non-empty string.`);
+    }
+    return normalized;
+}
+
+function nullableBoundedString(value: unknown, field: string, maximum: number): string | null | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (value === null) {
+        return null;
+    }
+    return boundedString(value, field, maximum);
+}
+
+function finiteNumber(value: unknown, field: string): number {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        throw new HealthWriteValidationError(`${field} must be a finite number.`);
+    }
+    return value;
+}
+
+function safeInteger(value: unknown, field: string): number {
+    const normalized = finiteNumber(value, field);
+    if (!Number.isSafeInteger(normalized)) {
+        throw new HealthWriteValidationError(`${field} must be a safe integer.`);
+    }
+    return normalized;
+}
+
+function nullableNonNegativeNumber(value: unknown, field: string): number | null | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (value === null) {
+        return null;
+    }
+    const normalized = finiteNumber(value, field);
+    if (normalized < 0) {
+        throw new HealthWriteValidationError(`${field} cannot be negative.`);
+    }
+    return normalized;
+}
+
+function enumValue<T extends string>(value: unknown, allowed: readonly T[], field: string): T {
+    if (typeof value !== 'string' || !allowed.includes(value as T)) {
+        throw new HealthWriteValidationError(`${field} is not supported.`);
+    }
+    return value as T;
+}
+
+function validateCalendarDate(value: unknown): string {
+    const calendarDate = boundedString(value, 'calendarDate', 10);
+    const timestamp = Date.parse(`${calendarDate}T00:00:00.000Z`);
+    if (!ISO_DATE_PATTERN.test(calendarDate)
+        || !Number.isFinite(timestamp)
+        || new Date(timestamp).toISOString().slice(0, 10) !== calendarDate) {
+        throw new HealthWriteValidationError('calendarDate must be a valid YYYY-MM-DD date.');
+    }
+    return calendarDate;
+}
+
+function validateScalar(value: unknown, valueType: HealthValueType, field: string): HealthScalar {
+    if (valueType === HEALTH_VALUE_TYPES.Number) {
+        return finiteNumber(value, field);
+    }
+    if (valueType === HEALTH_VALUE_TYPES.Boolean) {
+        if (typeof value !== 'boolean') {
+            throw new HealthWriteValidationError(`${field} must be a boolean.`);
+        }
+        return value;
+    }
+    return boundedString(value, field, MAX_NATIVE_VALUE_LENGTH);
+}
+
+function validateDevice(value: unknown, field: string): HealthDeviceAttribution | null | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (value === null) {
+        return null;
+    }
+    const input = objectValue(value, field);
+    return {
+        deviceKey: nullableBoundedString(input.deviceKey, `${field}.deviceKey`, MAX_LABEL_LENGTH),
+        manufacturer: nullableBoundedString(input.manufacturer, `${field}.manufacturer`, MAX_LABEL_LENGTH),
+        model: nullableBoundedString(input.model, `${field}.model`, MAX_LABEL_LENGTH),
+        displayName: nullableBoundedString(input.displayName, `${field}.displayName`, MAX_LABEL_LENGTH),
+    };
+}
+
+function validateQuality(value: unknown, field: string): HealthQuality {
+    const input = objectValue(value, field);
+    return {
+        status: enumValue(input.status, Object.values(HEALTH_QUALITY_STATUSES), `${field}.status`),
+        nativeCode: nullableBoundedString(input.nativeCode, `${field}.nativeCode`, MAX_LABEL_LENGTH),
+    };
+}
+
+function validateCoverage(value: unknown, field: string): HealthCoverage {
+    const input = objectValue(value, field);
+    return {
+        status: enumValue(input.status, Object.values(HEALTH_COVERAGE_STATUSES), `${field}.status`),
+        expectedStartTimeMs: nullableNonNegativeNumber(input.expectedStartTimeMs, `${field}.expectedStartTimeMs`),
+        expectedEndTimeMs: nullableNonNegativeNumber(input.expectedEndTimeMs, `${field}.expectedEndTimeMs`),
+        observedDurationSeconds: nullableNonNegativeNumber(input.observedDurationSeconds, `${field}.observedDurationSeconds`),
+        expectedDurationSeconds: nullableNonNegativeNumber(input.expectedDurationSeconds, `${field}.expectedDurationSeconds`),
+        sampleCount: nullableNonNegativeNumber(input.sampleCount, `${field}.sampleCount`),
+        expectedSampleCount: nullableNonNegativeNumber(input.expectedSampleCount, `${field}.expectedSampleCount`),
+        expectedUpdateIntervalMs: nullableNonNegativeNumber(input.expectedUpdateIntervalMs, `${field}.expectedUpdateIntervalMs`),
+    };
+}
+
+function validateMetricIdentity(input: Record<string, unknown>, field: string): {
+    metricId: HealthMetricId;
+    valueType: HealthValueType;
+    aggregation: string;
+    semanticVariant: string;
+    origin: HealthValueOrigin;
+    recordingMethod: HealthRecordingMethod;
+} {
+    if (!isHealthMetricId(input.metricId)) {
+        throw new HealthWriteValidationError(`${field}.metricId is not supported.`);
+    }
+    const definition = getHealthMetricDefinition(input.metricId);
+    const valueType = enumValue(input.valueType, Object.values(HEALTH_VALUE_TYPES), `${field}.valueType`);
+    if (valueType !== definition.valueType) {
+        throw new HealthWriteValidationError(`${field}.valueType must match the metric catalog.`);
+    }
+    return {
+        metricId: input.metricId,
+        valueType,
+        aggregation: boundedString(input.aggregation, `${field}.aggregation`, MAX_LABEL_LENGTH),
+        semanticVariant: boundedString(input.semanticVariant, `${field}.semanticVariant`, MAX_LABEL_LENGTH),
+        origin: enumValue(input.origin, Object.values(HEALTH_VALUE_ORIGINS), `${field}.origin`),
+        recordingMethod: enumValue(input.recordingMethod, Object.values(HEALTH_RECORDING_METHODS), `${field}.recordingMethod`),
+    };
+}
+
+function validateQualifiers(value: unknown, field: string): Record<string, string | number | boolean | null> | null | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (value === null) {
+        return null;
+    }
+    const input = objectValue(value, field);
+    const entries = Object.entries(input);
+    if (entries.length > MAX_QUALIFIERS) {
+        throw new HealthWriteValidationError(`${field} contains too many qualifiers.`);
+    }
+    return entries.reduce<Record<string, string | number | boolean | null>>((result, [key, item]) => {
+        const normalizedKey = boundedString(key, `${field} key`, MAX_LABEL_LENGTH);
+        if (RESERVED_QUALIFIER_KEYS.has(normalizedKey)) {
+            throw new HealthWriteValidationError(`${field} contains a reserved qualifier key.`);
+        }
+        if (Object.prototype.hasOwnProperty.call(result, normalizedKey)) {
+            throw new HealthWriteValidationError(`${field} contains duplicate normalized qualifier keys.`);
+        }
+        if (item === null || typeof item === 'boolean') {
+            result[normalizedKey] = item;
+        } else if (typeof item === 'number') {
+            result[normalizedKey] = finiteNumber(item, `${field}.${normalizedKey}`);
+        } else {
+            result[normalizedKey] = boundedString(item, `${field}.${normalizedKey}`, MAX_NATIVE_VALUE_LENGTH, true);
+        }
+        return result;
+    }, {});
+}
+
+function validateGoal(
+    value: unknown,
+    metricId: HealthMetricId,
+    valueType: HealthValueType,
+    field: string,
+): HealthMetricGoal | null | undefined {
+    if (value === undefined || value === null) {
+        return value as null | undefined;
+    }
+    const input = objectValue(value, field);
+    let native: HealthMetricGoal['native'];
+    if (input.native === null) {
+        native = null;
+    } else if (input.native !== undefined) {
+        const nativeInput = objectValue(input.native, `${field}.native`);
+        native = {
+            metric: boundedString(nativeInput.metric, `${field}.native.metric`, MAX_LABEL_LENGTH),
+            value: validateScalar(nativeInput.value, valueType, `${field}.native.value`),
+            unit: nullableBoundedString(nativeInput.unit, `${field}.native.unit`, MAX_LABEL_LENGTH),
+            qualifiers: validateQualifiers(nativeInput.qualifiers, `${field}.native.qualifiers`),
+        };
+    }
+    let canonical: HealthMetricGoal['canonical'];
+    if (input.canonical === null) {
+        canonical = null;
+    } else if (input.canonical !== undefined) {
+        const canonicalInput = objectValue(input.canonical, `${field}.canonical`);
+        const unit = enumValue(canonicalInput.unit, Object.values(HEALTH_UNITS), `${field}.canonical.unit`);
+        if (unit !== getHealthMetricDefinition(metricId).canonicalUnit) {
+            throw new HealthWriteValidationError(`${field}.canonical.unit must match the metric catalog.`);
+        }
+        canonical = {
+            value: validateScalar(canonicalInput.value, valueType, `${field}.canonical.value`),
+            unit,
+        };
+    }
+    if (!native && !canonical) {
+        throw new HealthWriteValidationError(`${field} must contain a native or canonical goal.`);
+    }
+    return { native, canonical };
+}
+
+function validateMetricEntry(value: unknown, index: number): HealthMetricEntry {
+    const field = `metrics[${index}]`;
+    const input = objectValue(value, field);
+    const identity = validateMetricIdentity(input, field);
+    const common = {
+        ...identity,
+        quality: validateQuality(input.quality, `${field}.quality`),
+        coverage: input.coverage === undefined || input.coverage === null
+            ? input.coverage as null | undefined
+            : validateCoverage(input.coverage, `${field}.coverage`),
+        device: validateDevice(input.device, `${field}.device`),
+    };
+
+    if (input.kind === 'sleep_reference') {
+        const reference = objectValue(input.reference, `${field}.reference`);
+        if (reference.domain !== 'sleep') {
+            throw new HealthWriteValidationError(`${field}.reference.domain must be sleep.`);
+        }
+        const referenceField = enumValue(
+            reference.field,
+            Object.values(HEALTH_SLEEP_REFERENCE_FIELDS),
+            `${field}.reference.field`,
+        );
+        if (!HEALTH_SLEEP_REFERENCE_METRIC_IDS[referenceField].includes(identity.metricId)) {
+            throw new HealthWriteValidationError(`${field}.metricId does not match the referenced sleep field.`);
+        }
+        return {
+            ...common,
+            kind: 'sleep_reference',
+            reference: {
+                domain: 'sleep',
+                documentId: boundedString(reference.documentId, `${field}.reference.documentId`, MAX_SOURCE_KEY_LENGTH),
+                field: referenceField,
+            },
+        };
+    }
+
+    if (input.kind !== 'value') {
+        throw new HealthWriteValidationError(`${field}.kind is not supported.`);
+    }
+    const normalizationStatus = enumValue(
+        input.normalizationStatus,
+        Object.values(HEALTH_NORMALIZATION_STATUSES),
+        `${field}.normalizationStatus`,
+    );
+    const nativeInput = objectValue(input.native, `${field}.native`);
+    const native = {
+        metric: boundedString(nativeInput.metric, `${field}.native.metric`, MAX_LABEL_LENGTH),
+        value: validateScalar(nativeInput.value, identity.valueType, `${field}.native.value`),
+        unit: nullableBoundedString(nativeInput.unit, `${field}.native.unit`, MAX_LABEL_LENGTH),
+        qualifiers: validateQualifiers(nativeInput.qualifiers, `${field}.native.qualifiers`),
+    };
+    let canonical = null;
+    if (input.canonical !== undefined && input.canonical !== null) {
+        const canonicalInput = objectValue(input.canonical, `${field}.canonical`);
+        const canonicalUnit = enumValue(canonicalInput.unit, Object.values(HEALTH_UNITS), `${field}.canonical.unit`);
+        if (canonicalUnit !== getHealthMetricDefinition(identity.metricId).canonicalUnit) {
+            throw new HealthWriteValidationError(`${field}.canonical.unit must match the metric catalog.`);
+        }
+        canonical = {
+            value: validateScalar(canonicalInput.value, identity.valueType, `${field}.canonical.value`),
+            unit: canonicalUnit,
+        };
+    }
+    if (normalizationStatus === HEALTH_NORMALIZATION_STATUSES.Canonical && !canonical) {
+        throw new HealthWriteValidationError(`${field}.canonical is required for canonical values.`);
+    }
+    if (normalizationStatus !== HEALTH_NORMALIZATION_STATUSES.Canonical && canonical) {
+        throw new HealthWriteValidationError(`${field}.canonical must be omitted for non-canonical values.`);
+    }
+
+    return {
+        ...common,
+        kind: 'value',
+        normalizationStatus,
+        native,
+        canonical,
+        goal: validateGoal(input.goal, identity.metricId, identity.valueType, `${field}.goal`),
+    };
+}
+
+function validateSampleSeries(
+    value: unknown,
+    index: number,
+    recordDurationMs: number,
+): HealthSampleSeriesInput {
+    const field = `sampleSeries[${index}]`;
+    const input = objectValue(value, field);
+    const identity = validateMetricIdentity(input, field);
+    const normalizationStatus = enumValue(
+        input.normalizationStatus,
+        Object.values(HEALTH_NORMALIZATION_STATUSES),
+        `${field}.normalizationStatus`,
+    );
+    const canonicalUnit = input.canonicalUnit === undefined || input.canonicalUnit === null
+        ? input.canonicalUnit as null | undefined
+        : enumValue(input.canonicalUnit, Object.values(HEALTH_UNITS), `${field}.canonicalUnit`);
+    if (normalizationStatus === HEALTH_NORMALIZATION_STATUSES.Canonical
+        && canonicalUnit !== getHealthMetricDefinition(identity.metricId).canonicalUnit) {
+        throw new HealthWriteValidationError(`${field}.canonicalUnit must match the metric catalog.`);
+    }
+    if (normalizationStatus !== HEALTH_NORMALIZATION_STATUSES.Canonical && canonicalUnit) {
+        throw new HealthWriteValidationError(`${field}.canonicalUnit must be omitted for non-canonical samples.`);
+    }
+    if (!Array.isArray(input.offsetMs) || input.offsetMs.length === 0 || input.offsetMs.length > MAX_SAMPLE_POINTS_PER_RECORD) {
+        throw new HealthWriteValidationError(`${field}.offsetMs must contain a bounded set of sample offsets.`);
+    }
+    let previousOffsetMs = -1;
+    const offsetMs = input.offsetMs.map((offset, offsetIndex) => {
+        const normalized = safeInteger(offset, `${field}.offsetMs[${offsetIndex}]`);
+        if (normalized < 0 || normalized > recordDurationMs) {
+            throw new HealthWriteValidationError(`${field}.offsetMs[${offsetIndex}] is outside the record interval.`);
+        }
+        if (offsetIndex > 0 && normalized <= previousOffsetMs) {
+            throw new HealthWriteValidationError(`${field}.offsetMs must be strictly increasing.`);
+        }
+        previousOffsetMs = normalized;
+        return normalized;
+    });
+    if (!Array.isArray(input.nativeValues) || input.nativeValues.length !== offsetMs.length) {
+        throw new HealthWriteValidationError(`${field}.nativeValues must align with offsetMs.`);
+    }
+    const nativeValues = input.nativeValues.map((item, itemIndex) => validateScalar(
+        item,
+        identity.valueType,
+        `${field}.nativeValues[${itemIndex}]`,
+    ));
+    let canonicalValues: HealthScalar[] | null | undefined;
+    if (input.canonicalValues === null) {
+        canonicalValues = null;
+    } else if (input.canonicalValues !== undefined) {
+        if (!Array.isArray(input.canonicalValues) || input.canonicalValues.length !== offsetMs.length) {
+            throw new HealthWriteValidationError(`${field}.canonicalValues must align with offsetMs.`);
+        }
+        canonicalValues = input.canonicalValues.map((item, itemIndex) => validateScalar(
+            item,
+            identity.valueType,
+            `${field}.canonicalValues[${itemIndex}]`,
+        ));
+    }
+    if (normalizationStatus === HEALTH_NORMALIZATION_STATUSES.Canonical && !canonicalValues) {
+        throw new HealthWriteValidationError(`${field}.canonicalValues are required for canonical samples.`);
+    }
+    if (normalizationStatus !== HEALTH_NORMALIZATION_STATUSES.Canonical && canonicalValues) {
+        throw new HealthWriteValidationError(`${field}.canonicalValues must be omitted for non-canonical samples.`);
+    }
+    let qualityCodes: string[] | null | undefined;
+    if (input.qualityCodes === null) {
+        qualityCodes = null;
+    } else if (input.qualityCodes !== undefined) {
+        if (!Array.isArray(input.qualityCodes) || input.qualityCodes.length !== offsetMs.length) {
+            throw new HealthWriteValidationError(`${field}.qualityCodes must align with offsetMs.`);
+        }
+        qualityCodes = input.qualityCodes.map((code, codeIndex) => boundedString(
+            code,
+            `${field}.qualityCodes[${codeIndex}]`,
+            MAX_LABEL_LENGTH,
+            true,
+        ));
+    }
+    return {
+        ...identity,
+        seriesKey: boundedString(input.seriesKey, `${field}.seriesKey`, MAX_LABEL_LENGTH),
+        normalizationStatus,
+        nativeMetric: boundedString(input.nativeMetric, `${field}.nativeMetric`, MAX_LABEL_LENGTH),
+        nativeUnit: nullableBoundedString(input.nativeUnit, `${field}.nativeUnit`, MAX_LABEL_LENGTH),
+        canonicalUnit,
+        offsetMs,
+        nativeValues,
+        canonicalValues,
+        qualityCodes,
+        coverage: validateCoverage(input.coverage, `${field}.coverage`),
+        device: validateDevice(input.device, `${field}.device`),
+    };
+}
+
+export function validateHealthSourceRecordInput(value: unknown): HealthSourceRecordInput {
+    const input = objectValue(value, 'healthRecord');
+    if (!isHealthProvider(input.provider)) {
+        throw new HealthWriteValidationError('provider is not supported.');
+    }
+    const startTimeMs = safeInteger(input.startTimeMs, 'startTimeMs');
+    const endTimeMs = safeInteger(input.endTimeMs, 'endTimeMs');
+    if (endTimeMs < startTimeMs) {
+        throw new HealthWriteValidationError('endTimeMs must be on or after startTimeMs.');
+    }
+    if (!Array.isArray(input.metrics) || input.metrics.length > HEALTH_MAX_METRICS_PER_RECORD) {
+        throw new HealthWriteValidationError(`metrics must contain at most ${HEALTH_MAX_METRICS_PER_RECORD} entries.`);
+    }
+    const metrics = input.metrics.map(validateMetricEntry);
+    const rawSampleSeries = input.sampleSeries === undefined ? [] : input.sampleSeries;
+    if (!Array.isArray(rawSampleSeries)) {
+        throw new HealthWriteValidationError('sampleSeries must be an array.');
+    }
+    if (rawSampleSeries.length > HEALTH_MAX_SAMPLE_CHUNKS_PER_RECORD) {
+        throw new HealthWriteValidationError(`sampleSeries cannot contain more than ${HEALTH_MAX_SAMPLE_CHUNKS_PER_RECORD} series.`);
+    }
+    const sampleSeries: HealthSampleSeriesInput[] = [];
+    let sampleChunkCount = 0;
+    rawSampleSeries.forEach((series, index) => {
+        const validatedSeries = validateSampleSeries(series, index, endTimeMs - startTimeMs);
+        sampleChunkCount += Math.ceil(validatedSeries.offsetMs.length / HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK);
+        if (sampleChunkCount > HEALTH_MAX_SAMPLE_CHUNKS_PER_RECORD) {
+            throw new HealthWriteValidationError(`sampleSeries exceeds the ${HEALTH_MAX_SAMPLE_CHUNKS_PER_RECORD}-chunk record limit.`);
+        }
+        sampleSeries.push(validatedSeries);
+    });
+    const seriesKeys = new Set(sampleSeries.map(series => series.seriesKey));
+    if (seriesKeys.size !== sampleSeries.length) {
+        throw new HealthWriteValidationError('sampleSeries seriesKey values must be unique per record.');
+    }
+    if (metrics.length === 0 && sampleSeries.length === 0) {
+        throw new HealthWriteValidationError('A health record must contain metrics or sampleSeries.');
+    }
+    const revision = objectValue(input.revision, 'revision');
+    const revisionOrder = safeInteger(revision.order, 'revision.order');
+    if (revisionOrder < 0) {
+        throw new HealthWriteValidationError('revision.order cannot be negative.');
+    }
+    let timezoneOffsetSeconds: number | null | undefined;
+    if (input.timezoneOffsetSeconds === null) {
+        timezoneOffsetSeconds = null;
+    } else if (input.timezoneOffsetSeconds !== undefined) {
+        timezoneOffsetSeconds = safeInteger(input.timezoneOffsetSeconds, 'timezoneOffsetSeconds');
+        if (Math.abs(timezoneOffsetSeconds) > 18 * 60 * 60) {
+            throw new HealthWriteValidationError('timezoneOffsetSeconds is outside the supported range.');
+        }
+    }
+
+    return {
+        provider: input.provider,
+        providerAccountId: boundedString(input.providerAccountId, 'providerAccountId', MAX_ACCOUNT_ID_LENGTH),
+        sourceRecordType: boundedString(input.sourceRecordType, 'sourceRecordType', MAX_LABEL_LENGTH),
+        sourceRecordKey: boundedString(input.sourceRecordKey, 'sourceRecordKey', MAX_SOURCE_KEY_LENGTH),
+        revision: {
+            order: revisionOrder,
+            token: boundedString(revision.token, 'revision.token', MAX_SOURCE_KEY_LENGTH),
+        },
+        receivedAtMs: (() => {
+            const receivedAtMs = safeInteger(input.receivedAtMs, 'receivedAtMs');
+            if (receivedAtMs < 0) {
+                throw new HealthWriteValidationError('receivedAtMs cannot be negative.');
+            }
+            return receivedAtMs;
+        })(),
+        kind: enumValue(input.kind, Object.values(HEALTH_RECORD_KINDS), 'kind'),
+        calendarDate: validateCalendarDate(input.calendarDate),
+        startTimeMs,
+        endTimeMs,
+        timezoneOffsetSeconds,
+        metrics,
+        coverage: validateCoverage(input.coverage, 'coverage'),
+        device: validateDevice(input.device, 'device'),
+        sampleSeries,
+    };
+}

--- a/functions/src/health/validation.ts
+++ b/functions/src/health/validation.ts
@@ -3,6 +3,7 @@ import {
     HEALTH_MAX_METRICS_PER_SOURCE_RECORD,
     HEALTH_MAX_SAMPLE_CHUNKS_PER_SOURCE_RECORD,
     HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK,
+    HEALTH_MAX_WRITE_BYTES,
     HEALTH_NORMALIZATION_STATUSES,
     HEALTH_QUALITY_STATUSES,
     HEALTH_RECORDING_METHODS,
@@ -47,6 +48,45 @@ export class HealthWriteValidationError extends Error {
 
     constructor(message: string) {
         super(message);
+    }
+}
+
+export class HealthWriteSizeError extends HealthWriteValidationError {
+    public readonly name = 'HealthWriteSizeError';
+}
+
+class HealthWriteUtf8Budget {
+    private consumedBytes = 0;
+
+    public addJsonValue(value: unknown): void {
+        this.addSerializedValue(value, 0);
+    }
+
+    public addJsonCollectionValue(value: unknown, index: number): void {
+        this.addSerializedValue(value, index > 0 ? 1 : 0);
+    }
+
+    private addSerializedValue(value: unknown, separatorBytes: number): void {
+        let serialized: string | undefined;
+        try {
+            serialized = JSON.stringify(value);
+        } catch {
+            throw new HealthWriteSizeError(
+                'Health source-record input could not be serialized for cumulative JSON UTF-8 validation.',
+            );
+        }
+        if (typeof serialized !== 'string') {
+            throw new HealthWriteSizeError(
+                'Health source-record input could not be serialized for cumulative JSON UTF-8 validation.',
+            );
+        }
+        const nextBytes = this.consumedBytes + separatorBytes + Buffer.byteLength(serialized, 'utf8');
+        if (nextBytes > HEALTH_MAX_WRITE_BYTES) {
+            throw new HealthWriteSizeError(
+                'Health source-record input exceeds the cumulative JSON UTF-8 budget.',
+            );
+        }
+        this.consumedBytes = nextBytes;
     }
 }
 
@@ -103,6 +143,9 @@ function objectValue(value: unknown, field: string): Record<string, unknown> {
 function boundedString(value: unknown, field: string, maximum: number, allowEmpty = false): string {
     if (typeof value !== 'string') {
         throw new HealthWriteValidationError(`${field} must be a string.`);
+    }
+    if (value.length > maximum) {
+        throw new HealthWriteValidationError(`${field} must be a bounded non-empty string.`);
     }
     const normalized = value.trim();
     if ((!allowEmpty && normalized.length === 0) || normalized.length > maximum) {
@@ -428,6 +471,7 @@ function validateSampleSeries(
     value: unknown,
     index: number,
     sourceRecordDurationMs: number,
+    writeBudget: HealthWriteUtf8Budget,
 ): HealthSampleSeriesInput {
     const field = `sampleSeries[${index}]`;
     const input = objectValue(value, field);
@@ -452,75 +496,129 @@ function validateSampleSeries(
         || input.offsetMs.length > MAX_SAMPLE_POINTS_PER_SOURCE_RECORD) {
         throw new HealthWriteValidationError(`${field}.offsetMs must contain a bounded set of sample offsets.`);
     }
-    let previousOffsetMs = -1;
-    const offsetMs = Array.from(input.offsetMs).map((offset, offsetIndex) => {
-        const normalized = safeInteger(offset, `${field}.offsetMs[${offsetIndex}]`);
-        if (normalized < 0 || normalized > sourceRecordDurationMs) {
-            throw new HealthWriteValidationError(`${field}.offsetMs[${offsetIndex}] is outside the source-record interval.`);
-        }
-        if (offsetIndex > 0 && normalized <= previousOffsetMs) {
-            throw new HealthWriteValidationError(`${field}.offsetMs must be strictly increasing.`);
-        }
-        previousOffsetMs = normalized;
-        return normalized;
-    });
-    if (!Array.isArray(input.nativeValues) || input.nativeValues.length !== offsetMs.length) {
+    const pointCount = input.offsetMs.length;
+    if (!Array.isArray(input.nativeValues) || input.nativeValues.length !== pointCount) {
         throw new HealthWriteValidationError(`${field}.nativeValues must align with offsetMs.`);
     }
-    const nativeValues = Array.from(input.nativeValues).map((item, itemIndex) => validateScalar(
-        item,
-        identity.valueType,
-        `${field}.nativeValues[${itemIndex}]`,
-    ));
+    let canonicalValueInput: unknown[] | null | undefined;
     let canonicalValues: HealthScalar[] | null | undefined;
     if (input.canonicalValues === null) {
+        canonicalValueInput = null;
         canonicalValues = null;
     } else if (input.canonicalValues !== undefined) {
-        if (!Array.isArray(input.canonicalValues) || input.canonicalValues.length !== offsetMs.length) {
+        if (!Array.isArray(input.canonicalValues) || input.canonicalValues.length !== pointCount) {
             throw new HealthWriteValidationError(`${field}.canonicalValues must align with offsetMs.`);
         }
-        canonicalValues = Array.from(input.canonicalValues).map((item, itemIndex) => validateScalar(
-            item,
-            identity.valueType,
-            `${field}.canonicalValues[${itemIndex}]`,
-        ));
+        canonicalValueInput = input.canonicalValues;
+        canonicalValues = [];
     }
-    if (normalizationStatus === HEALTH_NORMALIZATION_STATUSES.Canonical && !canonicalValues) {
+    if (normalizationStatus === HEALTH_NORMALIZATION_STATUSES.Canonical && !canonicalValueInput) {
         throw new HealthWriteValidationError(`${field}.canonicalValues are required for canonical samples.`);
     }
-    if (normalizationStatus !== HEALTH_NORMALIZATION_STATUSES.Canonical && canonicalValues) {
+    if (normalizationStatus !== HEALTH_NORMALIZATION_STATUSES.Canonical && Array.isArray(canonicalValueInput)) {
         throw new HealthWriteValidationError(`${field}.canonicalValues must be omitted for non-canonical samples.`);
     }
+    let qualityCodeInput: unknown[] | null | undefined;
     let qualityCodes: string[] | null | undefined;
     if (input.qualityCodes === null) {
+        qualityCodeInput = null;
         qualityCodes = null;
     } else if (input.qualityCodes !== undefined) {
-        if (!Array.isArray(input.qualityCodes) || input.qualityCodes.length !== offsetMs.length) {
+        if (!Array.isArray(input.qualityCodes) || input.qualityCodes.length !== pointCount) {
             throw new HealthWriteValidationError(`${field}.qualityCodes must align with offsetMs.`);
         }
-        qualityCodes = Array.from(input.qualityCodes).map((code, codeIndex) => boundedString(
-            code,
-            `${field}.qualityCodes[${codeIndex}]`,
-            MAX_LABEL_LENGTH,
-        ));
+        qualityCodeInput = input.qualityCodes;
+        qualityCodes = [];
     }
     const coverage = validateCoverage(input.coverage, `${field}.coverage`);
-    if (typeof coverage.sampleCount === 'number' && coverage.sampleCount !== offsetMs.length) {
-        throw new HealthWriteValidationError(`${field}.coverage.sampleCount must match the aligned sample arrays.`);
-    }
-    return {
+    const common = {
         ...identity,
         seriesKey: boundedString(input.seriesKey, `${field}.seriesKey`, MAX_LABEL_LENGTH),
         normalizationStatus,
         nativeMetric: boundedString(input.nativeMetric, `${field}.nativeMetric`, MAX_LABEL_LENGTH),
         nativeUnit: nullableBoundedString(input.nativeUnit, `${field}.nativeUnit`, MAX_LABEL_LENGTH),
         canonicalUnit,
+        coverage: { ...coverage, sampleCount: pointCount },
+        device: validateDevice(input.device, `${field}.device`),
+    };
+    writeBudget.addJsonCollectionValue({
+        ...common,
+        offsetMs: [],
+        nativeValues: [],
+        canonicalValues,
+        qualityCodes,
+    }, index);
+
+    const offsetMs: number[] = [];
+    const nativeValues: HealthScalar[] = [];
+    let previousOffsetMs = -1;
+    for (let itemIndex = 0; itemIndex < pointCount; itemIndex += 1) {
+        const offset = safeInteger(input.offsetMs[itemIndex], `${field}.offsetMs[${itemIndex}]`);
+        if (offset < 0 || offset > sourceRecordDurationMs) {
+            throw new HealthWriteValidationError(`${field}.offsetMs[${itemIndex}] is outside the source-record interval.`);
+        }
+        if (itemIndex > 0 && offset <= previousOffsetMs) {
+            throw new HealthWriteValidationError(`${field}.offsetMs must be strictly increasing.`);
+        }
+        const rawNativeValue = input.nativeValues[itemIndex];
+        const nativeValue = validateScalar(
+            rawNativeValue,
+            identity.valueType,
+            `${field}.nativeValues[${itemIndex}]`,
+        );
+        const rawCanonicalValue = canonicalValueInput?.[itemIndex];
+        const canonicalValue = canonicalValueInput
+            ? validateScalar(
+                rawCanonicalValue,
+                identity.valueType,
+                `${field}.canonicalValues[${itemIndex}]`,
+            )
+            : undefined;
+        const rawQualityCode = qualityCodeInput?.[itemIndex];
+        const qualityCode = qualityCodeInput
+            ? boundedString(
+                rawQualityCode,
+                `${field}.qualityCodes[${itemIndex}]`,
+                MAX_LABEL_LENGTH,
+            )
+            : undefined;
+
+        writeBudget.addJsonCollectionValue(offset, itemIndex);
+        writeBudget.addJsonCollectionValue(
+            typeof rawNativeValue === 'string' ? rawNativeValue : nativeValue,
+            itemIndex,
+        );
+        if (canonicalValueInput) {
+            writeBudget.addJsonCollectionValue(
+                typeof rawCanonicalValue === 'string' ? rawCanonicalValue : canonicalValue,
+                itemIndex,
+            );
+        }
+        if (qualityCodeInput) {
+            writeBudget.addJsonCollectionValue(rawQualityCode, itemIndex);
+        }
+
+        previousOffsetMs = offset;
+        offsetMs.push(offset);
+        nativeValues.push(nativeValue);
+        if (canonicalValueInput) {
+            (canonicalValues as HealthScalar[]).push(canonicalValue as HealthScalar);
+        }
+        if (qualityCodeInput) {
+            (qualityCodes as string[]).push(qualityCode as string);
+        }
+    }
+
+    if (typeof coverage.sampleCount === 'number' && coverage.sampleCount !== pointCount) {
+        throw new HealthWriteValidationError(`${field}.coverage.sampleCount must match the aligned sample arrays.`);
+    }
+
+    return {
+        ...common,
         offsetMs,
         nativeValues,
         canonicalValues,
         qualityCodes,
-        coverage: { ...coverage, sampleCount: offsetMs.length },
-        device: validateDevice(input.device, `${field}.device`),
     };
 }
 
@@ -539,7 +637,13 @@ export function validateHealthSourceRecordInput(value: unknown): HealthSourceRec
             `metrics must contain at most ${HEALTH_MAX_METRICS_PER_SOURCE_RECORD} entries.`,
         );
     }
-    const metrics = Array.from(input.metrics).map(validateMetricEntry);
+    const writeBudget = new HealthWriteUtf8Budget();
+    const metrics: HealthMetricEntry[] = [];
+    for (let index = 0; index < input.metrics.length; index += 1) {
+        const metric = validateMetricEntry(input.metrics[index], index);
+        writeBudget.addJsonCollectionValue(metric, index);
+        metrics.push(metric);
+    }
     const rawSampleSeries = input.sampleSeries === undefined ? [] : input.sampleSeries;
     if (!Array.isArray(rawSampleSeries)) {
         throw new HealthWriteValidationError('sampleSeries must be an array.');
@@ -551,8 +655,13 @@ export function validateHealthSourceRecordInput(value: unknown): HealthSourceRec
     }
     const sampleSeries: HealthSampleSeriesInput[] = [];
     let sampleChunkCount = 0;
-    Array.from(rawSampleSeries).forEach((series, index) => {
-        const validatedSeries = validateSampleSeries(series, index, endTimeMs - startTimeMs);
+    for (let index = 0; index < rawSampleSeries.length; index += 1) {
+        const validatedSeries = validateSampleSeries(
+            rawSampleSeries[index],
+            index,
+            endTimeMs - startTimeMs,
+            writeBudget,
+        );
         sampleChunkCount += Math.ceil(validatedSeries.offsetMs.length / HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK);
         if (sampleChunkCount > HEALTH_MAX_SAMPLE_CHUNKS_PER_SOURCE_RECORD) {
             throw new HealthWriteValidationError(
@@ -560,7 +669,7 @@ export function validateHealthSourceRecordInput(value: unknown): HealthSourceRec
             );
         }
         sampleSeries.push(validatedSeries);
-    });
+    }
     const seriesKeys = new Set(sampleSeries.map(series => series.seriesKey));
     if (seriesKeys.size !== sampleSeries.length) {
         throw new HealthWriteValidationError('sampleSeries seriesKey values must be unique per source record.');
@@ -584,11 +693,7 @@ export function validateHealthSourceRecordInput(value: unknown): HealthSourceRec
     }
     const providerAccountId = boundedString(input.providerAccountId, 'providerAccountId', MAX_ACCOUNT_ID_LENGTH);
     const sourceRecordKey = boundedString(input.sourceRecordKey, 'sourceRecordKey', MAX_SOURCE_KEY_LENGTH);
-    if (sourceRecordKey === providerAccountId) {
-        throw new HealthWriteValidationError('sourceRecordKey must not expose the raw provider account ID.');
-    }
-
-    return {
+    const result: HealthSourceRecordInput = {
         provider: input.provider,
         providerAccountId,
         sourceRecordType: boundedString(input.sourceRecordType, 'sourceRecordType', MAX_LABEL_LENGTH),
@@ -614,4 +719,10 @@ export function validateHealthSourceRecordInput(value: unknown): HealthSourceRec
         device: validateDevice(input.device, 'device'),
         sampleSeries,
     };
+    writeBudget.addJsonValue({
+        ...result,
+        metrics: [],
+        sampleSeries: [],
+    });
+    return result;
 }

--- a/functions/src/health/writer.spec.ts
+++ b/functions/src/health/writer.spec.ts
@@ -1,0 +1,390 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import {
+    HEALTH_COVERAGE_STATUSES,
+    HEALTH_METRIC_IDS,
+    HEALTH_NORMALIZATION_STATUSES,
+    HEALTH_PROVIDERS,
+    HEALTH_QUALITY_STATUSES,
+    HEALTH_RECORDING_METHODS,
+    HEALTH_RECORD_KINDS,
+    HEALTH_SYNC_STATUSES,
+    HEALTH_UNITS,
+    HEALTH_VALUE_ORIGINS,
+    HEALTH_VALUE_TYPES,
+    HealthSourceRecord,
+} from '../../../shared/health';
+
+const hoisted = vi.hoisted(() => ({
+    deletionGuard: vi.fn(),
+}));
+
+vi.mock('firebase-functions/logger', () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+}));
+
+vi.mock('../shared/user-deletion-guard', () => ({
+    getUserDeletionGuardStateInTransaction: hoisted.deletionGuard,
+    UserDeletionGuardReadError: class UserDeletionGuardReadError extends Error {
+        constructor(public readonly uid: string, public readonly phase: string, public readonly originalError: unknown) {
+            super(`Deletion guard failed for ${uid} during ${phase}.`);
+        }
+    },
+}));
+
+import {
+    HealthRevisionConflictError,
+    buildHealthWrite,
+    markHealthProviderDisconnected,
+    replaceHealthSourceRecord,
+    updateHealthSyncState,
+} from './writer';
+
+interface FakeDocumentReference {
+    id: string;
+    path: string;
+    collection: (name: string) => FakeCollectionReference;
+}
+
+interface FakeCollectionReference {
+    doc: (id: string) => FakeDocumentReference;
+}
+
+function fakeDatabase() {
+    const stored = new Map<string, unknown>();
+    const sets = vi.fn();
+    const deletes = vi.fn();
+    const document = (path: string): FakeDocumentReference => ({
+        id: path.split('/').at(-1) || '',
+        path,
+        collection: (name: string) => collection(`${path}/${name}`),
+    });
+    const collection = (path: string): FakeCollectionReference => ({
+        doc: (id: string) => document(`${path}/${id}`),
+    });
+    const transaction = {
+        get: vi.fn(async (reference: FakeDocumentReference) => ({
+            exists: stored.has(reference.path),
+            data: () => stored.get(reference.path),
+        })),
+        set: sets,
+        delete: deletes,
+    };
+    const db = {
+        collection,
+        runTransaction: vi.fn(async (runner: (value: typeof transaction) => unknown) => runner(transaction)),
+    };
+    return { db, stored, sets, deletes, transaction };
+}
+
+function fakeId(parts: string[]): Promise<string> {
+    return Promise.resolve(createHash('sha256').update(JSON.stringify(parts)).digest('hex'));
+}
+
+function joiningHashId(parts: string[]): Promise<string> {
+    return Promise.resolve(createHash('sha256').update(parts.join(':')).digest('hex'));
+}
+
+function validInput(pointCount = 2): Record<string, unknown> {
+    const offsets = Array.from({ length: pointCount }, (_, index) => index * 1000);
+    return {
+        provider: HEALTH_PROVIDERS.GarminAPI,
+        providerAccountId: 'secret-provider-account',
+        sourceRecordType: 'daily-summary',
+        sourceRecordKey: '2026-01-01',
+        revision: { order: 1, token: 'revision-1' },
+        receivedAtMs: Date.parse('2026-01-02T00:00:00.000Z'),
+        kind: HEALTH_RECORD_KINDS.DailySummary,
+        calendarDate: '2026-01-01',
+        startTimeMs: Date.parse('2026-01-01T00:00:00.000Z'),
+        endTimeMs: Date.parse('2026-01-02T00:00:00.000Z'),
+        timezoneOffsetSeconds: 0,
+        metrics: [{
+            kind: 'value',
+            metricId: HEALTH_METRIC_IDS.Steps,
+            valueType: HEALTH_VALUE_TYPES.Number,
+            aggregation: 'total',
+            semanticVariant: 'provider_daily_summary',
+            origin: HEALTH_VALUE_ORIGINS.ProviderSummary,
+            recordingMethod: HEALTH_RECORDING_METHODS.ProviderCalculated,
+            quality: { status: HEALTH_QUALITY_STATUSES.Valid },
+            normalizationStatus: HEALTH_NORMALIZATION_STATUSES.Canonical,
+            native: { metric: 'steps', value: 100, unit: 'count' },
+            canonical: { value: 100, unit: HEALTH_UNITS.Count },
+        }],
+        coverage: { status: HEALTH_COVERAGE_STATUSES.Complete },
+        sampleSeries: [{
+            seriesKey: 'heart-rate',
+            metricId: HEALTH_METRIC_IDS.HeartRate,
+            valueType: HEALTH_VALUE_TYPES.Number,
+            aggregation: 'sample',
+            semanticVariant: 'device_sample',
+            origin: HEALTH_VALUE_ORIGINS.Recorded,
+            recordingMethod: HEALTH_RECORDING_METHODS.Device,
+            normalizationStatus: HEALTH_NORMALIZATION_STATUSES.Canonical,
+            nativeMetric: 'heartRate',
+            nativeUnit: 'bpm',
+            canonicalUnit: HEALTH_UNITS.BeatsPerMinute,
+            offsetMs: offsets,
+            nativeValues: offsets.map((_, index) => 60 + index),
+            canonicalValues: offsets.map((_, index) => 60 + index),
+            coverage: { status: HEALTH_COVERAGE_STATUSES.Complete },
+        }],
+    };
+}
+
+function recordPath(id: string): string {
+    return `users/user-1/healthRecords/${id}`;
+}
+
+describe('health writer', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        hoisted.deletionGuard.mockResolvedValue({
+            userExists: true,
+            deletionInProgress: false,
+            shouldSkip: false,
+        });
+    });
+
+    it('builds deterministic bounded chunks without persisting the raw provider account ID', async () => {
+        const built = await buildHealthWrite('user-1', validInput(1441), 10_000, fakeId);
+
+        expect(built.chunks).toHaveLength(2);
+        expect(built.chunks[0].offsetMs).toHaveLength(1440);
+        expect(built.chunks[1].offsetMs).toEqual([0]);
+        expect(built.record.sampleChunkIds).toEqual(built.chunks.map(chunk => chunk.id));
+        expect(built.record.metricIds).toEqual([HEALTH_METRIC_IDS.Steps, HEALTH_METRIC_IDS.HeartRate]);
+        expect(JSON.stringify(built)).not.toContain('secret-provider-account');
+        expect(built.record.source.accountKey).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('atomically writes a record and all of its chunks', async () => {
+        const fake = fakeDatabase();
+        const result = await replaceHealthSourceRecord('user-1', validInput(), 10_000, {
+            db: fake.db as never,
+            generateId: fakeId,
+        });
+
+        expect(result).toMatchObject({ status: 'written', chunksWritten: 1, chunksDeleted: 0 });
+        expect(fake.sets).toHaveBeenCalledTimes(2);
+        expect(fake.deletes).not.toHaveBeenCalled();
+        expect(hoisted.deletionGuard).toHaveBeenCalledOnce();
+    });
+
+    it('length-encodes ID inputs so delimiter-bearing provider fields cannot collide', async () => {
+        const first = validInput();
+        first.providerAccountId = 'account:daily';
+        first.sourceRecordType = 'summary';
+        const second = validInput();
+        second.providerAccountId = 'account';
+        second.sourceRecordType = 'daily:summary';
+
+        const [firstBuilt, secondBuilt] = await Promise.all([
+            buildHealthWrite('user-1', first, 10_000, joiningHashId),
+            buildHealthWrite('user-1', second, 10_000, joiningHashId),
+        ]);
+
+        expect(firstBuilt.record.id).not.toBe(secondBuilt.record.id);
+        expect(firstBuilt.record.source.accountKey).not.toBe(secondBuilt.record.source.accountKey);
+    });
+
+    it('treats an identical provider revision as idempotent', async () => {
+        const fake = fakeDatabase();
+        const built = await buildHealthWrite('user-1', validInput(), 9_000, fakeId);
+        fake.stored.set(recordPath(built.record.id), built.record);
+
+        const result = await replaceHealthSourceRecord('user-1', validInput(), 10_000, {
+            db: fake.db as never,
+            generateId: fakeId,
+        });
+
+        expect(result.status).toBe('unchanged');
+        expect(fake.sets).not.toHaveBeenCalled();
+        expect(fake.deletes).not.toHaveBeenCalled();
+    });
+
+    it('ignores a stale lower provider revision', async () => {
+        const fake = fakeDatabase();
+        const built = await buildHealthWrite('user-1', validInput(), 9_000, fakeId);
+        built.record.source.revision.order = 2;
+        fake.stored.set(recordPath(built.record.id), built.record);
+
+        const result = await replaceHealthSourceRecord('user-1', validInput(), 10_000, {
+            db: fake.db as never,
+            generateId: fakeId,
+        });
+
+        expect(result.status).toBe('stale');
+        expect(fake.sets).not.toHaveBeenCalled();
+    });
+
+    it('rejects ambiguous content at the same provider revision order', async () => {
+        const fake = fakeDatabase();
+        const built = await buildHealthWrite('user-1', validInput(), 9_000, fakeId);
+        built.record.source.revision.digest = 'different-digest';
+        fake.stored.set(recordPath(built.record.id), built.record);
+
+        await expect(replaceHealthSourceRecord('user-1', validInput(), 10_000, {
+            db: fake.db as never,
+            generateId: fakeId,
+        })).rejects.toBeInstanceOf(HealthRevisionConflictError);
+        expect(fake.sets).not.toHaveBeenCalled();
+    });
+
+    it('replaces higher revisions and document-deletes only stale leaf chunks', async () => {
+        const fake = fakeDatabase();
+        const input = validInput();
+        const built = await buildHealthWrite('user-1', input, 9_000, fakeId);
+        const staleChunkId = 'a'.repeat(64);
+        built.record.sampleChunkIds = [staleChunkId];
+        fake.stored.set(recordPath(built.record.id), built.record);
+        (input.revision as Record<string, unknown>).order = 2;
+        (input.revision as Record<string, unknown>).token = 'revision-2';
+
+        const result = await replaceHealthSourceRecord('user-1', input, 10_000, {
+            db: fake.db as never,
+            generateId: fakeId,
+        });
+
+        expect(result).toMatchObject({ status: 'written', chunksDeleted: 1 });
+        expect(fake.deletes).toHaveBeenCalledOnce();
+        expect(fake.deletes.mock.calls[0][0].path).toContain(`/healthSampleChunks/${staleChunkId}`);
+    });
+
+    it('does not recreate records when account deletion is active inside the transaction', async () => {
+        const fake = fakeDatabase();
+        hoisted.deletionGuard.mockResolvedValue({ userExists: true, deletionInProgress: true, shouldSkip: true });
+
+        const result = await replaceHealthSourceRecord('user-1', validInput(), 10_000, {
+            db: fake.db as never,
+            generateId: fakeId,
+        });
+
+        expect(result.status).toBe('skipped_deleted_user');
+        expect(fake.transaction.get).not.toHaveBeenCalled();
+        expect(fake.sets).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when a stored record violates the leaf-chunk bound', async () => {
+        const fake = fakeDatabase();
+        const input = validInput();
+        const built = await buildHealthWrite('user-1', input, 9_000, fakeId);
+        built.record.sampleChunkIds = Array.from({ length: 201 }, (_, index) => `old-${index}`);
+        fake.stored.set(recordPath(built.record.id), built.record);
+        (input.revision as Record<string, unknown>).order = 2;
+        (input.revision as Record<string, unknown>).token = 'revision-2';
+
+        await expect(replaceHealthSourceRecord('user-1', input, 10_000, {
+            db: fake.db as never,
+            generateId: fakeId,
+        })).rejects.toThrow('bounded sample-chunk invariant');
+        expect(fake.deletes).not.toHaveBeenCalled();
+        expect(fake.sets).not.toHaveBeenCalled();
+    });
+
+    it('fails closed before deleting a malformed stored chunk path', async () => {
+        const fake = fakeDatabase();
+        const input = validInput();
+        const built = await buildHealthWrite('user-1', input, 9_000, fakeId);
+        built.record.sampleChunkIds = ['nested/path'];
+        fake.stored.set(recordPath(built.record.id), built.record);
+        (input.revision as Record<string, unknown>).order = 2;
+        (input.revision as Record<string, unknown>).token = 'revision-2';
+
+        await expect(replaceHealthSourceRecord('user-1', input, 10_000, {
+            db: fake.db as never,
+            generateId: fakeId,
+        })).rejects.toThrow('bounded sample-chunk invariant');
+        expect(fake.deletes).not.toHaveBeenCalled();
+        expect(fake.sets).not.toHaveBeenCalled();
+    });
+
+    it('preserves an explicit null sample device instead of inheriting record attribution', async () => {
+        const input = validInput();
+        input.device = { manufacturer: 'Garmin', model: 'Watch' };
+        const sampleSeries = input.sampleSeries as Array<Record<string, unknown>>;
+        sampleSeries[0].device = null;
+
+        const built = await buildHealthWrite('user-1', input, 10_000, fakeId);
+
+        expect(built.record.device).toMatchObject({ manufacturer: 'Garmin', model: 'Watch' });
+        expect(built.chunks[0].device).toBeNull();
+    });
+
+    it('writes only opaque sync error codes', async () => {
+        const fake = fakeDatabase();
+        await updateHealthSyncState('user-1', HEALTH_PROVIDERS.COROSAPI, {
+            status: HEALTH_SYNC_STATUSES.Failed,
+            lastErrorCode: 'provider_rate_limited',
+        }, 10_000, { db: fake.db as never });
+
+        expect(fake.sets).toHaveBeenCalledWith(expect.objectContaining({
+            path: 'users/user-1/healthSyncState/COROSAPI',
+        }), expect.objectContaining({
+            status: HEALTH_SYNC_STATUSES.Failed,
+            lastErrorCode: 'provider_rate_limited',
+        }), { merge: true });
+
+        await expect(updateHealthSyncState('user-1', HEALTH_PROVIDERS.COROSAPI, {
+            lastErrorCode: 'raw response with user data',
+        }, 10_000, { db: fake.db as never })).rejects.toThrow('opaque bounded error code');
+    });
+
+    it('defaults new sync state to ready while preserving an existing status on partial updates', async () => {
+        const fresh = fakeDatabase();
+        await updateHealthSyncState('user-1', HEALTH_PROVIDERS.COROSAPI, {
+            lastPollAtMs: 9_000,
+        }, 10_000, { db: fresh.db as never });
+        expect(fresh.sets.mock.calls[0][1]).toMatchObject({
+            status: HEALTH_SYNC_STATUSES.Ready,
+            lastPollAtMs: 9_000,
+        });
+
+        const existing = fakeDatabase();
+        existing.stored.set('users/user-1/healthSyncState/COROSAPI', {
+            provider: HEALTH_PROVIDERS.COROSAPI,
+            status: HEALTH_SYNC_STATUSES.Disconnected,
+        });
+        await updateHealthSyncState('user-1', HEALTH_PROVIDERS.COROSAPI, {
+            lastPollAtMs: 9_000,
+        }, 10_000, { db: existing.db as never });
+        expect(existing.sets.mock.calls[0][1]).toMatchObject({ lastPollAtMs: 9_000 });
+        expect(existing.sets.mock.calls[0][1]).not.toHaveProperty('status');
+    });
+
+    it('retains imported records when a provider is disconnected', async () => {
+        const fake = fakeDatabase();
+        const written = await markHealthProviderDisconnected(
+            'user-1',
+            HEALTH_PROVIDERS.SuuntoApp,
+            10_000,
+            { db: fake.db as never },
+        );
+
+        expect(written).toBe(true);
+        expect(fake.sets).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
+            status: HEALTH_SYNC_STATUSES.Disconnected,
+        }), { merge: true });
+        expect(fake.deletes).not.toHaveBeenCalled();
+    });
+
+    it('preserves the existing record creation time during replacement', async () => {
+        const fake = fakeDatabase();
+        const input = validInput();
+        const built = await buildHealthWrite('user-1', input, 9_000, fakeId);
+        const existing: HealthSourceRecord = { ...built.record, createdAtMs: 0 };
+        fake.stored.set(recordPath(existing.id), existing);
+        (input.revision as Record<string, unknown>).order = 2;
+        (input.revision as Record<string, unknown>).token = 'revision-2';
+
+        const result = await replaceHealthSourceRecord('user-1', input, 10_000, {
+            db: fake.db as never,
+            generateId: fakeId,
+        });
+
+        expect(result.record?.createdAtMs).toBe(0);
+    });
+});

--- a/functions/src/health/writer.spec.ts
+++ b/functions/src/health/writer.spec.ts
@@ -168,6 +168,20 @@ describe('health writer', () => {
         expect(built.sourceRecord.source.accountKey).toMatch(/^[a-f0-9]{64}$/);
     });
 
+    it('persists an opaque source key when an adapter key contains the raw provider account ID', async () => {
+        const input = validInput();
+        input.providerAccountId = 'account-id';
+        input.sourceRecordKey = 'account-id:daily:2026-01-01';
+        (input.revision as Record<string, unknown>).token = 'account-id:revision:1';
+
+        const built = await buildHealthSourceRecordWrite('user-1', input, 10_000, fakeId);
+
+        expect(built.sourceRecord.source.sourceRecordKey).toMatch(/^[a-f0-9]{64}$/);
+        expect(built.sourceRecord.source.sourceRecordKey).not.toBe(input.sourceRecordKey);
+        expect(built.sourceRecord.source.revision.token).toMatch(/^[a-f0-9]{64}$/);
+        expect(JSON.stringify(built)).not.toContain('account-id');
+    });
+
     it('atomically writes a source record and all of its chunks', async () => {
         const fake = fakeDatabase();
         const result = await replaceHealthSourceRecord('user-1', validInput(), 10_000, {
@@ -267,6 +281,29 @@ describe('health writer', () => {
             .toThrow('source record source-record-id');
         expect(() => assertHealthSourceRecordWriteSize(smallRecord, [oversizedChunk]))
             .toThrow('sample chunk sample-chunk-id');
+    });
+
+    it('stops measuring chunks as soon as the cumulative write budget is exceeded', () => {
+        const sourceRecord = {
+            id: 'source-record-id',
+            padding: 'x'.repeat(100 * 1024),
+        } as unknown as HealthSourceRecord;
+        const padding = 'x'.repeat(800 * 1024);
+        const chunks = new Proxy(Array.from({ length: 6 }, (_, index) => ({
+            id: `chunk-${index}`,
+            padding,
+        })) as unknown as HealthSampleChunk[], {
+            get(target, property, receiver) {
+                if (property === '5') {
+                    throw new Error('size validator read beyond the cumulative write budget');
+                }
+                return Reflect.get(target, property, receiver);
+            },
+        });
+
+        expect(() => assertHealthSourceRecordWriteSize(sourceRecord, chunks)).toThrow(HealthWriteSizeError);
+        expect(() => assertHealthSourceRecordWriteSize(sourceRecord, chunks))
+            .toThrow('bounded transaction payload size');
     });
 
     it('treats an identical provider revision as idempotent', async () => {

--- a/functions/src/health/writer.spec.ts
+++ b/functions/src/health/writer.spec.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createHash } from 'node:crypto';
 import {
     HEALTH_COVERAGE_STATUSES,
+    HEALTH_MAX_RECORD_DOCUMENT_BYTES,
+    HEALTH_MAX_SAMPLE_CHUNK_DOCUMENT_BYTES,
+    HEALTH_MAX_WRITE_BYTES,
     HEALTH_METRIC_IDS,
     HEALTH_NORMALIZATION_STATUSES,
     HEALTH_PROVIDERS,
@@ -12,6 +15,7 @@ import {
     HEALTH_UNITS,
     HEALTH_VALUE_ORIGINS,
     HEALTH_VALUE_TYPES,
+    HealthSampleChunk,
     HealthSourceRecord,
 } from '../../../shared/health';
 
@@ -36,6 +40,8 @@ vi.mock('../shared/user-deletion-guard', () => ({
 
 import {
     HealthRevisionConflictError,
+    HealthWriteSizeError,
+    assertHealthWriteSize,
     buildHealthWrite,
     markHealthProviderDisconnected,
     replaceHealthSourceRecord,
@@ -155,8 +161,9 @@ describe('health writer', () => {
         expect(built.chunks).toHaveLength(2);
         expect(built.chunks[0].offsetMs).toHaveLength(1440);
         expect(built.chunks[1].offsetMs).toEqual([0]);
+        expect(built.chunks.map(chunk => chunk.coverage.sampleCount)).toEqual([1441, 1441]);
         expect(built.record.sampleChunkIds).toEqual(built.chunks.map(chunk => chunk.id));
-        expect(built.record.metricIds).toEqual([HEALTH_METRIC_IDS.Steps, HEALTH_METRIC_IDS.HeartRate]);
+        expect(built.record.metricIds).toEqual([HEALTH_METRIC_IDS.HeartRate, HEALTH_METRIC_IDS.Steps]);
         expect(JSON.stringify(built)).not.toContain('secret-provider-account');
         expect(built.record.source.accountKey).toMatch(/^[a-f0-9]{64}$/);
     });
@@ -189,6 +196,67 @@ describe('health writer', () => {
 
         expect(firstBuilt.record.id).not.toBe(secondBuilt.record.id);
         expect(firstBuilt.record.source.accountKey).not.toBe(secondBuilt.record.source.accountKey);
+    });
+
+    it('canonicalizes unordered metric and series collections before digesting and storing', async () => {
+        const first = validInput();
+        const firstMetrics = first.metrics as Array<Record<string, unknown>>;
+        firstMetrics.push({
+            ...firstMetrics[0],
+            semanticVariant: 'secondary_daily_summary',
+            native: { metric: 'secondarySteps', value: 50, unit: 'count' },
+            canonical: { value: 50, unit: HEALTH_UNITS.Count },
+        });
+        const firstSeries = first.sampleSeries as Array<Record<string, unknown>>;
+        firstSeries.push({ ...firstSeries[0], seriesKey: 'heart-rate-secondary' });
+        const second = JSON.parse(JSON.stringify(first)) as Record<string, unknown>;
+        (second.metrics as unknown[]).reverse();
+        (second.sampleSeries as unknown[]).reverse();
+
+        const [firstBuilt, secondBuilt] = await Promise.all([
+            buildHealthWrite('user-1', first, 10_000, fakeId),
+            buildHealthWrite('user-1', second, 10_000, fakeId),
+        ]);
+
+        expect(secondBuilt).toEqual(firstBuilt);
+    });
+
+    it('rejects unsafe user document IDs before constructing Firestore paths', async () => {
+        await expect(buildHealthWrite(' user-1 ', validInput(), 10_000, fakeId))
+            .rejects.toThrow('safe bounded non-empty document ID');
+        await expect(buildHealthWrite('users/other', validInput(), 10_000, fakeId))
+            .rejects.toThrow('safe bounded non-empty document ID');
+    });
+
+    it('bounds one revision below half the Firestore transaction request limit', () => {
+        expect(HEALTH_MAX_WRITE_BYTES).toBe(4 * 1024 * 1024);
+        const record = { id: 'record', padding: 'x'.repeat(100 * 1024) } as unknown as HealthSourceRecord;
+        const padding = 'x'.repeat(800 * 1024);
+        const chunks = Array.from({ length: 5 }, (_, index) => ({
+            id: `chunk-${index}`,
+            padding,
+        })) as unknown as HealthSampleChunk[];
+
+        expect(() => assertHealthWriteSize(record, chunks)).toThrow(HealthWriteSizeError);
+        expect(() => assertHealthWriteSize(record, chunks)).toThrow('bounded transaction payload size');
+    });
+
+    it('uses separate bounded sizes for source records and sample chunks', () => {
+        expect(HEALTH_MAX_RECORD_DOCUMENT_BYTES).toBe(256 * 1024);
+        expect(HEALTH_MAX_SAMPLE_CHUNK_DOCUMENT_BYTES).toBe(900 * 1024);
+
+        const oversizedRecord = {
+            id: 'record',
+            padding: 'x'.repeat(HEALTH_MAX_RECORD_DOCUMENT_BYTES),
+        } as unknown as HealthSourceRecord;
+        const smallRecord = { id: 'record' } as unknown as HealthSourceRecord;
+        const oversizedChunk = {
+            id: 'chunk',
+            padding: 'x'.repeat(HEALTH_MAX_SAMPLE_CHUNK_DOCUMENT_BYTES),
+        } as unknown as HealthSampleChunk;
+
+        expect(() => assertHealthWriteSize(oversizedRecord, [])).toThrow('source record record');
+        expect(() => assertHealthWriteSize(smallRecord, [oversizedChunk])).toThrow('sample chunk chunk');
     });
 
     it('treats an identical provider revision as idempotent', async () => {
@@ -268,6 +336,19 @@ describe('health writer', () => {
         expect(fake.sets).not.toHaveBeenCalled();
     });
 
+    it('fails closed when the account-deletion guard cannot be read', async () => {
+        const fake = fakeDatabase();
+        hoisted.deletionGuard.mockRejectedValueOnce(new Error('Firestore unavailable'));
+
+        await expect(replaceHealthSourceRecord('user-1', validInput(), 10_000, {
+            db: fake.db as never,
+            generateId: fakeId,
+        })).rejects.toThrow('Deletion guard failed');
+        expect(fake.transaction.get).not.toHaveBeenCalled();
+        expect(fake.sets).not.toHaveBeenCalled();
+        expect(fake.deletes).not.toHaveBeenCalled();
+    });
+
     it('fails closed when a stored record violates the leaf-chunk bound', async () => {
         const fake = fakeDatabase();
         const input = validInput();
@@ -314,6 +395,20 @@ describe('health writer', () => {
         expect(built.chunks[0].device).toBeNull();
     });
 
+    it('preserves explicit null sample value and quality arrays', async () => {
+        const input = validInput();
+        const sampleSeries = input.sampleSeries as Array<Record<string, unknown>>;
+        sampleSeries[0].normalizationStatus = HEALTH_NORMALIZATION_STATUSES.NativeOnly;
+        sampleSeries[0].canonicalUnit = null;
+        sampleSeries[0].canonicalValues = null;
+        sampleSeries[0].qualityCodes = null;
+
+        const built = await buildHealthWrite('user-1', input, 10_000, fakeId);
+
+        expect(built.chunks[0].canonicalValues).toBeNull();
+        expect(built.chunks[0].qualityCodes).toBeNull();
+    });
+
     it('writes only opaque sync error codes', async () => {
         const fake = fakeDatabase();
         await updateHealthSyncState('user-1', HEALTH_PROVIDERS.COROSAPI, {
@@ -331,6 +426,34 @@ describe('health writer', () => {
         await expect(updateHealthSyncState('user-1', HEALTH_PROVIDERS.COROSAPI, {
             lastErrorCode: 'raw response with user data',
         }, 10_000, { db: fake.db as never })).rejects.toThrow('opaque bounded error code');
+    });
+
+    it('does not recreate sync state while account deletion is active', async () => {
+        const fake = fakeDatabase();
+        hoisted.deletionGuard.mockResolvedValueOnce({
+            userExists: true,
+            deletionInProgress: true,
+            shouldSkip: true,
+        });
+
+        await expect(updateHealthSyncState('user-1', HEALTH_PROVIDERS.COROSAPI, {
+            status: HEALTH_SYNC_STATUSES.Ready,
+        }, 10_000, { db: fake.db as never })).resolves.toBe(false);
+
+        expect(fake.transaction.get).not.toHaveBeenCalled();
+        expect(fake.sets).not.toHaveBeenCalled();
+    });
+
+    it('fails sync-state writes closed when the deletion guard cannot be read', async () => {
+        const fake = fakeDatabase();
+        hoisted.deletionGuard.mockRejectedValueOnce(new Error('Firestore unavailable'));
+
+        await expect(updateHealthSyncState('user-1', HEALTH_PROVIDERS.COROSAPI, {
+            status: HEALTH_SYNC_STATUSES.Ready,
+        }, 10_000, { db: fake.db as never })).rejects.toThrow('Deletion guard failed');
+
+        expect(fake.transaction.get).not.toHaveBeenCalled();
+        expect(fake.sets).not.toHaveBeenCalled();
     });
 
     it('defaults new sync state to ready while preserving an existing status on partial updates', async () => {
@@ -353,6 +476,36 @@ describe('health writer', () => {
         }, 10_000, { db: existing.db as never });
         expect(existing.sets.mock.calls[0][1]).toMatchObject({ lastPollAtMs: 9_000 });
         expect(existing.sets.mock.calls[0][1]).not.toHaveProperty('status');
+    });
+
+    it('does not let stale sync updates regress connection state or last-seen timestamps', async () => {
+        const fake = fakeDatabase();
+        fake.stored.set('users/user-1/healthSyncState/COROSAPI', {
+            provider: HEALTH_PROVIDERS.COROSAPI,
+            status: HEALTH_SYNC_STATUSES.Disconnected,
+            lastPollAtMs: 12_000,
+            lastObservedAtMs: 11_000,
+            lastSyncedAtMs: 10_000,
+            lastErrorCode: null,
+            updatedAtMs: 13_000,
+        });
+
+        await updateHealthSyncState('user-1', HEALTH_PROVIDERS.COROSAPI, {
+            status: HEALTH_SYNC_STATUSES.Failed,
+            lastPollAtMs: 10_000,
+            lastObservedAtMs: 12_000,
+            lastSyncedAtMs: null,
+            lastErrorCode: 'stale_failure',
+        }, 12_500, { db: fake.db as never });
+
+        expect(fake.sets.mock.calls[0][1]).not.toHaveProperty('status');
+        expect(fake.sets.mock.calls[0][1]).not.toHaveProperty('lastPollAtMs');
+        expect(fake.sets.mock.calls[0][1]).not.toHaveProperty('lastSyncedAtMs');
+        expect(fake.sets.mock.calls[0][1]).not.toHaveProperty('lastErrorCode');
+        expect(fake.sets.mock.calls[0][1]).toMatchObject({
+            lastObservedAtMs: 12_000,
+            updatedAtMs: 13_000,
+        });
     });
 
     it('retains imported records when a provider is disconnected', async () => {

--- a/functions/src/health/writer.spec.ts
+++ b/functions/src/health/writer.spec.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createHash } from 'node:crypto';
 import {
     HEALTH_COVERAGE_STATUSES,
-    HEALTH_MAX_RECORD_DOCUMENT_BYTES,
+    HEALTH_MAX_SOURCE_RECORD_DOCUMENT_BYTES,
     HEALTH_MAX_SAMPLE_CHUNK_DOCUMENT_BYTES,
     HEALTH_MAX_WRITE_BYTES,
     HEALTH_METRIC_IDS,
@@ -10,7 +10,7 @@ import {
     HEALTH_PROVIDERS,
     HEALTH_QUALITY_STATUSES,
     HEALTH_RECORDING_METHODS,
-    HEALTH_RECORD_KINDS,
+    HEALTH_SOURCE_RECORD_KINDS,
     HEALTH_SYNC_STATUSES,
     HEALTH_UNITS,
     HEALTH_VALUE_ORIGINS,
@@ -39,10 +39,10 @@ vi.mock('../shared/user-deletion-guard', () => ({
 }));
 
 import {
-    HealthRevisionConflictError,
+    HealthSourceRecordRevisionConflictError,
     HealthWriteSizeError,
-    assertHealthWriteSize,
-    buildHealthWrite,
+    assertHealthSourceRecordWriteSize,
+    buildHealthSourceRecordWrite,
     markHealthProviderDisconnected,
     replaceHealthSourceRecord,
     updateHealthSyncState,
@@ -102,7 +102,7 @@ function validInput(pointCount = 2): Record<string, unknown> {
         sourceRecordKey: '2026-01-01',
         revision: { order: 1, token: 'revision-1' },
         receivedAtMs: Date.parse('2026-01-02T00:00:00.000Z'),
-        kind: HEALTH_RECORD_KINDS.DailySummary,
+        kind: HEALTH_SOURCE_RECORD_KINDS.DailySummary,
         calendarDate: '2026-01-01',
         startTimeMs: Date.parse('2026-01-01T00:00:00.000Z'),
         endTimeMs: Date.parse('2026-01-02T00:00:00.000Z'),
@@ -141,8 +141,8 @@ function validInput(pointCount = 2): Record<string, unknown> {
     };
 }
 
-function recordPath(id: string): string {
-    return `users/user-1/healthRecords/${id}`;
+function sourceRecordPath(id: string): string {
+    return `users/user-1/healthSourceRecords/${id}`;
 }
 
 describe('health writer', () => {
@@ -156,26 +156,31 @@ describe('health writer', () => {
     });
 
     it('builds deterministic bounded chunks without persisting the raw provider account ID', async () => {
-        const built = await buildHealthWrite('user-1', validInput(1441), 10_000, fakeId);
+        const built = await buildHealthSourceRecordWrite('user-1', validInput(1441), 10_000, fakeId);
 
         expect(built.chunks).toHaveLength(2);
         expect(built.chunks[0].offsetMs).toHaveLength(1440);
         expect(built.chunks[1].offsetMs).toEqual([0]);
         expect(built.chunks.map(chunk => chunk.coverage.sampleCount)).toEqual([1441, 1441]);
-        expect(built.record.sampleChunkIds).toEqual(built.chunks.map(chunk => chunk.id));
-        expect(built.record.metricIds).toEqual([HEALTH_METRIC_IDS.HeartRate, HEALTH_METRIC_IDS.Steps]);
+        expect(built.sourceRecord.sampleChunkIds).toEqual(built.chunks.map(chunk => chunk.id));
+        expect(built.sourceRecord.metricIds).toEqual([HEALTH_METRIC_IDS.HeartRate, HEALTH_METRIC_IDS.Steps]);
         expect(JSON.stringify(built)).not.toContain('secret-provider-account');
-        expect(built.record.source.accountKey).toMatch(/^[a-f0-9]{64}$/);
+        expect(built.sourceRecord.source.accountKey).toMatch(/^[a-f0-9]{64}$/);
     });
 
-    it('atomically writes a record and all of its chunks', async () => {
+    it('atomically writes a source record and all of its chunks', async () => {
         const fake = fakeDatabase();
         const result = await replaceHealthSourceRecord('user-1', validInput(), 10_000, {
             db: fake.db as never,
             generateId: fakeId,
         });
 
-        expect(result).toMatchObject({ status: 'written', chunksWritten: 1, chunksDeleted: 0 });
+        expect(result).toMatchObject({
+            sourceRecordId: expect.stringMatching(/^[a-f0-9]{64}$/),
+            status: 'written',
+            chunksWritten: 1,
+            chunksDeleted: 0,
+        });
         expect(fake.sets).toHaveBeenCalledTimes(2);
         expect(fake.deletes).not.toHaveBeenCalled();
         expect(hoisted.deletionGuard).toHaveBeenCalledOnce();
@@ -190,12 +195,12 @@ describe('health writer', () => {
         second.sourceRecordType = 'daily:summary';
 
         const [firstBuilt, secondBuilt] = await Promise.all([
-            buildHealthWrite('user-1', first, 10_000, joiningHashId),
-            buildHealthWrite('user-1', second, 10_000, joiningHashId),
+            buildHealthSourceRecordWrite('user-1', first, 10_000, joiningHashId),
+            buildHealthSourceRecordWrite('user-1', second, 10_000, joiningHashId),
         ]);
 
-        expect(firstBuilt.record.id).not.toBe(secondBuilt.record.id);
-        expect(firstBuilt.record.source.accountKey).not.toBe(secondBuilt.record.source.accountKey);
+        expect(firstBuilt.sourceRecord.id).not.toBe(secondBuilt.sourceRecord.id);
+        expect(firstBuilt.sourceRecord.source.accountKey).not.toBe(secondBuilt.sourceRecord.source.accountKey);
     });
 
     it('canonicalizes unordered metric and series collections before digesting and storing', async () => {
@@ -214,55 +219,60 @@ describe('health writer', () => {
         (second.sampleSeries as unknown[]).reverse();
 
         const [firstBuilt, secondBuilt] = await Promise.all([
-            buildHealthWrite('user-1', first, 10_000, fakeId),
-            buildHealthWrite('user-1', second, 10_000, fakeId),
+            buildHealthSourceRecordWrite('user-1', first, 10_000, fakeId),
+            buildHealthSourceRecordWrite('user-1', second, 10_000, fakeId),
         ]);
 
         expect(secondBuilt).toEqual(firstBuilt);
     });
 
     it('rejects unsafe user document IDs before constructing Firestore paths', async () => {
-        await expect(buildHealthWrite(' user-1 ', validInput(), 10_000, fakeId))
+        await expect(buildHealthSourceRecordWrite(' user-1 ', validInput(), 10_000, fakeId))
             .rejects.toThrow('safe bounded non-empty document ID');
-        await expect(buildHealthWrite('users/other', validInput(), 10_000, fakeId))
+        await expect(buildHealthSourceRecordWrite('users/other', validInput(), 10_000, fakeId))
             .rejects.toThrow('safe bounded non-empty document ID');
     });
 
     it('bounds one revision below half the Firestore transaction request limit', () => {
         expect(HEALTH_MAX_WRITE_BYTES).toBe(4 * 1024 * 1024);
-        const record = { id: 'record', padding: 'x'.repeat(100 * 1024) } as unknown as HealthSourceRecord;
+        const sourceRecord = {
+            id: 'source-record-id',
+            padding: 'x'.repeat(100 * 1024),
+        } as unknown as HealthSourceRecord;
         const padding = 'x'.repeat(800 * 1024);
         const chunks = Array.from({ length: 5 }, (_, index) => ({
             id: `chunk-${index}`,
             padding,
         })) as unknown as HealthSampleChunk[];
 
-        expect(() => assertHealthWriteSize(record, chunks)).toThrow(HealthWriteSizeError);
-        expect(() => assertHealthWriteSize(record, chunks)).toThrow('bounded transaction payload size');
+        expect(() => assertHealthSourceRecordWriteSize(sourceRecord, chunks)).toThrow(HealthWriteSizeError);
+        expect(() => assertHealthSourceRecordWriteSize(sourceRecord, chunks)).toThrow('bounded transaction payload size');
     });
 
     it('uses separate bounded sizes for source records and sample chunks', () => {
-        expect(HEALTH_MAX_RECORD_DOCUMENT_BYTES).toBe(256 * 1024);
+        expect(HEALTH_MAX_SOURCE_RECORD_DOCUMENT_BYTES).toBe(256 * 1024);
         expect(HEALTH_MAX_SAMPLE_CHUNK_DOCUMENT_BYTES).toBe(900 * 1024);
 
         const oversizedRecord = {
-            id: 'record',
-            padding: 'x'.repeat(HEALTH_MAX_RECORD_DOCUMENT_BYTES),
+            id: 'source-record-id',
+            padding: 'x'.repeat(HEALTH_MAX_SOURCE_RECORD_DOCUMENT_BYTES),
         } as unknown as HealthSourceRecord;
-        const smallRecord = { id: 'record' } as unknown as HealthSourceRecord;
+        const smallRecord = { id: 'source-record-id' } as unknown as HealthSourceRecord;
         const oversizedChunk = {
-            id: 'chunk',
+            id: 'sample-chunk-id',
             padding: 'x'.repeat(HEALTH_MAX_SAMPLE_CHUNK_DOCUMENT_BYTES),
         } as unknown as HealthSampleChunk;
 
-        expect(() => assertHealthWriteSize(oversizedRecord, [])).toThrow('source record record');
-        expect(() => assertHealthWriteSize(smallRecord, [oversizedChunk])).toThrow('sample chunk chunk');
+        expect(() => assertHealthSourceRecordWriteSize(oversizedRecord, []))
+            .toThrow('source record source-record-id');
+        expect(() => assertHealthSourceRecordWriteSize(smallRecord, [oversizedChunk]))
+            .toThrow('sample chunk sample-chunk-id');
     });
 
     it('treats an identical provider revision as idempotent', async () => {
         const fake = fakeDatabase();
-        const built = await buildHealthWrite('user-1', validInput(), 9_000, fakeId);
-        fake.stored.set(recordPath(built.record.id), built.record);
+        const built = await buildHealthSourceRecordWrite('user-1', validInput(), 9_000, fakeId);
+        fake.stored.set(sourceRecordPath(built.sourceRecord.id), built.sourceRecord);
 
         const result = await replaceHealthSourceRecord('user-1', validInput(), 10_000, {
             db: fake.db as never,
@@ -276,9 +286,9 @@ describe('health writer', () => {
 
     it('ignores a stale lower provider revision', async () => {
         const fake = fakeDatabase();
-        const built = await buildHealthWrite('user-1', validInput(), 9_000, fakeId);
-        built.record.source.revision.order = 2;
-        fake.stored.set(recordPath(built.record.id), built.record);
+        const built = await buildHealthSourceRecordWrite('user-1', validInput(), 9_000, fakeId);
+        built.sourceRecord.source.revision.order = 2;
+        fake.stored.set(sourceRecordPath(built.sourceRecord.id), built.sourceRecord);
 
         const result = await replaceHealthSourceRecord('user-1', validInput(), 10_000, {
             db: fake.db as never,
@@ -291,24 +301,24 @@ describe('health writer', () => {
 
     it('rejects ambiguous content at the same provider revision order', async () => {
         const fake = fakeDatabase();
-        const built = await buildHealthWrite('user-1', validInput(), 9_000, fakeId);
-        built.record.source.revision.digest = 'different-digest';
-        fake.stored.set(recordPath(built.record.id), built.record);
+        const built = await buildHealthSourceRecordWrite('user-1', validInput(), 9_000, fakeId);
+        built.sourceRecord.source.revision.digest = 'different-digest';
+        fake.stored.set(sourceRecordPath(built.sourceRecord.id), built.sourceRecord);
 
         await expect(replaceHealthSourceRecord('user-1', validInput(), 10_000, {
             db: fake.db as never,
             generateId: fakeId,
-        })).rejects.toBeInstanceOf(HealthRevisionConflictError);
+        })).rejects.toBeInstanceOf(HealthSourceRecordRevisionConflictError);
         expect(fake.sets).not.toHaveBeenCalled();
     });
 
     it('replaces higher revisions and document-deletes only stale leaf chunks', async () => {
         const fake = fakeDatabase();
         const input = validInput();
-        const built = await buildHealthWrite('user-1', input, 9_000, fakeId);
+        const built = await buildHealthSourceRecordWrite('user-1', input, 9_000, fakeId);
         const staleChunkId = 'a'.repeat(64);
-        built.record.sampleChunkIds = [staleChunkId];
-        fake.stored.set(recordPath(built.record.id), built.record);
+        built.sourceRecord.sampleChunkIds = [staleChunkId];
+        fake.stored.set(sourceRecordPath(built.sourceRecord.id), built.sourceRecord);
         (input.revision as Record<string, unknown>).order = 2;
         (input.revision as Record<string, unknown>).token = 'revision-2';
 
@@ -322,7 +332,7 @@ describe('health writer', () => {
         expect(fake.deletes.mock.calls[0][0].path).toContain(`/healthSampleChunks/${staleChunkId}`);
     });
 
-    it('does not recreate records when account deletion is active inside the transaction', async () => {
+    it('does not recreate source records when account deletion is active inside the transaction', async () => {
         const fake = fakeDatabase();
         hoisted.deletionGuard.mockResolvedValue({ userExists: true, deletionInProgress: true, shouldSkip: true });
 
@@ -349,12 +359,12 @@ describe('health writer', () => {
         expect(fake.deletes).not.toHaveBeenCalled();
     });
 
-    it('fails closed when a stored record violates the leaf-chunk bound', async () => {
+    it('fails closed when a stored source record violates the leaf-chunk bound', async () => {
         const fake = fakeDatabase();
         const input = validInput();
-        const built = await buildHealthWrite('user-1', input, 9_000, fakeId);
-        built.record.sampleChunkIds = Array.from({ length: 201 }, (_, index) => `old-${index}`);
-        fake.stored.set(recordPath(built.record.id), built.record);
+        const built = await buildHealthSourceRecordWrite('user-1', input, 9_000, fakeId);
+        built.sourceRecord.sampleChunkIds = Array.from({ length: 201 }, (_, index) => `old-${index}`);
+        fake.stored.set(sourceRecordPath(built.sourceRecord.id), built.sourceRecord);
         (input.revision as Record<string, unknown>).order = 2;
         (input.revision as Record<string, unknown>).token = 'revision-2';
 
@@ -369,9 +379,9 @@ describe('health writer', () => {
     it('fails closed before deleting a malformed stored chunk path', async () => {
         const fake = fakeDatabase();
         const input = validInput();
-        const built = await buildHealthWrite('user-1', input, 9_000, fakeId);
-        built.record.sampleChunkIds = ['nested/path'];
-        fake.stored.set(recordPath(built.record.id), built.record);
+        const built = await buildHealthSourceRecordWrite('user-1', input, 9_000, fakeId);
+        built.sourceRecord.sampleChunkIds = ['nested/path'];
+        fake.stored.set(sourceRecordPath(built.sourceRecord.id), built.sourceRecord);
         (input.revision as Record<string, unknown>).order = 2;
         (input.revision as Record<string, unknown>).token = 'revision-2';
 
@@ -383,15 +393,15 @@ describe('health writer', () => {
         expect(fake.sets).not.toHaveBeenCalled();
     });
 
-    it('preserves an explicit null sample device instead of inheriting record attribution', async () => {
+    it('preserves an explicit null sample device instead of inheriting source-record attribution', async () => {
         const input = validInput();
         input.device = { manufacturer: 'Garmin', model: 'Watch' };
         const sampleSeries = input.sampleSeries as Array<Record<string, unknown>>;
         sampleSeries[0].device = null;
 
-        const built = await buildHealthWrite('user-1', input, 10_000, fakeId);
+        const built = await buildHealthSourceRecordWrite('user-1', input, 10_000, fakeId);
 
-        expect(built.record.device).toMatchObject({ manufacturer: 'Garmin', model: 'Watch' });
+        expect(built.sourceRecord.device).toMatchObject({ manufacturer: 'Garmin', model: 'Watch' });
         expect(built.chunks[0].device).toBeNull();
     });
 
@@ -403,7 +413,7 @@ describe('health writer', () => {
         sampleSeries[0].canonicalValues = null;
         sampleSeries[0].qualityCodes = null;
 
-        const built = await buildHealthWrite('user-1', input, 10_000, fakeId);
+        const built = await buildHealthSourceRecordWrite('user-1', input, 10_000, fakeId);
 
         expect(built.chunks[0].canonicalValues).toBeNull();
         expect(built.chunks[0].qualityCodes).toBeNull();
@@ -508,7 +518,7 @@ describe('health writer', () => {
         });
     });
 
-    it('retains imported records when a provider is disconnected', async () => {
+    it('retains imported source records when a provider is disconnected', async () => {
         const fake = fakeDatabase();
         const written = await markHealthProviderDisconnected(
             'user-1',
@@ -524,12 +534,12 @@ describe('health writer', () => {
         expect(fake.deletes).not.toHaveBeenCalled();
     });
 
-    it('preserves the existing record creation time during replacement', async () => {
+    it('preserves the existing source-record creation time during replacement', async () => {
         const fake = fakeDatabase();
         const input = validInput();
-        const built = await buildHealthWrite('user-1', input, 9_000, fakeId);
-        const existing: HealthSourceRecord = { ...built.record, createdAtMs: 0 };
-        fake.stored.set(recordPath(existing.id), existing);
+        const built = await buildHealthSourceRecordWrite('user-1', input, 9_000, fakeId);
+        const existing: HealthSourceRecord = { ...built.sourceRecord, createdAtMs: 0 };
+        fake.stored.set(sourceRecordPath(existing.id), existing);
         (input.revision as Record<string, unknown>).order = 2;
         (input.revision as Record<string, unknown>).token = 'revision-2';
 
@@ -538,6 +548,6 @@ describe('health writer', () => {
             generateId: fakeId,
         });
 
-        expect(result.record?.createdAtMs).toBe(0);
+        expect(result.sourceRecord?.createdAtMs).toBe(0);
     });
 });

--- a/functions/src/health/writer.ts
+++ b/functions/src/health/writer.ts
@@ -1,8 +1,9 @@
 import * as admin from 'firebase-admin';
 import * as logger from 'firebase-functions/logger';
 import {
-    HEALTH_MAX_DOCUMENT_BYTES,
+    HEALTH_MAX_RECORD_DOCUMENT_BYTES,
     HEALTH_MAX_SAMPLE_CHUNKS_PER_RECORD,
+    HEALTH_MAX_SAMPLE_CHUNK_DOCUMENT_BYTES,
     HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK,
     HEALTH_MAX_WRITE_BYTES,
     HEALTH_PROVIDERS,
@@ -89,6 +90,27 @@ function stableComparableValue(value: unknown): unknown {
     }, {});
 }
 
+function stableValueKey(value: unknown): string {
+    return JSON.stringify(stableComparableValue(value));
+}
+
+function sortStableValues<T>(values: readonly T[]): T[] {
+    return values
+        .map((value, index) => ({ value, index, key: stableValueKey(value) }))
+        .sort((left, right) => (
+            left.key < right.key ? -1 : left.key > right.key ? 1 : left.index - right.index
+        ))
+        .map(item => item.value);
+}
+
+function canonicalizeInput(input: HealthSourceRecordInput): HealthSourceRecordInput {
+    return {
+        ...input,
+        metrics: sortStableValues(input.metrics),
+        sampleSeries: sortStableValues(input.sampleSeries),
+    };
+}
+
 async function generateOpaqueId(generateId: HealthIdGenerator, parts: readonly string[]): Promise<string> {
     // One length-preserving JSON part avoids delimiter collisions inside the shared ID generator.
     const id = await generateId([JSON.stringify(parts)]);
@@ -99,8 +121,12 @@ async function generateOpaqueId(generateId: HealthIdGenerator, parts: readonly s
 }
 
 function validateWriteContext(userID: string, nowMs: number): void {
-    if (typeof userID !== 'string' || userID.trim().length === 0 || userID.length > 128) {
-        throw new HealthWriteValidationError('userID must be a bounded non-empty string.');
+    if (typeof userID !== 'string'
+        || userID.trim().length === 0
+        || userID !== userID.trim()
+        || userID.includes('/')
+        || userID.length > 128) {
+        throw new HealthWriteValidationError('userID must be a safe bounded non-empty document ID.');
     }
     if (!Number.isSafeInteger(nowMs) || nowMs < 0) {
         throw new HealthWriteValidationError('nowMs must be a non-negative safe integer.');
@@ -108,16 +134,24 @@ function validateWriteContext(userID: string, nowMs: number): void {
 }
 
 function documentBytes(value: unknown): number {
-    return Buffer.byteLength(JSON.stringify(cleanUndefined(value)), 'utf8');
+    const serialized = JSON.stringify(value);
+    if (typeof serialized !== 'string') {
+        throw new HealthWriteSizeError('Health document could not be serialized for bounded-size validation.');
+    }
+    return Buffer.byteLength(serialized, 'utf8');
 }
 
 export function assertHealthWriteSize(record: HealthSourceRecord, chunks: readonly HealthSampleChunk[]): void {
-    const documents = [record, ...chunks];
-    const oversizedDocument = documents.find(document => documentBytes(document) > HEALTH_MAX_DOCUMENT_BYTES);
-    if (oversizedDocument) {
-        throw new HealthWriteSizeError(`Health document ${oversizedDocument.id} exceeds the bounded document size.`);
+    const recordBytes = documentBytes(record);
+    if (recordBytes > HEALTH_MAX_RECORD_DOCUMENT_BYTES) {
+        throw new HealthWriteSizeError(`Health source record ${record.id} exceeds the bounded document size.`);
     }
-    const totalBytes = documents.reduce((total, document) => total + documentBytes(document), 0);
+    const chunkSizes = chunks.map(chunk => ({ chunk, bytes: documentBytes(chunk) }));
+    const oversizedChunk = chunkSizes.find(item => item.bytes > HEALTH_MAX_SAMPLE_CHUNK_DOCUMENT_BYTES);
+    if (oversizedChunk) {
+        throw new HealthWriteSizeError(`Health sample chunk ${oversizedChunk.chunk.id} exceeds the bounded document size.`);
+    }
+    const totalBytes = recordBytes + chunkSizes.reduce((total, item) => total + item.bytes, 0);
     if (totalBytes > HEALTH_MAX_WRITE_BYTES) {
         throw new HealthWriteSizeError('Health record replacement exceeds the bounded transaction payload size.');
     }
@@ -147,7 +181,7 @@ export async function buildHealthWrite(
     generateId: HealthIdGenerator = generateIDFromParts,
 ): Promise<BuiltHealthWrite> {
     validateWriteContext(userID, nowMs);
-    const input = validateHealthSourceRecordInput(value);
+    const input = canonicalizeInput(validateHealthSourceRecordInput(value));
     const accountKey = await generateOpaqueId(generateId, [
         'health-account-v1',
         userID,
@@ -206,17 +240,19 @@ export async function buildHealthWrite(
                 calendarDate: input.calendarDate,
                 startTimeMs: input.startTimeMs + firstOffsetMs,
                 endTimeMs: input.startTimeMs + firstOffsetMs + (offsetMs[offsetMs.length - 1] || 0),
+                receivedAtMs: input.receivedAtMs,
                 timezoneOffsetSeconds: input.timezoneOffsetSeconds,
                 seriesKey: series.seriesKey,
                 chunkIndex,
                 offsetMs,
                 nativeValues: series.nativeValues.slice(sliceStart, sliceEnd),
-                canonicalValues: series.canonicalValues?.slice(sliceStart, sliceEnd),
-                qualityCodes: series.qualityCodes?.slice(sliceStart, sliceEnd),
-                coverage: {
-                    ...series.coverage,
-                    sampleCount: offsetMs.length,
-                },
+                canonicalValues: series.canonicalValues === null
+                    ? null
+                    : series.canonicalValues?.slice(sliceStart, sliceEnd),
+                qualityCodes: series.qualityCodes === null
+                    ? null
+                    : series.qualityCodes?.slice(sliceStart, sliceEnd),
+                coverage: series.coverage,
                 device: series.device === undefined ? input.device : series.device,
                 revision,
                 createdAtMs: nowMs,
@@ -229,7 +265,7 @@ export async function buildHealthWrite(
     const metricIds = [...new Set([
         ...input.metrics.map(metric => metric.metricId),
         ...input.sampleSeries.map(series => series.metricId),
-    ])];
+    ])].sort();
     const record: HealthSourceRecord = {
         schemaVersion: HEALTH_SCHEMA_VERSION,
         id,
@@ -381,6 +417,22 @@ function optionalSyncTime(value: unknown, field: string): number | null | undefi
     return value;
 }
 
+function monotonicSyncTime(
+    incoming: number | null | undefined,
+    existing: unknown,
+    staleUpdate: boolean,
+): number | null | undefined {
+    if (staleUpdate && incoming === null) {
+        return undefined;
+    }
+    if (incoming === null || incoming === undefined) {
+        return incoming;
+    }
+    return typeof existing === 'number' && Number.isSafeInteger(existing) && existing > incoming
+        ? undefined
+        : incoming;
+}
+
 function validateSyncUpdate(provider: unknown, value: unknown): { provider: HealthProvider; update: HealthSyncStateUpdate } {
     if (!isHealthProvider(provider) || provider === HEALTH_PROVIDERS.QuantifiedSelf) {
         throw new HealthWriteValidationError('Health sync provider is not supported.');
@@ -443,11 +495,29 @@ export async function updateHealthSyncState(
             return false;
         }
         const snapshot = await transaction.get(stateRef);
+        const existing = snapshot.exists
+            ? snapshot.data() as Partial<HealthSyncState>
+            : null;
+        const existingUpdatedAtMs = typeof existing?.updatedAtMs === 'number'
+            && Number.isSafeInteger(existing.updatedAtMs)
+            ? existing.updatedAtMs
+            : null;
+        const staleUpdate = existingUpdatedAtMs !== null && existingUpdatedAtMs > nowMs;
+        const updatedAtMs = existingUpdatedAtMs === null
+            ? nowMs
+            : Math.max(existingUpdatedAtMs, nowMs);
         const state: Partial<HealthSyncState> & Pick<HealthSyncState, 'provider' | 'updatedAtMs'> = cleanUndefined({
             provider,
             ...update,
-            status: update.status ?? (snapshot.exists ? undefined : HEALTH_SYNC_STATUSES.Ready),
-            updatedAtMs: nowMs,
+            status: staleUpdate
+                ? undefined
+                : update.status ?? (snapshot.exists ? undefined : HEALTH_SYNC_STATUSES.Ready),
+            lastWebhookAtMs: monotonicSyncTime(update.lastWebhookAtMs, existing?.lastWebhookAtMs, staleUpdate),
+            lastPollAtMs: monotonicSyncTime(update.lastPollAtMs, existing?.lastPollAtMs, staleUpdate),
+            lastSyncedAtMs: monotonicSyncTime(update.lastSyncedAtMs, existing?.lastSyncedAtMs, staleUpdate),
+            lastObservedAtMs: monotonicSyncTime(update.lastObservedAtMs, existing?.lastObservedAtMs, staleUpdate),
+            lastErrorCode: staleUpdate ? undefined : update.lastErrorCode,
+            updatedAtMs,
         });
         transaction.set(stateRef, state, { merge: true });
         return true;

--- a/functions/src/health/writer.ts
+++ b/functions/src/health/writer.ts
@@ -26,9 +26,12 @@ import {
 import { generateIDFromParts } from '../shared/id-generator';
 import {
     HealthSourceRecordInput,
+    HealthWriteSizeError,
     HealthWriteValidationError,
     validateHealthSourceRecordInput,
 } from './validation';
+
+export { HealthWriteSizeError } from './validation';
 
 type HealthIdGenerator = (parts: string[]) => Promise<string>;
 const OPAQUE_ID_PATTERN = /^[a-f0-9]{64}$/;
@@ -54,14 +57,6 @@ export class HealthSourceRecordRevisionConflictError extends Error {
 
     constructor(public readonly sourceRecordId: string) {
         super(`Health source record ${sourceRecordId} has conflicting content for the same provider revision order.`);
-    }
-}
-
-export class HealthWriteSizeError extends HealthWriteValidationError {
-    public readonly name = 'HealthWriteSizeError';
-
-    constructor(message: string) {
-        super(message);
     }
 }
 
@@ -149,15 +144,22 @@ export function assertHealthSourceRecordWriteSize(
     if (sourceRecordBytes > HEALTH_MAX_SOURCE_RECORD_DOCUMENT_BYTES) {
         throw new HealthWriteSizeError(`Health source record ${sourceRecord.id} exceeds the bounded document size.`);
     }
-    const chunkSizes = chunks.map(chunk => ({ chunk, bytes: documentBytes(chunk) }));
-    const oversizedChunk = chunkSizes.find(item => item.bytes > HEALTH_MAX_SAMPLE_CHUNK_DOCUMENT_BYTES);
-    if (oversizedChunk) {
-        throw new HealthWriteSizeError(`Health sample chunk ${oversizedChunk.chunk.id} exceeds the bounded document size.`);
+    let totalBytes = sourceRecordBytes;
+    for (const chunk of chunks) {
+        totalBytes = addHealthSampleChunkWriteBytes(totalBytes, chunk);
     }
-    const totalBytes = sourceRecordBytes + chunkSizes.reduce((total, item) => total + item.bytes, 0);
-    if (totalBytes > HEALTH_MAX_WRITE_BYTES) {
+}
+
+function addHealthSampleChunkWriteBytes(totalBytes: number, chunk: HealthSampleChunk): number {
+    const chunkBytes = documentBytes(chunk);
+    if (chunkBytes > HEALTH_MAX_SAMPLE_CHUNK_DOCUMENT_BYTES) {
+        throw new HealthWriteSizeError(`Health sample chunk ${chunk.id} exceeds the bounded document size.`);
+    }
+    const nextBytes = totalBytes + chunkBytes;
+    if (nextBytes > HEALTH_MAX_WRITE_BYTES) {
         throw new HealthWriteSizeError('Health source-record replacement exceeds the bounded transaction payload size.');
     }
+    return nextBytes;
 }
 
 function digestPayload(input: HealthSourceRecordInput): unknown {
@@ -191,6 +193,14 @@ export async function buildHealthSourceRecordWrite(
         input.provider,
         input.providerAccountId,
     ]);
+    const opaqueSourceRecordKey = await generateOpaqueId(generateId, [
+        'health-source-key-v1',
+        userID,
+        input.provider,
+        accountKey,
+        input.sourceRecordType,
+        input.sourceRecordKey,
+    ]);
     const id = await generateOpaqueId(generateId, [
         'health-source-record-v1',
         userID,
@@ -203,14 +213,20 @@ export async function buildHealthSourceRecordWrite(
         'health-source-record-content-v1',
         JSON.stringify(digestPayload(input)),
     ]);
+    const opaqueRevisionToken = await generateOpaqueId(generateId, [
+        'health-revision-token-v1',
+        id,
+        input.revision.token,
+    ]);
     const revision = {
         order: input.revision.order,
-        token: input.revision.token,
+        token: opaqueRevisionToken,
         digest,
     };
 
-    const chunkGroups = await Promise.all(input.sampleSeries.map(async (series) => {
-        const chunks: HealthSampleChunk[] = [];
+    const chunks: HealthSampleChunk[] = [];
+    let chunkWriteBytes = 0;
+    for (const series of input.sampleSeries) {
         const chunkCount = Math.ceil(series.offsetMs.length / HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK);
         for (let chunkIndex = 0; chunkIndex < chunkCount; chunkIndex += 1) {
             const sliceStart = chunkIndex * HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK;
@@ -223,7 +239,7 @@ export async function buildHealthSourceRecordWrite(
                 series.seriesKey,
                 String(chunkIndex),
             ]);
-            chunks.push({
+            const chunk = cleanUndefined<HealthSampleChunk>({
                 schemaVersion: HEALTH_SCHEMA_VERSION,
                 id: chunkId,
                 userID,
@@ -261,15 +277,15 @@ export async function buildHealthSourceRecordWrite(
                 createdAtMs: nowMs,
                 updatedAtMs: nowMs,
             });
+            chunkWriteBytes = addHealthSampleChunkWriteBytes(chunkWriteBytes, chunk);
+            chunks.push(chunk);
         }
-        return chunks;
-    }));
-    const chunks = chunkGroups.flat();
+    }
     const metricIds = [...new Set([
         ...input.metrics.map(metric => metric.metricId),
         ...input.sampleSeries.map(series => series.metricId),
     ])].sort();
-    const sourceRecord: HealthSourceRecord = {
+    const sourceRecord = cleanUndefined<HealthSourceRecord>({
         schemaVersion: HEALTH_SCHEMA_VERSION,
         id,
         userID,
@@ -278,7 +294,7 @@ export async function buildHealthSourceRecordWrite(
             provider: input.provider,
             accountKey,
             sourceRecordType: input.sourceRecordType,
-            sourceRecordKey: input.sourceRecordKey,
+            sourceRecordKey: opaqueSourceRecordKey,
             revision,
             receivedAtMs: input.receivedAtMs,
         },
@@ -293,10 +309,9 @@ export async function buildHealthSourceRecordWrite(
         sampleChunkIds: chunks.map(chunk => chunk.id),
         createdAtMs: nowMs,
         updatedAtMs: nowMs,
-    };
-    const result = cleanUndefined({ sourceRecord, chunks });
-    assertHealthSourceRecordWriteSize(result.sourceRecord, result.chunks);
-    return result;
+    });
+    assertHealthSourceRecordWriteSize(sourceRecord, chunks);
+    return { sourceRecord, chunks };
 }
 
 function userHealthCollection(

--- a/functions/src/health/writer.ts
+++ b/functions/src/health/writer.ts
@@ -1,13 +1,13 @@
 import * as admin from 'firebase-admin';
 import * as logger from 'firebase-functions/logger';
 import {
-    HEALTH_MAX_RECORD_DOCUMENT_BYTES,
-    HEALTH_MAX_SAMPLE_CHUNKS_PER_RECORD,
+    HEALTH_MAX_SAMPLE_CHUNKS_PER_SOURCE_RECORD,
     HEALTH_MAX_SAMPLE_CHUNK_DOCUMENT_BYTES,
     HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK,
+    HEALTH_MAX_SOURCE_RECORD_DOCUMENT_BYTES,
     HEALTH_MAX_WRITE_BYTES,
     HEALTH_PROVIDERS,
-    HEALTH_RECORDS_COLLECTION_ID,
+    HEALTH_SOURCE_RECORDS_COLLECTION_ID,
     HEALTH_SAMPLE_CHUNKS_COLLECTION_ID,
     HEALTH_SCHEMA_VERSION,
     HEALTH_SYNC_STATE_COLLECTION_ID,
@@ -38,22 +38,22 @@ export interface HealthWriterDependencies {
     generateId?: HealthIdGenerator;
 }
 
-export type HealthRecordWriteStatus = 'written' | 'unchanged' | 'stale' | 'skipped_deleted_user';
+export type HealthSourceRecordWriteStatus = 'written' | 'unchanged' | 'stale' | 'skipped_deleted_user';
 
-export interface HealthRecordWriteResult {
-    id: string;
-    status: HealthRecordWriteStatus;
-    record: HealthSourceRecord | null;
+export interface HealthSourceRecordWriteResult {
+    sourceRecordId: string;
+    status: HealthSourceRecordWriteStatus;
+    sourceRecord: HealthSourceRecord | null;
     chunksWritten: number;
     chunksDeleted: number;
 }
 
-export class HealthRevisionConflictError extends Error {
-    public readonly name = 'HealthRevisionConflictError';
-    public readonly code = 'health_revision_conflict';
+export class HealthSourceRecordRevisionConflictError extends Error {
+    public readonly name = 'HealthSourceRecordRevisionConflictError';
+    public readonly code = 'health_source_record_revision_conflict';
 
-    constructor(public readonly recordId: string) {
-        super(`Health record ${recordId} has conflicting content for the same provider revision order.`);
+    constructor(public readonly sourceRecordId: string) {
+        super(`Health source record ${sourceRecordId} has conflicting content for the same provider revision order.`);
     }
 }
 
@@ -65,8 +65,8 @@ export class HealthWriteSizeError extends HealthWriteValidationError {
     }
 }
 
-export interface BuiltHealthWrite {
-    record: HealthSourceRecord;
+export interface BuiltHealthSourceRecordWrite {
+    sourceRecord: HealthSourceRecord;
     chunks: HealthSampleChunk[];
 }
 
@@ -141,19 +141,22 @@ function documentBytes(value: unknown): number {
     return Buffer.byteLength(serialized, 'utf8');
 }
 
-export function assertHealthWriteSize(record: HealthSourceRecord, chunks: readonly HealthSampleChunk[]): void {
-    const recordBytes = documentBytes(record);
-    if (recordBytes > HEALTH_MAX_RECORD_DOCUMENT_BYTES) {
-        throw new HealthWriteSizeError(`Health source record ${record.id} exceeds the bounded document size.`);
+export function assertHealthSourceRecordWriteSize(
+    sourceRecord: HealthSourceRecord,
+    chunks: readonly HealthSampleChunk[],
+): void {
+    const sourceRecordBytes = documentBytes(sourceRecord);
+    if (sourceRecordBytes > HEALTH_MAX_SOURCE_RECORD_DOCUMENT_BYTES) {
+        throw new HealthWriteSizeError(`Health source record ${sourceRecord.id} exceeds the bounded document size.`);
     }
     const chunkSizes = chunks.map(chunk => ({ chunk, bytes: documentBytes(chunk) }));
     const oversizedChunk = chunkSizes.find(item => item.bytes > HEALTH_MAX_SAMPLE_CHUNK_DOCUMENT_BYTES);
     if (oversizedChunk) {
         throw new HealthWriteSizeError(`Health sample chunk ${oversizedChunk.chunk.id} exceeds the bounded document size.`);
     }
-    const totalBytes = recordBytes + chunkSizes.reduce((total, item) => total + item.bytes, 0);
+    const totalBytes = sourceRecordBytes + chunkSizes.reduce((total, item) => total + item.bytes, 0);
     if (totalBytes > HEALTH_MAX_WRITE_BYTES) {
-        throw new HealthWriteSizeError('Health record replacement exceeds the bounded transaction payload size.');
+        throw new HealthWriteSizeError('Health source-record replacement exceeds the bounded transaction payload size.');
     }
 }
 
@@ -174,12 +177,12 @@ function digestPayload(input: HealthSourceRecordInput): unknown {
     });
 }
 
-export async function buildHealthWrite(
+export async function buildHealthSourceRecordWrite(
     userID: string,
     value: unknown,
     nowMs = Date.now(),
     generateId: HealthIdGenerator = generateIDFromParts,
-): Promise<BuiltHealthWrite> {
+): Promise<BuiltHealthSourceRecordWrite> {
     validateWriteContext(userID, nowMs);
     const input = canonicalizeInput(validateHealthSourceRecordInput(value));
     const accountKey = await generateOpaqueId(generateId, [
@@ -189,7 +192,7 @@ export async function buildHealthWrite(
         input.providerAccountId,
     ]);
     const id = await generateOpaqueId(generateId, [
-        'health-record-v1',
+        'health-source-record-v1',
         userID,
         input.provider,
         input.providerAccountId,
@@ -197,7 +200,7 @@ export async function buildHealthWrite(
         input.sourceRecordKey,
     ]);
     const digest = await generateOpaqueId(generateId, [
-        'health-record-content-v1',
+        'health-source-record-content-v1',
         JSON.stringify(digestPayload(input)),
     ]);
     const revision = {
@@ -224,7 +227,7 @@ export async function buildHealthWrite(
                 schemaVersion: HEALTH_SCHEMA_VERSION,
                 id: chunkId,
                 userID,
-                parentRecordId: id,
+                parentSourceRecordId: id,
                 provider: input.provider,
                 accountKey,
                 metricId: series.metricId,
@@ -266,7 +269,7 @@ export async function buildHealthWrite(
         ...input.metrics.map(metric => metric.metricId),
         ...input.sampleSeries.map(series => series.metricId),
     ])].sort();
-    const record: HealthSourceRecord = {
+    const sourceRecord: HealthSourceRecord = {
         schemaVersion: HEALTH_SCHEMA_VERSION,
         id,
         userID,
@@ -291,8 +294,8 @@ export async function buildHealthWrite(
         createdAtMs: nowMs,
         updatedAtMs: nowMs,
     };
-    const result = cleanUndefined({ record, chunks });
-    assertHealthWriteSize(result.record, result.chunks);
+    const result = cleanUndefined({ sourceRecord, chunks });
+    assertHealthSourceRecordWriteSize(result.sourceRecord, result.chunks);
     return result;
 }
 
@@ -309,10 +312,19 @@ export async function replaceHealthSourceRecord(
     value: unknown,
     nowMs = Date.now(),
     dependencies: HealthWriterDependencies = {},
-): Promise<HealthRecordWriteResult> {
+): Promise<HealthSourceRecordWriteResult> {
     const db = dependencies.db || admin.firestore();
-    const built = await buildHealthWrite(userID, value, nowMs, dependencies.generateId || generateIDFromParts);
-    const recordRef = userHealthCollection(db, userID, HEALTH_RECORDS_COLLECTION_ID).doc(built.record.id);
+    const built = await buildHealthSourceRecordWrite(
+        userID,
+        value,
+        nowMs,
+        dependencies.generateId || generateIDFromParts,
+    );
+    const sourceRecordRef = userHealthCollection(
+        db,
+        userID,
+        HEALTH_SOURCE_RECORDS_COLLECTION_ID,
+    ).doc(built.sourceRecord.id);
     const chunkCollection = userHealthCollection(db, userID, HEALTH_SAMPLE_CHUNKS_COLLECTION_ID);
 
     const result = await db.runTransaction(async transaction => {
@@ -320,52 +332,56 @@ export async function replaceHealthSourceRecord(
         try {
             deletionGuard = await getUserDeletionGuardStateInTransaction(db, transaction, userID, nowMs);
         } catch (error) {
-            throw new UserDeletionGuardReadError(userID, 'health_record_write', error);
+            throw new UserDeletionGuardReadError(userID, 'health_source_record_write', error);
         }
         if (deletionGuard.shouldSkip) {
             return {
-                id: built.record.id,
+                sourceRecordId: built.sourceRecord.id,
                 status: 'skipped_deleted_user' as const,
-                record: null,
+                sourceRecord: null,
                 chunksWritten: 0,
                 chunksDeleted: 0,
             };
         }
 
-        const snapshot = await transaction.get(recordRef);
-        const existing = snapshot.exists ? snapshot.data() as HealthSourceRecord : null;
-        if (existing && existing.source.revision.order > built.record.source.revision.order) {
+        const snapshot = await transaction.get(sourceRecordRef);
+        const existingSourceRecord = snapshot.exists ? snapshot.data() as HealthSourceRecord : null;
+        if (existingSourceRecord
+            && existingSourceRecord.source.revision.order > built.sourceRecord.source.revision.order) {
             return {
-                id: existing.id,
+                sourceRecordId: existingSourceRecord.id,
                 status: 'stale' as const,
-                record: existing,
+                sourceRecord: existingSourceRecord,
                 chunksWritten: 0,
                 chunksDeleted: 0,
             };
         }
-        if (existing && existing.source.revision.order === built.record.source.revision.order) {
-            const unchanged = existing.source.revision.token === built.record.source.revision.token
-                && existing.source.revision.digest === built.record.source.revision.digest;
+        if (existingSourceRecord
+            && existingSourceRecord.source.revision.order === built.sourceRecord.source.revision.order) {
+            const unchanged = existingSourceRecord.source.revision.token === built.sourceRecord.source.revision.token
+                && existingSourceRecord.source.revision.digest === built.sourceRecord.source.revision.digest;
             if (!unchanged) {
-                throw new HealthRevisionConflictError(built.record.id);
+                throw new HealthSourceRecordRevisionConflictError(built.sourceRecord.id);
             }
             return {
-                id: existing.id,
+                sourceRecordId: existingSourceRecord.id,
                 status: 'unchanged' as const,
-                record: existing,
+                sourceRecord: existingSourceRecord,
                 chunksWritten: 0,
                 chunksDeleted: 0,
             };
         }
 
-        const existingChunkIds = existing?.sampleChunkIds || [];
+        const existingChunkIds = existingSourceRecord?.sampleChunkIds || [];
         if (!Array.isArray(existingChunkIds)
-            || existingChunkIds.length > HEALTH_MAX_SAMPLE_CHUNKS_PER_RECORD
+            || existingChunkIds.length > HEALTH_MAX_SAMPLE_CHUNKS_PER_SOURCE_RECORD
             || new Set(existingChunkIds).size !== existingChunkIds.length
             || existingChunkIds.some(chunkId => typeof chunkId !== 'string' || !OPAQUE_ID_PATTERN.test(chunkId))) {
-            throw new HealthWriteValidationError('Stored health record violates the bounded sample-chunk invariant.');
+            throw new HealthWriteValidationError(
+                'Stored health source record violates the bounded sample-chunk invariant.',
+            );
         }
-        const incomingChunkIds = new Set(built.record.sampleChunkIds);
+        const incomingChunkIds = new Set(built.sourceRecord.sampleChunkIds);
         const staleChunkIds = existingChunkIds.filter(chunkId => !incomingChunkIds.has(chunkId));
         for (const chunkId of staleChunkIds) {
             // Health sample chunks are permanent leaf documents by schema; descendants are forbidden by Rules.
@@ -374,23 +390,23 @@ export async function replaceHealthSourceRecord(
         for (const chunk of built.chunks) {
             transaction.set(chunkCollection.doc(chunk.id), chunk);
         }
-        const record = {
-            ...built.record,
-            createdAtMs: existing?.createdAtMs ?? built.record.createdAtMs,
+        const sourceRecord = {
+            ...built.sourceRecord,
+            createdAtMs: existingSourceRecord?.createdAtMs ?? built.sourceRecord.createdAtMs,
         };
-        transaction.set(recordRef, record);
+        transaction.set(sourceRecordRef, sourceRecord);
         return {
-            id: record.id,
+            sourceRecordId: sourceRecord.id,
             status: 'written' as const,
-            record,
+            sourceRecord,
             chunksWritten: built.chunks.length,
             chunksDeleted: staleChunkIds.length,
         };
     });
 
-    logger.info('[HealthSync] Health record write completed.', {
-        provider: built.record.source.provider,
-        recordId: built.record.id,
+    logger.info('[HealthSync] Health source-record write completed.', {
+        provider: built.sourceRecord.source.provider,
+        sourceRecordId: built.sourceRecord.id,
         status: result.status,
         chunksWritten: result.chunksWritten,
         chunksDeleted: result.chunksDeleted,

--- a/functions/src/health/writer.ts
+++ b/functions/src/health/writer.ts
@@ -1,0 +1,470 @@
+import * as admin from 'firebase-admin';
+import * as logger from 'firebase-functions/logger';
+import {
+    HEALTH_MAX_DOCUMENT_BYTES,
+    HEALTH_MAX_SAMPLE_CHUNKS_PER_RECORD,
+    HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK,
+    HEALTH_MAX_WRITE_BYTES,
+    HEALTH_PROVIDERS,
+    HEALTH_RECORDS_COLLECTION_ID,
+    HEALTH_SAMPLE_CHUNKS_COLLECTION_ID,
+    HEALTH_SCHEMA_VERSION,
+    HEALTH_SYNC_STATE_COLLECTION_ID,
+    HEALTH_SYNC_STATUSES,
+    HealthProvider,
+    HealthSampleChunk,
+    HealthSourceRecord,
+    HealthSyncState,
+    HealthSyncStatus,
+    isHealthProvider,
+} from '../../../shared/health';
+import {
+    getUserDeletionGuardStateInTransaction,
+    UserDeletionGuardReadError,
+} from '../shared/user-deletion-guard';
+import { generateIDFromParts } from '../shared/id-generator';
+import {
+    HealthSourceRecordInput,
+    HealthWriteValidationError,
+    validateHealthSourceRecordInput,
+} from './validation';
+
+type HealthIdGenerator = (parts: string[]) => Promise<string>;
+const OPAQUE_ID_PATTERN = /^[a-f0-9]{64}$/;
+
+export interface HealthWriterDependencies {
+    db?: admin.firestore.Firestore;
+    generateId?: HealthIdGenerator;
+}
+
+export type HealthRecordWriteStatus = 'written' | 'unchanged' | 'stale' | 'skipped_deleted_user';
+
+export interface HealthRecordWriteResult {
+    id: string;
+    status: HealthRecordWriteStatus;
+    record: HealthSourceRecord | null;
+    chunksWritten: number;
+    chunksDeleted: number;
+}
+
+export class HealthRevisionConflictError extends Error {
+    public readonly name = 'HealthRevisionConflictError';
+    public readonly code = 'health_revision_conflict';
+
+    constructor(public readonly recordId: string) {
+        super(`Health record ${recordId} has conflicting content for the same provider revision order.`);
+    }
+}
+
+export class HealthWriteSizeError extends HealthWriteValidationError {
+    public readonly name = 'HealthWriteSizeError';
+
+    constructor(message: string) {
+        super(message);
+    }
+}
+
+export interface BuiltHealthWrite {
+    record: HealthSourceRecord;
+    chunks: HealthSampleChunk[];
+}
+
+function cleanUndefined<T>(value: T): T {
+    return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function stableComparableValue(value: unknown): unknown {
+    if (Array.isArray(value)) {
+        return value.map(stableComparableValue);
+    }
+    if (!value || typeof value !== 'object') {
+        return value === undefined ? null : value;
+    }
+    const source = value as Record<string, unknown>;
+    return Object.keys(source).sort().reduce<Record<string, unknown>>((result, key) => {
+        if (source[key] !== undefined) {
+            result[key] = stableComparableValue(source[key]);
+        }
+        return result;
+    }, {});
+}
+
+async function generateOpaqueId(generateId: HealthIdGenerator, parts: readonly string[]): Promise<string> {
+    // One length-preserving JSON part avoids delimiter collisions inside the shared ID generator.
+    const id = await generateId([JSON.stringify(parts)]);
+    if (!OPAQUE_ID_PATTERN.test(id)) {
+        throw new HealthWriteValidationError('Health ID generator returned an invalid opaque ID.');
+    }
+    return id;
+}
+
+function validateWriteContext(userID: string, nowMs: number): void {
+    if (typeof userID !== 'string' || userID.trim().length === 0 || userID.length > 128) {
+        throw new HealthWriteValidationError('userID must be a bounded non-empty string.');
+    }
+    if (!Number.isSafeInteger(nowMs) || nowMs < 0) {
+        throw new HealthWriteValidationError('nowMs must be a non-negative safe integer.');
+    }
+}
+
+function documentBytes(value: unknown): number {
+    return Buffer.byteLength(JSON.stringify(cleanUndefined(value)), 'utf8');
+}
+
+export function assertHealthWriteSize(record: HealthSourceRecord, chunks: readonly HealthSampleChunk[]): void {
+    const documents = [record, ...chunks];
+    const oversizedDocument = documents.find(document => documentBytes(document) > HEALTH_MAX_DOCUMENT_BYTES);
+    if (oversizedDocument) {
+        throw new HealthWriteSizeError(`Health document ${oversizedDocument.id} exceeds the bounded document size.`);
+    }
+    const totalBytes = documents.reduce((total, document) => total + documentBytes(document), 0);
+    if (totalBytes > HEALTH_MAX_WRITE_BYTES) {
+        throw new HealthWriteSizeError('Health record replacement exceeds the bounded transaction payload size.');
+    }
+}
+
+function digestPayload(input: HealthSourceRecordInput): unknown {
+    return stableComparableValue({
+        provider: input.provider,
+        sourceRecordType: input.sourceRecordType,
+        sourceRecordKey: input.sourceRecordKey,
+        kind: input.kind,
+        calendarDate: input.calendarDate,
+        startTimeMs: input.startTimeMs,
+        endTimeMs: input.endTimeMs,
+        timezoneOffsetSeconds: input.timezoneOffsetSeconds,
+        metrics: input.metrics,
+        coverage: input.coverage,
+        device: input.device,
+        sampleSeries: input.sampleSeries,
+    });
+}
+
+export async function buildHealthWrite(
+    userID: string,
+    value: unknown,
+    nowMs = Date.now(),
+    generateId: HealthIdGenerator = generateIDFromParts,
+): Promise<BuiltHealthWrite> {
+    validateWriteContext(userID, nowMs);
+    const input = validateHealthSourceRecordInput(value);
+    const accountKey = await generateOpaqueId(generateId, [
+        'health-account-v1',
+        userID,
+        input.provider,
+        input.providerAccountId,
+    ]);
+    const id = await generateOpaqueId(generateId, [
+        'health-record-v1',
+        userID,
+        input.provider,
+        input.providerAccountId,
+        input.sourceRecordType,
+        input.sourceRecordKey,
+    ]);
+    const digest = await generateOpaqueId(generateId, [
+        'health-record-content-v1',
+        JSON.stringify(digestPayload(input)),
+    ]);
+    const revision = {
+        order: input.revision.order,
+        token: input.revision.token,
+        digest,
+    };
+
+    const chunkGroups = await Promise.all(input.sampleSeries.map(async (series) => {
+        const chunks: HealthSampleChunk[] = [];
+        const chunkCount = Math.ceil(series.offsetMs.length / HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK);
+        for (let chunkIndex = 0; chunkIndex < chunkCount; chunkIndex += 1) {
+            const sliceStart = chunkIndex * HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK;
+            const sliceEnd = Math.min(sliceStart + HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK, series.offsetMs.length);
+            const firstOffsetMs = series.offsetMs[sliceStart];
+            const offsetMs = series.offsetMs.slice(sliceStart, sliceEnd).map(offset => offset - firstOffsetMs);
+            const chunkId = await generateOpaqueId(generateId, [
+                'health-chunk-v1',
+                id,
+                series.seriesKey,
+                String(chunkIndex),
+            ]);
+            chunks.push({
+                schemaVersion: HEALTH_SCHEMA_VERSION,
+                id: chunkId,
+                userID,
+                parentRecordId: id,
+                provider: input.provider,
+                accountKey,
+                metricId: series.metricId,
+                valueType: series.valueType,
+                aggregation: series.aggregation,
+                semanticVariant: series.semanticVariant,
+                origin: series.origin,
+                recordingMethod: series.recordingMethod,
+                normalizationStatus: series.normalizationStatus,
+                nativeMetric: series.nativeMetric,
+                nativeUnit: series.nativeUnit,
+                canonicalUnit: series.canonicalUnit,
+                calendarDate: input.calendarDate,
+                startTimeMs: input.startTimeMs + firstOffsetMs,
+                endTimeMs: input.startTimeMs + firstOffsetMs + (offsetMs[offsetMs.length - 1] || 0),
+                timezoneOffsetSeconds: input.timezoneOffsetSeconds,
+                seriesKey: series.seriesKey,
+                chunkIndex,
+                offsetMs,
+                nativeValues: series.nativeValues.slice(sliceStart, sliceEnd),
+                canonicalValues: series.canonicalValues?.slice(sliceStart, sliceEnd),
+                qualityCodes: series.qualityCodes?.slice(sliceStart, sliceEnd),
+                coverage: {
+                    ...series.coverage,
+                    sampleCount: offsetMs.length,
+                },
+                device: series.device === undefined ? input.device : series.device,
+                revision,
+                createdAtMs: nowMs,
+                updatedAtMs: nowMs,
+            });
+        }
+        return chunks;
+    }));
+    const chunks = chunkGroups.flat();
+    const metricIds = [...new Set([
+        ...input.metrics.map(metric => metric.metricId),
+        ...input.sampleSeries.map(series => series.metricId),
+    ])];
+    const record: HealthSourceRecord = {
+        schemaVersion: HEALTH_SCHEMA_VERSION,
+        id,
+        userID,
+        kind: input.kind,
+        source: {
+            provider: input.provider,
+            accountKey,
+            sourceRecordType: input.sourceRecordType,
+            sourceRecordKey: input.sourceRecordKey,
+            revision,
+            receivedAtMs: input.receivedAtMs,
+        },
+        calendarDate: input.calendarDate,
+        startTimeMs: input.startTimeMs,
+        endTimeMs: input.endTimeMs,
+        timezoneOffsetSeconds: input.timezoneOffsetSeconds,
+        metrics: input.metrics,
+        metricIds,
+        coverage: input.coverage,
+        device: input.device,
+        sampleChunkIds: chunks.map(chunk => chunk.id),
+        createdAtMs: nowMs,
+        updatedAtMs: nowMs,
+    };
+    const result = cleanUndefined({ record, chunks });
+    assertHealthWriteSize(result.record, result.chunks);
+    return result;
+}
+
+function userHealthCollection(
+    db: admin.firestore.Firestore,
+    userID: string,
+    collectionId: string,
+): admin.firestore.CollectionReference {
+    return db.collection('users').doc(userID).collection(collectionId);
+}
+
+export async function replaceHealthSourceRecord(
+    userID: string,
+    value: unknown,
+    nowMs = Date.now(),
+    dependencies: HealthWriterDependencies = {},
+): Promise<HealthRecordWriteResult> {
+    const db = dependencies.db || admin.firestore();
+    const built = await buildHealthWrite(userID, value, nowMs, dependencies.generateId || generateIDFromParts);
+    const recordRef = userHealthCollection(db, userID, HEALTH_RECORDS_COLLECTION_ID).doc(built.record.id);
+    const chunkCollection = userHealthCollection(db, userID, HEALTH_SAMPLE_CHUNKS_COLLECTION_ID);
+
+    const result = await db.runTransaction(async transaction => {
+        let deletionGuard;
+        try {
+            deletionGuard = await getUserDeletionGuardStateInTransaction(db, transaction, userID, nowMs);
+        } catch (error) {
+            throw new UserDeletionGuardReadError(userID, 'health_record_write', error);
+        }
+        if (deletionGuard.shouldSkip) {
+            return {
+                id: built.record.id,
+                status: 'skipped_deleted_user' as const,
+                record: null,
+                chunksWritten: 0,
+                chunksDeleted: 0,
+            };
+        }
+
+        const snapshot = await transaction.get(recordRef);
+        const existing = snapshot.exists ? snapshot.data() as HealthSourceRecord : null;
+        if (existing && existing.source.revision.order > built.record.source.revision.order) {
+            return {
+                id: existing.id,
+                status: 'stale' as const,
+                record: existing,
+                chunksWritten: 0,
+                chunksDeleted: 0,
+            };
+        }
+        if (existing && existing.source.revision.order === built.record.source.revision.order) {
+            const unchanged = existing.source.revision.token === built.record.source.revision.token
+                && existing.source.revision.digest === built.record.source.revision.digest;
+            if (!unchanged) {
+                throw new HealthRevisionConflictError(built.record.id);
+            }
+            return {
+                id: existing.id,
+                status: 'unchanged' as const,
+                record: existing,
+                chunksWritten: 0,
+                chunksDeleted: 0,
+            };
+        }
+
+        const existingChunkIds = existing?.sampleChunkIds || [];
+        if (!Array.isArray(existingChunkIds)
+            || existingChunkIds.length > HEALTH_MAX_SAMPLE_CHUNKS_PER_RECORD
+            || new Set(existingChunkIds).size !== existingChunkIds.length
+            || existingChunkIds.some(chunkId => typeof chunkId !== 'string' || !OPAQUE_ID_PATTERN.test(chunkId))) {
+            throw new HealthWriteValidationError('Stored health record violates the bounded sample-chunk invariant.');
+        }
+        const incomingChunkIds = new Set(built.record.sampleChunkIds);
+        const staleChunkIds = existingChunkIds.filter(chunkId => !incomingChunkIds.has(chunkId));
+        for (const chunkId of staleChunkIds) {
+            // Health sample chunks are permanent leaf documents by schema; descendants are forbidden by Rules.
+            transaction.delete(chunkCollection.doc(chunkId));
+        }
+        for (const chunk of built.chunks) {
+            transaction.set(chunkCollection.doc(chunk.id), chunk);
+        }
+        const record = {
+            ...built.record,
+            createdAtMs: existing?.createdAtMs ?? built.record.createdAtMs,
+        };
+        transaction.set(recordRef, record);
+        return {
+            id: record.id,
+            status: 'written' as const,
+            record,
+            chunksWritten: built.chunks.length,
+            chunksDeleted: staleChunkIds.length,
+        };
+    });
+
+    logger.info('[HealthSync] Health record write completed.', {
+        provider: built.record.source.provider,
+        recordId: built.record.id,
+        status: result.status,
+        chunksWritten: result.chunksWritten,
+        chunksDeleted: result.chunksDeleted,
+    });
+    return result;
+}
+
+export interface HealthSyncStateUpdate {
+    status?: HealthSyncStatus;
+    lastWebhookAtMs?: number | null;
+    lastPollAtMs?: number | null;
+    lastSyncedAtMs?: number | null;
+    lastObservedAtMs?: number | null;
+    lastErrorCode?: string | null;
+}
+
+function optionalSyncTime(value: unknown, field: string): number | null | undefined {
+    if (value === undefined || value === null) {
+        return value as null | undefined;
+    }
+    if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+        throw new HealthWriteValidationError(`${field} must be a non-negative safe integer or null.`);
+    }
+    return value;
+}
+
+function validateSyncUpdate(provider: unknown, value: unknown): { provider: HealthProvider; update: HealthSyncStateUpdate } {
+    if (!isHealthProvider(provider) || provider === HEALTH_PROVIDERS.QuantifiedSelf) {
+        throw new HealthWriteValidationError('Health sync provider is not supported.');
+    }
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new HealthWriteValidationError('Health sync update must be an object.');
+    }
+    const input = value as Record<string, unknown>;
+    let status: HealthSyncStatus | undefined;
+    if (input.status !== undefined) {
+        if (typeof input.status !== 'string' || !Object.values(HEALTH_SYNC_STATUSES).includes(input.status as HealthSyncStatus)) {
+            throw new HealthWriteValidationError('Health sync status is not supported.');
+        }
+        status = input.status as HealthSyncStatus;
+    }
+    let lastErrorCode: string | null | undefined;
+    if (input.lastErrorCode === null) {
+        lastErrorCode = null;
+    } else if (input.lastErrorCode !== undefined) {
+        if (typeof input.lastErrorCode !== 'string'
+            || input.lastErrorCode.length === 0
+            || input.lastErrorCode.length > 64
+            || !/^[a-z0-9_.:-]+$/i.test(input.lastErrorCode)) {
+            throw new HealthWriteValidationError('lastErrorCode must be an opaque bounded error code.');
+        }
+        lastErrorCode = input.lastErrorCode;
+    }
+    return {
+        provider,
+        update: {
+            status,
+            lastWebhookAtMs: optionalSyncTime(input.lastWebhookAtMs, 'lastWebhookAtMs'),
+            lastPollAtMs: optionalSyncTime(input.lastPollAtMs, 'lastPollAtMs'),
+            lastSyncedAtMs: optionalSyncTime(input.lastSyncedAtMs, 'lastSyncedAtMs'),
+            lastObservedAtMs: optionalSyncTime(input.lastObservedAtMs, 'lastObservedAtMs'),
+            lastErrorCode,
+        },
+    };
+}
+
+export async function updateHealthSyncState(
+    userID: string,
+    providerValue: unknown,
+    updateValue: unknown,
+    nowMs = Date.now(),
+    dependencies: Pick<HealthWriterDependencies, 'db'> = {},
+): Promise<boolean> {
+    validateWriteContext(userID, nowMs);
+    const { provider, update } = validateSyncUpdate(providerValue, updateValue);
+    const db = dependencies.db || admin.firestore();
+    const stateRef = userHealthCollection(db, userID, HEALTH_SYNC_STATE_COLLECTION_ID).doc(provider);
+    const written = await db.runTransaction(async transaction => {
+        let deletionGuard;
+        try {
+            deletionGuard = await getUserDeletionGuardStateInTransaction(db, transaction, userID, nowMs);
+        } catch (error) {
+            throw new UserDeletionGuardReadError(userID, 'health_sync_state_write', error);
+        }
+        if (deletionGuard.shouldSkip) {
+            return false;
+        }
+        const snapshot = await transaction.get(stateRef);
+        const state: Partial<HealthSyncState> & Pick<HealthSyncState, 'provider' | 'updatedAtMs'> = cleanUndefined({
+            provider,
+            ...update,
+            status: update.status ?? (snapshot.exists ? undefined : HEALTH_SYNC_STATUSES.Ready),
+            updatedAtMs: nowMs,
+        });
+        transaction.set(stateRef, state, { merge: true });
+        return true;
+    });
+    logger.info('[HealthSync] Health sync state write completed.', { provider, written });
+    return written;
+}
+
+/** Disconnecting a provider changes only sync state; imported health history is intentionally retained. */
+export function markHealthProviderDisconnected(
+    userID: string,
+    provider: HealthProvider,
+    nowMs = Date.now(),
+    dependencies: Pick<HealthWriterDependencies, 'db'> = {},
+): Promise<boolean> {
+    return updateHealthSyncState(userID, provider, {
+        status: HEALTH_SYNC_STATUSES.Disconnected,
+        lastErrorCode: null,
+    }, nowMs, dependencies);
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -164,6 +164,7 @@ export {
   resetAssistantConversation,
 } from './assistant/callable';
 export { ensureDerivedMetrics } from './derived-metrics/ensure-derived-metrics';
+export { queryHealthRange } from './health/callable';
 export { setTrainingBuildBenchmark } from './derived-metrics/set-training-build-benchmark';
 export {
   onDashboardDerivedMetricsActivityWrite,

--- a/functions/src/user/user.spec.ts
+++ b/functions/src/user/user.spec.ts
@@ -220,7 +220,7 @@ describe('deleteSelf Cloud Function', () => {
         expect(result).toEqual({ success: true });
     });
 
-    it('should continue deleting the user if writing the deletion marker fails', async () => {
+    it('should fail closed without deleting the user if writing the deletion marker fails', async () => {
         const uid = 'test-uid';
         const context = {
             rawRequest: {},
@@ -234,14 +234,17 @@ describe('deleteSelf Cloud Function', () => {
         const markerError = new Error('Marker write failed');
         deletionMarkerSetMock.mockRejectedValueOnce(markerError);
 
-        const result = await (deleteSelf as any)({}, context);
+        await expect((deleteSelf as any)({}, context)).rejects.toMatchObject({
+            code: 'internal',
+            message: 'Unable to delete user'
+        });
 
-        expect(deleteUserMock).toHaveBeenCalledWith(uid);
+        expect(deleteUserMock).not.toHaveBeenCalled();
         expect(loggerErrorMock).toHaveBeenCalledWith(
-            `Failed to write user deletion marker for ${uid}. Continuing with deletion.`,
+            `Failed to write user deletion marker for ${uid}. Aborting deletion.`,
             markerError
         );
-        expect(result).toEqual({ success: true });
+        expect(mailSetMock).not.toHaveBeenCalled();
     });
 
     it('should return success even when queuing confirmation email fails', async () => {

--- a/functions/src/user/user.ts
+++ b/functions/src/user/user.ts
@@ -74,7 +74,8 @@ export const deleteSelf = functions
                 }, { merge: true });
                 deletionMarkerWritten = true;
             } catch (markerError) {
-                logger.error(`Failed to write user deletion marker for ${uid}. Continuing with deletion.`, markerError);
+                logger.error(`Failed to write user deletion marker for ${uid}. Aborting deletion.`, markerError);
+                throw markerError;
             }
 
             // Delete Auth User (idempotent if already deleted)

--- a/shared/functions-manifest.ts
+++ b/shared/functions-manifest.ts
@@ -22,6 +22,7 @@ export const FUNCTIONS_MANIFEST = {
     decideMcpAuthorization: { name: 'decideMcpAuthorization', region: 'europe-west2' },
     listMcpConnections: { name: 'listMcpConnections', region: 'europe-west2' },
     revokeMcpConnection: { name: 'revokeMcpConnection', region: 'europe-west2' },
+    queryHealthRange: { name: 'queryHealthRange', region: 'europe-west2' },
 
     // COROS Functions
     getCOROSAPIAuthRequestTokenRedirectURI: { name: 'getCOROSAPIAuthRequestTokenRedirectURI', region: 'europe-west2' },

--- a/shared/health-firestore-query.ts
+++ b/shared/health-firestore-query.ts
@@ -1,5 +1,5 @@
 import {
-  HEALTH_RECORDS_COLLECTION_ID,
+  HEALTH_SOURCE_RECORDS_COLLECTION_ID,
   HEALTH_SAMPLE_CHUNKS_COLLECTION_ID,
   HealthQueryCursor,
   HealthRangeQuery,
@@ -16,7 +16,7 @@ export interface HealthFirestoreFilterPlan {
 }
 
 export interface HealthFirestoreQueryPlan {
-  collectionId: typeof HEALTH_RECORDS_COLLECTION_ID | typeof HEALTH_SAMPLE_CHUNKS_COLLECTION_ID;
+  collectionId: typeof HEALTH_SOURCE_RECORDS_COLLECTION_ID | typeof HEALTH_SAMPLE_CHUNKS_COLLECTION_ID;
   startDate: string;
   endDate: string;
   filter: HealthFirestoreFilterPlan | null;
@@ -26,7 +26,7 @@ export interface HealthFirestoreQueryPlan {
 
 export interface HealthFirestoreQueryPlans {
   query: NormalizedHealthRangeQuery;
-  records: HealthFirestoreQueryPlan;
+  sourceRecords: HealthFirestoreQueryPlan;
   chunks: HealthFirestoreQueryPlan | null;
 }
 
@@ -40,7 +40,7 @@ function providerFilter(field: string, providers: readonly string[]): HealthFire
   return null;
 }
 
-function recordMetricFilter(metricIds: readonly string[]): HealthFirestoreFilterPlan | null {
+function sourceRecordMetricFilter(metricIds: readonly string[]): HealthFirestoreFilterPlan | null {
   if (metricIds.length === 1) {
     return { field: 'metricIds', operator: 'array-contains', value: metricIds[0] };
   }
@@ -67,19 +67,19 @@ export function planHealthFirestoreQueries(
   // A provider predicate takes precedence so provider + metric queries do not
   // require a combinatorial provider/metric/date index. The shared projector
   // applies every requested filter to the bounded result set afterward.
-  const recordFilter = providerFilter('source.provider', query.providers)
-    || recordMetricFilter(query.metricIds);
+  const sourceRecordFilter = providerFilter('source.provider', query.providers)
+    || sourceRecordMetricFilter(query.metricIds);
   const chunkFilter = providerFilter('provider', query.providers)
     || chunkMetricFilter(query.metricIds);
   return {
     query,
-    records: {
-      collectionId: HEALTH_RECORDS_COLLECTION_ID,
+    sourceRecords: {
+      collectionId: HEALTH_SOURCE_RECORDS_COLLECTION_ID,
       startDate: query.startDate,
       endDate: query.endDate,
-      filter: recordFilter,
-      cursor: query.recordCursor,
-      fetchLimit: query.recordLimit + 1,
+      filter: sourceRecordFilter,
+      cursor: query.sourceRecordCursor,
+      fetchLimit: query.sourceRecordLimit + 1,
     },
     chunks: query.includeSamples ? {
       collectionId: HEALTH_SAMPLE_CHUNKS_COLLECTION_ID,

--- a/shared/health-firestore-query.ts
+++ b/shared/health-firestore-query.ts
@@ -1,0 +1,93 @@
+import {
+  HEALTH_RECORDS_COLLECTION_ID,
+  HEALTH_SAMPLE_CHUNKS_COLLECTION_ID,
+  HealthQueryCursor,
+  HealthRangeQuery,
+  NormalizedHealthRangeQuery,
+} from './health';
+import { normalizeHealthRangeQuery } from './health-query';
+
+export type HealthFirestoreFilterOperator = '==' | 'in' | 'array-contains' | 'array-contains-any';
+
+export interface HealthFirestoreFilterPlan {
+  field: string;
+  operator: HealthFirestoreFilterOperator;
+  value: string | string[];
+}
+
+export interface HealthFirestoreQueryPlan {
+  collectionId: typeof HEALTH_RECORDS_COLLECTION_ID | typeof HEALTH_SAMPLE_CHUNKS_COLLECTION_ID;
+  startDate: string;
+  endDate: string;
+  filter: HealthFirestoreFilterPlan | null;
+  cursor: HealthQueryCursor | null;
+  fetchLimit: number;
+}
+
+export interface HealthFirestoreQueryPlans {
+  query: NormalizedHealthRangeQuery;
+  records: HealthFirestoreQueryPlan;
+  chunks: HealthFirestoreQueryPlan | null;
+}
+
+function providerFilter(field: string, providers: readonly string[]): HealthFirestoreFilterPlan | null {
+  if (providers.length === 1) {
+    return { field, operator: '==', value: providers[0] };
+  }
+  if (providers.length > 1) {
+    return { field, operator: 'in', value: [...providers] };
+  }
+  return null;
+}
+
+function recordMetricFilter(metricIds: readonly string[]): HealthFirestoreFilterPlan | null {
+  if (metricIds.length === 1) {
+    return { field: 'metricIds', operator: 'array-contains', value: metricIds[0] };
+  }
+  if (metricIds.length > 1) {
+    return { field: 'metricIds', operator: 'array-contains-any', value: [...metricIds] };
+  }
+  return null;
+}
+
+function chunkMetricFilter(metricIds: readonly string[]): HealthFirestoreFilterPlan | null {
+  if (metricIds.length === 1) {
+    return { field: 'metricId', operator: '==', value: metricIds[0] };
+  }
+  if (metricIds.length > 1) {
+    return { field: 'metricId', operator: 'in', value: [...metricIds] };
+  }
+  return null;
+}
+
+export function planHealthFirestoreQueries(
+  queryValue: HealthRangeQuery | NormalizedHealthRangeQuery | unknown,
+): HealthFirestoreQueryPlans {
+  const query = normalizeHealthRangeQuery(queryValue);
+  // A provider predicate takes precedence so provider + metric queries do not
+  // require a combinatorial provider/metric/date index. The shared projector
+  // applies every requested filter to the bounded result set afterward.
+  const recordFilter = providerFilter('source.provider', query.providers)
+    || recordMetricFilter(query.metricIds);
+  const chunkFilter = providerFilter('provider', query.providers)
+    || chunkMetricFilter(query.metricIds);
+  return {
+    query,
+    records: {
+      collectionId: HEALTH_RECORDS_COLLECTION_ID,
+      startDate: query.startDate,
+      endDate: query.endDate,
+      filter: recordFilter,
+      cursor: query.recordCursor,
+      fetchLimit: query.recordLimit + 1,
+    },
+    chunks: query.includeSamples ? {
+      collectionId: HEALTH_SAMPLE_CHUNKS_COLLECTION_ID,
+      startDate: query.startDate,
+      endDate: query.endDate,
+      filter: chunkFilter,
+      cursor: query.chunkCursor,
+      fetchLimit: query.chunkLimit + 1,
+    } : null,
+  };
+}

--- a/shared/health-query.ts
+++ b/shared/health-query.ts
@@ -11,6 +11,7 @@ import {
   HEALTH_MAX_SUMMARY_RANGE_DAYS,
   HEALTH_NORMALIZATION_STATUSES,
   HealthConflict,
+  HealthCoverageStatus,
   HealthDailySummary,
   HealthFreshnessResult,
   HealthMetricCoverageResult,
@@ -23,9 +24,11 @@ import {
   HealthQueryCursor,
   HealthRangeQuery,
   HealthRangeResult,
+  HealthRecordingMethod,
   HealthSampleChunk,
   HealthSourceRecord,
   HealthUnit,
+  HealthValueOrigin,
   HealthValueType,
   NormalizedHealthRangeQuery,
   getHealthMetricDefinition,
@@ -87,20 +90,28 @@ function normalizeProviders(value: unknown): HealthProvider[] {
   if (value === undefined || value === null) {
     return [];
   }
-  if (!Array.isArray(value) || value.length > 5 || value.some(provider => !isHealthProvider(provider))) {
+  if (!Array.isArray(value)) {
     throw new HealthQueryValidationError('providers must contain at most five supported providers.');
   }
-  return [...new Set(value as HealthProvider[])];
+  const providers = Array.from(value);
+  if (providers.length > 5 || providers.some(provider => !isHealthProvider(provider))) {
+    throw new HealthQueryValidationError('providers must contain at most five supported providers.');
+  }
+  return [...new Set(providers as HealthProvider[])];
 }
 
 function normalizeMetricIds(value: unknown): HealthMetricId[] {
   if (value === undefined || value === null) {
     return [];
   }
-  if (!Array.isArray(value) || value.length > 30 || value.some(metricId => !isHealthMetricId(metricId))) {
+  if (!Array.isArray(value)) {
     throw new HealthQueryValidationError('metricIds must contain at most 30 supported metric IDs.');
   }
-  return [...new Set(value as HealthMetricId[])];
+  const metricIds = Array.from(value);
+  if (metricIds.length > 30 || metricIds.some(metricId => !isHealthMetricId(metricId))) {
+    throw new HealthQueryValidationError('metricIds must contain at most 30 supported metric IDs.');
+  }
+  return [...new Set(metricIds as HealthMetricId[])];
 }
 
 export function normalizeHealthRangeQuery(value: HealthRangeQuery | unknown): NormalizedHealthRangeQuery {
@@ -147,7 +158,11 @@ function compareDateAndId(
   left: Pick<HealthSourceRecord | HealthSampleChunk, 'calendarDate' | 'id'>,
   right: Pick<HealthSourceRecord | HealthSampleChunk, 'calendarDate' | 'id'>,
 ): number {
-  return left.calendarDate.localeCompare(right.calendarDate) || left.id.localeCompare(right.id);
+  return compareText(left.calendarDate, right.calendarDate) || compareText(left.id, right.id);
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
 }
 
 function isAfterCursor(
@@ -165,15 +180,28 @@ function metricMatches(metricId: HealthMetricId, metricIds: readonly HealthMetri
   return metricIds.length === 0 || metricIds.includes(metricId);
 }
 
+function chunkMatchesKnownParentRevision(
+  chunk: HealthSampleChunk,
+  recordsById: ReadonlyMap<string, HealthSourceRecord>,
+): boolean {
+  const parent = recordsById.get(chunk.parentRecordId);
+  if (!parent) {
+    return true;
+  }
+  return chunk.revision.order === parent.source.revision.order
+    && chunk.revision.token === parent.source.revision.token
+    && chunk.revision.digest === parent.source.revision.digest;
+}
+
 function entryCanonicalUnit(entry: HealthMetricEntry): HealthUnit | null {
   return entry.kind === 'value' && entry.canonical ? entry.canonical.unit : null;
 }
 
 function observationSort(left: HealthObservation, right: HealthObservation): number {
-  return left.calendarDate.localeCompare(right.calendarDate)
+  return compareText(left.calendarDate, right.calendarDate)
     || left.startTimeMs - right.startTimeMs
-    || left.provider.localeCompare(right.provider)
-    || left.id.localeCompare(right.id);
+    || compareText(left.provider, right.provider)
+    || compareText(left.id, right.id);
 }
 
 function addUnique<T>(values: T[], value: T): void {
@@ -187,7 +215,10 @@ interface DiscoveryAccumulator {
   providers: HealthProvider[];
   valueTypes: HealthValueType[];
   canonicalUnits: HealthUnit[];
+  aggregations: string[];
   semanticVariants: string[];
+  origins: HealthValueOrigin[];
+  recordingMethods: HealthRecordingMethod[];
   firstDate: string;
   lastDate: string;
   hasSamples: boolean;
@@ -200,7 +231,10 @@ function addDiscoveryEntry(
     provider: HealthProvider;
     valueType: HealthValueType;
     canonicalUnit: HealthUnit | null;
+    aggregation: string;
     semanticVariant: string;
+    origin: HealthValueOrigin;
+    recordingMethod: HealthRecordingMethod;
     calendarDate: string;
     hasSamples: boolean;
   },
@@ -210,7 +244,10 @@ function addDiscoveryEntry(
     providers: [],
     valueTypes: [],
     canonicalUnits: [],
+    aggregations: [],
     semanticVariants: [],
+    origins: [],
+    recordingMethods: [],
     firstDate: input.calendarDate,
     lastDate: input.calendarDate,
     hasSamples: false,
@@ -220,7 +257,10 @@ function addDiscoveryEntry(
   if (input.canonicalUnit) {
     addUnique(current.canonicalUnits, input.canonicalUnit);
   }
+  addUnique(current.aggregations, input.aggregation);
   addUnique(current.semanticVariants, input.semanticVariant);
+  addUnique(current.origins, input.origin);
+  addUnique(current.recordingMethods, input.recordingMethod);
   current.firstDate = current.firstDate < input.calendarDate ? current.firstDate : input.calendarDate;
   current.lastDate = current.lastDate > input.calendarDate ? current.lastDate : input.calendarDate;
   current.hasSamples ||= input.hasSamples;
@@ -230,14 +270,35 @@ function addDiscoveryEntry(
 interface CoverageAccumulator {
   metricId: HealthMetricId;
   provider: HealthProvider;
+  accountKey: string;
+  aggregation: string;
   semanticVariant: string;
+  origin: HealthValueOrigin;
+  recordingMethod: HealthRecordingMethod;
   dates: Set<string>;
   partialDates: Set<string>;
+  unknownDates: Set<string>;
   latestDate: string;
 }
 
-function coverageKey(metricId: HealthMetricId, provider: HealthProvider, semanticVariant: string): string {
-  return `${metricId}\u0000${provider}\u0000${semanticVariant}`;
+function metricSeriesKey(input: {
+  metricId: HealthMetricId;
+  provider: HealthProvider;
+  accountKey: string;
+  aggregation: string;
+  semanticVariant: string;
+  origin: HealthValueOrigin;
+  recordingMethod: HealthRecordingMethod;
+}): string {
+  return JSON.stringify([
+    input.metricId,
+    input.provider,
+    input.accountKey,
+    input.aggregation,
+    input.semanticVariant,
+    input.origin,
+    input.recordingMethod,
+  ]);
 }
 
 function addCoverage(
@@ -245,23 +306,36 @@ function addCoverage(
   input: {
     metricId: HealthMetricId;
     provider: HealthProvider;
+    accountKey: string;
+    aggregation: string;
     semanticVariant: string;
+    origin: HealthValueOrigin;
+    recordingMethod: HealthRecordingMethod;
     calendarDate: string;
-    partial: boolean;
+    status: HealthCoverageStatus;
   },
 ): void {
-  const key = coverageKey(input.metricId, input.provider, input.semanticVariant);
+  const key = metricSeriesKey(input);
   const current = target.get(key) || {
     metricId: input.metricId,
     provider: input.provider,
+    accountKey: input.accountKey,
+    aggregation: input.aggregation,
     semanticVariant: input.semanticVariant,
+    origin: input.origin,
+    recordingMethod: input.recordingMethod,
     dates: new Set<string>(),
     partialDates: new Set<string>(),
+    unknownDates: new Set<string>(),
     latestDate: input.calendarDate,
   };
   current.dates.add(input.calendarDate);
-  if (input.partial) {
+  if (input.status === HEALTH_COVERAGE_STATUSES.Partial) {
     current.partialDates.add(input.calendarDate);
+    current.unknownDates.delete(input.calendarDate);
+  } else if (input.status === HEALTH_COVERAGE_STATUSES.Unknown
+    && !current.partialDates.has(input.calendarDate)) {
+    current.unknownDates.add(input.calendarDate);
   }
   current.latestDate = current.latestDate > input.calendarDate ? current.latestDate : input.calendarDate;
   target.set(key, current);
@@ -270,7 +344,11 @@ function addCoverage(
 interface FreshnessAccumulator {
   metricId: HealthMetricId;
   provider: HealthProvider;
+  accountKey: string;
+  aggregation: string;
   semanticVariant: string;
+  origin: HealthValueOrigin;
+  recordingMethod: HealthRecordingMethod;
   lastObservedAtMs: number;
   lastReceivedAtMs: number;
   staleAfterMs: number | null;
@@ -280,7 +358,7 @@ function addFreshness(
   target: Map<string, FreshnessAccumulator>,
   input: FreshnessAccumulator,
 ): void {
-  const key = coverageKey(input.metricId, input.provider, input.semanticVariant);
+  const key = metricSeriesKey(input);
   const current = target.get(key);
   if (!current || input.lastObservedAtMs > current.lastObservedAtMs) {
     target.set(key, input);
@@ -304,7 +382,7 @@ function intervalsOverlap(left: HealthObservation, right: HealthObservation): bo
   return left.startTimeMs <= right.endTimeMs && right.startTimeMs <= left.endTimeMs;
 }
 
-function buildConflicts(observations: readonly HealthObservation[]): HealthConflict[] {
+export function findHealthConflicts(observations: readonly HealthObservation[]): HealthConflict[] {
   const candidates = new Map<string, HealthObservation[]>();
   for (const observation of observations) {
     const entry = observation.entry;
@@ -315,14 +393,14 @@ function buildConflicts(observations: readonly HealthObservation[]): HealthConfl
     ) {
       continue;
     }
-    const key = [
+    const key = JSON.stringify([
       entry.metricId,
       observation.calendarDate,
       entry.aggregation,
       entry.semanticVariant,
       entry.origin,
       entry.canonical.unit,
-    ].join('\u0000');
+    ]);
     candidates.set(key, [...(candidates.get(key) || []), observation]);
   }
 
@@ -351,19 +429,31 @@ function buildConflicts(observations: readonly HealthObservation[]): HealthConfl
     const conflicting = group.filter(item => conflictingIds.has(item.id));
     const first = conflicting[0];
     const firstEntry = first.entry as HealthMetricValue;
+    const sources = [...new Map(conflicting.map(item => [
+      JSON.stringify([item.provider, item.accountKey]),
+      { provider: item.provider, accountKey: item.accountKey },
+    ])).values()].sort((left, right) => compareText(left.provider, right.provider)
+      || compareText(left.accountKey, right.accountKey));
     conflicts.push({
       metricId: firstEntry.metricId,
       calendarDate: first.calendarDate,
       aggregation: firstEntry.aggregation,
       semanticVariant: firstEntry.semanticVariant,
+      origin: firstEntry.origin,
       canonicalUnit: firstEntry.canonical!.unit,
-      observationIds: conflicting.map(item => item.id).sort(),
-      providers: [...new Set(conflicting.map(item => item.provider))].sort(),
+      observationIds: conflicting.map(item => item.id).sort(compareText),
+      providers: [...new Set(conflicting.map(item => item.provider))].sort(compareText),
+      sources,
+      recordingMethods: [...new Set(conflicting.map(item => item.entry.recordingMethod))].sort(compareText),
     });
   }
-  return conflicts.sort((left, right) => left.calendarDate.localeCompare(right.calendarDate)
-    || left.metricId.localeCompare(right.metricId)
-    || left.semanticVariant.localeCompare(right.semanticVariant));
+  return conflicts.sort((left, right) => compareText(left.calendarDate, right.calendarDate)
+    || compareText(left.metricId, right.metricId)
+    || compareText(left.aggregation, right.aggregation)
+    || compareText(left.semanticVariant, right.semanticVariant)
+    || compareText(left.origin, right.origin)
+    || compareText(left.canonicalUnit, right.canonicalUnit)
+    || compareText(left.observationIds.join('\u0000'), right.observationIds.join('\u0000')));
 }
 
 function cursorForLast(values: readonly Pick<HealthSourceRecord | HealthSampleChunk, 'calendarDate' | 'id'>[]): HealthQueryCursor | null {
@@ -405,12 +495,19 @@ export function projectHealthRange(
     : [];
   const chunkPageTruncated = primaryMatchingChunks.length > query.chunkLimit;
   const selectedChunkPage = primaryMatchingChunks.slice(0, query.chunkLimit);
+  const recordsById = new Map(records.map(record => [record.id, record]));
   const selectedChunks: HealthSampleChunk[] = [];
   let returnedSamplePoints = 0;
   let pointLimitTruncated = false;
+  let sampleRevisionMismatchCount = 0;
   let lastConsumedChunk: HealthSampleChunk | null = null;
   for (const chunk of selectedChunkPage) {
     if (!metricMatches(chunk.metricId, query.metricIds)) {
+      lastConsumedChunk = chunk;
+      continue;
+    }
+    if (!chunkMatchesKnownParentRevision(chunk, recordsById)) {
+      sampleRevisionMismatchCount += 1;
       lastConsumedChunk = chunk;
       continue;
     }
@@ -434,6 +531,7 @@ export function projectHealthRange(
       if (!metricMatches(entry.metricId, query.metricIds)) {
         return;
       }
+      const entryCoverage = entry.coverage || record.coverage;
       const observation: HealthObservation = {
         id: `${record.id}:${index}`,
         recordId: record.id,
@@ -446,6 +544,8 @@ export function projectHealthRange(
         sourceRecordType: record.source.sourceRecordType,
         sourceRecordKey: record.source.sourceRecordKey,
         receivedAtMs: record.source.receivedAtMs,
+        coverage: entryCoverage,
+        device: entry.device === undefined ? record.device ?? null : entry.device,
         entry,
       };
       observations.push(observation);
@@ -454,23 +554,33 @@ export function projectHealthRange(
         provider: record.source.provider,
         valueType: entry.valueType,
         canonicalUnit: entryCanonicalUnit(entry),
+        aggregation: entry.aggregation,
         semanticVariant: entry.semanticVariant,
+        origin: entry.origin,
+        recordingMethod: entry.recordingMethod,
         calendarDate: record.calendarDate,
         hasSamples: false,
       });
-      const entryCoverage = entry.coverage || record.coverage;
       addCoverage(coverage, {
         metricId: entry.metricId,
         provider: record.source.provider,
+        accountKey: record.source.accountKey,
+        aggregation: entry.aggregation,
         semanticVariant: entry.semanticVariant,
+        origin: entry.origin,
+        recordingMethod: entry.recordingMethod,
         calendarDate: record.calendarDate,
-        partial: entryCoverage.status === HEALTH_COVERAGE_STATUSES.Partial,
+        status: entryCoverage.status,
       });
       const expectedUpdateIntervalMs = entryCoverage.expectedUpdateIntervalMs;
       addFreshness(freshness, {
         metricId: entry.metricId,
         provider: record.source.provider,
+        accountKey: record.source.accountKey,
+        aggregation: entry.aggregation,
         semanticVariant: entry.semanticVariant,
+        origin: entry.origin,
+        recordingMethod: entry.recordingMethod,
         lastObservedAtMs: record.endTimeMs,
         lastReceivedAtMs: record.source.receivedAtMs,
         staleAfterMs: typeof expectedUpdateIntervalMs === 'number' && expectedUpdateIntervalMs > 0
@@ -487,24 +597,35 @@ export function projectHealthRange(
       provider: chunk.provider,
       valueType: chunk.valueType,
       canonicalUnit: chunk.canonicalUnit || null,
+      aggregation: chunk.aggregation,
       semanticVariant: chunk.semanticVariant,
+      origin: chunk.origin,
+      recordingMethod: chunk.recordingMethod,
       calendarDate: chunk.calendarDate,
       hasSamples: true,
     });
     addCoverage(coverage, {
       metricId: chunk.metricId,
       provider: chunk.provider,
+      accountKey: chunk.accountKey,
+      aggregation: chunk.aggregation,
       semanticVariant: chunk.semanticVariant,
+      origin: chunk.origin,
+      recordingMethod: chunk.recordingMethod,
       calendarDate: chunk.calendarDate,
-      partial: chunk.coverage.status === HEALTH_COVERAGE_STATUSES.Partial,
+      status: chunk.coverage.status,
     });
     const expectedUpdateIntervalMs = chunk.coverage.expectedUpdateIntervalMs;
     addFreshness(freshness, {
       metricId: chunk.metricId,
       provider: chunk.provider,
+      accountKey: chunk.accountKey,
+      aggregation: chunk.aggregation,
       semanticVariant: chunk.semanticVariant,
+      origin: chunk.origin,
+      recordingMethod: chunk.recordingMethod,
       lastObservedAtMs: chunk.endTimeMs,
-      lastReceivedAtMs: chunk.updatedAtMs,
+      lastReceivedAtMs: chunk.receivedAtMs,
       staleAfterMs: typeof expectedUpdateIntervalMs === 'number' && expectedUpdateIntervalMs > 0
         ? expectedUpdateIntervalMs
         : null,
@@ -531,14 +652,24 @@ export function projectHealthRange(
   const coverageResult: HealthMetricCoverageResult[] = [...coverage.values()].map(item => ({
     metricId: item.metricId,
     provider: item.provider,
+    accountKey: item.accountKey,
+    aggregation: item.aggregation,
     semanticVariant: item.semanticVariant,
+    origin: item.origin,
+    recordingMethod: item.recordingMethod,
     requestedDays: days,
     recordedDays: item.dates.size,
+    missingDays: Math.max(0, days - item.dates.size),
     partialDays: item.partialDates.size,
+    unknownDays: item.unknownDates.size,
     latestDate: item.latestDate,
-  })).sort((left, right) => left.metricId.localeCompare(right.metricId)
-    || left.provider.localeCompare(right.provider)
-    || left.semanticVariant.localeCompare(right.semanticVariant));
+  })).sort((left, right) => compareText(left.metricId, right.metricId)
+    || compareText(left.provider, right.provider)
+    || compareText(left.accountKey, right.accountKey)
+    || compareText(left.aggregation, right.aggregation)
+    || compareText(left.origin, right.origin)
+    || compareText(left.recordingMethod, right.recordingMethod)
+    || compareText(left.semanticVariant, right.semanticVariant));
 
   const freshnessResult: HealthFreshnessResult[] = [...freshness.values()].map((item): HealthFreshnessResult => {
     const ageMs = Math.max(0, nowMs - item.lastObservedAtMs);
@@ -549,31 +680,42 @@ export function projectHealthRange(
         ? 'unknown'
         : ageMs > item.staleAfterMs ? 'stale' : 'fresh',
     };
-  }).sort((left, right) => left.metricId.localeCompare(right.metricId)
-    || left.provider.localeCompare(right.provider)
-    || left.semanticVariant.localeCompare(right.semanticVariant));
+  }).sort((left, right) => compareText(left.metricId, right.metricId)
+    || compareText(left.provider, right.provider)
+    || compareText(left.accountKey, right.accountKey)
+    || compareText(left.aggregation, right.aggregation)
+    || compareText(left.origin, right.origin)
+    || compareText(left.recordingMethod, right.recordingMethod)
+    || compareText(left.semanticVariant, right.semanticVariant));
 
   const discoveryResult: HealthMetricDiscovery[] = [...discovery.values()].map(item => ({
     ...item,
-    providers: item.providers.sort(),
-    valueTypes: item.valueTypes.sort(),
-    canonicalUnits: item.canonicalUnits.sort(),
-    semanticVariants: item.semanticVariants.sort(),
-  })).sort((left, right) => left.metricId.localeCompare(right.metricId));
+    providers: item.providers.sort(compareText),
+    valueTypes: item.valueTypes.sort(compareText),
+    canonicalUnits: item.canonicalUnits.sort(compareText),
+    aggregations: item.aggregations.sort(compareText),
+    semanticVariants: item.semanticVariants.sort(compareText),
+    origins: item.origins.sort(compareText),
+    recordingMethods: item.recordingMethods.sort(compareText),
+  })).sort((left, right) => compareText(left.metricId, right.metricId));
 
   const samplesTruncated = chunkPageTruncated || pointLimitTruncated;
   return {
     query,
     observations,
     sampleChunks: selectedChunks,
-    dailySummaries: [...daily.values()].sort((left, right) => left.calendarDate.localeCompare(right.calendarDate)),
+    dailySummaries: [...daily.values()].sort((left, right) => compareText(left.calendarDate, right.calendarDate)),
     discovery: discoveryResult,
     coverage: coverageResult,
     freshness: freshnessResult,
-    conflicts: buildConflicts(observations),
+    conflicts: findHealthConflicts(observations),
     pageInfo: {
       recordsTruncated,
       samplesTruncated,
+      sampleRevisionMismatchCount,
+      recordAggregateComplete: query.recordCursor === null && !recordsTruncated,
+      sampleAggregateComplete: !query.includeSamples
+        || (query.chunkCursor === null && !samplesTruncated && sampleRevisionMismatchCount === 0),
       recordCursor: recordsTruncated ? cursorForLast(selectedRecords) : null,
       chunkCursor: samplesTruncated && lastConsumedChunk ? cursorForLast([lastConsumedChunk]) : null,
       returnedSamplePoints,

--- a/shared/health-query.ts
+++ b/shared/health-query.ts
@@ -199,7 +199,10 @@ function chunkMatchesKnownParentRevision(
 }
 
 function entryCanonicalUnit(entry: HealthMetricEntry): HealthUnit | null {
-  return entry.kind === 'value' && entry.canonical ? entry.canonical.unit : null;
+  if (entry.kind === 'sleep_reference') {
+    return getHealthMetricDefinition(entry.metricId).canonicalUnit;
+  }
+  return entry.canonical ? entry.canonical.unit : null;
 }
 
 function observationSort(left: HealthObservation, right: HealthObservation): number {

--- a/shared/health-query.ts
+++ b/shared/health-query.ts
@@ -1,10 +1,10 @@
 import {
   HEALTH_COVERAGE_STATUSES,
   HEALTH_DEFAULT_CHUNK_PAGE_SIZE,
-  HEALTH_DEFAULT_RECORD_PAGE_SIZE,
+  HEALTH_DEFAULT_SOURCE_RECORD_PAGE_SIZE,
   HEALTH_DEFAULT_SAMPLE_POINT_LIMIT,
   HEALTH_MAX_CHUNK_PAGE_SIZE,
-  HEALTH_MAX_RECORD_PAGE_SIZE,
+  HEALTH_MAX_SOURCE_RECORD_PAGE_SIZE,
   HEALTH_MAX_SAMPLE_POINT_LIMIT,
   HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK,
   HEALTH_MAX_SAMPLE_RANGE_DAYS,
@@ -140,7 +140,12 @@ export function normalizeHealthRangeQuery(value: HealthRangeQuery | unknown): No
     providers: normalizeProviders(query.providers),
     metricIds: normalizeMetricIds(query.metricIds),
     includeSamples,
-    recordLimit: normalizeLimit(query.recordLimit, HEALTH_DEFAULT_RECORD_PAGE_SIZE, HEALTH_MAX_RECORD_PAGE_SIZE, 'recordLimit'),
+    sourceRecordLimit: normalizeLimit(
+      query.sourceRecordLimit,
+      HEALTH_DEFAULT_SOURCE_RECORD_PAGE_SIZE,
+      HEALTH_MAX_SOURCE_RECORD_PAGE_SIZE,
+      'sourceRecordLimit',
+    ),
     chunkLimit: normalizeLimit(query.chunkLimit, HEALTH_DEFAULT_CHUNK_PAGE_SIZE, HEALTH_MAX_CHUNK_PAGE_SIZE, 'chunkLimit'),
     samplePointLimit: normalizeLimit(
       query.samplePointLimit,
@@ -149,7 +154,7 @@ export function normalizeHealthRangeQuery(value: HealthRangeQuery | unknown): No
       'samplePointLimit',
       HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK,
     ),
-    recordCursor: normalizeCursor(query.recordCursor, 'recordCursor'),
+    sourceRecordCursor: normalizeCursor(query.sourceRecordCursor, 'sourceRecordCursor'),
     chunkCursor: normalizeCursor(query.chunkCursor, 'chunkCursor'),
   };
 }
@@ -182,9 +187,9 @@ function metricMatches(metricId: HealthMetricId, metricIds: readonly HealthMetri
 
 function chunkMatchesKnownParentRevision(
   chunk: HealthSampleChunk,
-  recordsById: ReadonlyMap<string, HealthSourceRecord>,
+  sourceRecordsById: ReadonlyMap<string, HealthSourceRecord>,
 ): boolean {
-  const parent = recordsById.get(chunk.parentRecordId);
+  const parent = sourceRecordsById.get(chunk.parentSourceRecordId);
   if (!parent) {
     return true;
   }
@@ -468,22 +473,22 @@ function requestedDayCount(query: NormalizedHealthRangeQuery): number {
 }
 
 export function projectHealthRange(
-  records: readonly HealthSourceRecord[],
+  sourceRecords: readonly HealthSourceRecord[],
   chunks: readonly HealthSampleChunk[],
   queryValue: HealthRangeQuery | NormalizedHealthRangeQuery,
   nowMs = Date.now(),
 ): HealthRangeResult {
   const query = normalizeHealthRangeQuery(queryValue);
-  const matchingRecords = records
-    .filter(record => record.calendarDate >= query.startDate && record.calendarDate <= query.endDate)
-    .filter(record => providerMatches(record.source.provider, query.providers))
-    .filter(record => query.providers.length > 0
+  const matchingSourceRecords = sourceRecords
+    .filter(sourceRecord => sourceRecord.calendarDate >= query.startDate && sourceRecord.calendarDate <= query.endDate)
+    .filter(sourceRecord => providerMatches(sourceRecord.source.provider, query.providers))
+    .filter(sourceRecord => query.providers.length > 0
       || query.metricIds.length === 0
-      || record.metricIds.some(metricId => metricMatches(metricId, query.metricIds)))
-    .filter(record => isAfterCursor(record, query.recordCursor))
+      || sourceRecord.metricIds.some(metricId => metricMatches(metricId, query.metricIds)))
+    .filter(sourceRecord => isAfterCursor(sourceRecord, query.sourceRecordCursor))
     .sort(compareDateAndId);
-  const recordsTruncated = matchingRecords.length > query.recordLimit;
-  const selectedRecords = matchingRecords.slice(0, query.recordLimit);
+  const sourceRecordsTruncated = matchingSourceRecords.length > query.sourceRecordLimit;
+  const selectedSourceRecords = matchingSourceRecords.slice(0, query.sourceRecordLimit);
 
   const primaryMatchingChunks = query.includeSamples
     ? chunks
@@ -495,7 +500,7 @@ export function projectHealthRange(
     : [];
   const chunkPageTruncated = primaryMatchingChunks.length > query.chunkLimit;
   const selectedChunkPage = primaryMatchingChunks.slice(0, query.chunkLimit);
-  const recordsById = new Map(records.map(record => [record.id, record]));
+  const sourceRecordsById = new Map(sourceRecords.map(sourceRecord => [sourceRecord.id, sourceRecord]));
   const selectedChunks: HealthSampleChunk[] = [];
   let returnedSamplePoints = 0;
   let pointLimitTruncated = false;
@@ -506,7 +511,7 @@ export function projectHealthRange(
       lastConsumedChunk = chunk;
       continue;
     }
-    if (!chunkMatchesKnownParentRevision(chunk, recordsById)) {
+    if (!chunkMatchesKnownParentRevision(chunk, sourceRecordsById)) {
       sampleRevisionMismatchCount += 1;
       lastConsumedChunk = chunk;
       continue;
@@ -526,63 +531,63 @@ export function projectHealthRange(
   const coverage = new Map<string, CoverageAccumulator>();
   const freshness = new Map<string, FreshnessAccumulator>();
 
-  for (const record of selectedRecords) {
-    record.metrics.forEach((entry, index) => {
+  for (const sourceRecord of selectedSourceRecords) {
+    sourceRecord.metrics.forEach((entry, index) => {
       if (!metricMatches(entry.metricId, query.metricIds)) {
         return;
       }
-      const entryCoverage = entry.coverage || record.coverage;
+      const entryCoverage = entry.coverage || sourceRecord.coverage;
       const observation: HealthObservation = {
-        id: `${record.id}:${index}`,
-        recordId: record.id,
-        provider: record.source.provider,
-        accountKey: record.source.accountKey,
-        calendarDate: record.calendarDate,
-        startTimeMs: record.startTimeMs,
-        endTimeMs: record.endTimeMs,
-        timezoneOffsetSeconds: record.timezoneOffsetSeconds,
-        sourceRecordType: record.source.sourceRecordType,
-        sourceRecordKey: record.source.sourceRecordKey,
-        receivedAtMs: record.source.receivedAtMs,
+        id: `${sourceRecord.id}:${index}`,
+        sourceRecordId: sourceRecord.id,
+        provider: sourceRecord.source.provider,
+        accountKey: sourceRecord.source.accountKey,
+        calendarDate: sourceRecord.calendarDate,
+        startTimeMs: sourceRecord.startTimeMs,
+        endTimeMs: sourceRecord.endTimeMs,
+        timezoneOffsetSeconds: sourceRecord.timezoneOffsetSeconds,
+        sourceRecordType: sourceRecord.source.sourceRecordType,
+        sourceRecordKey: sourceRecord.source.sourceRecordKey,
+        receivedAtMs: sourceRecord.source.receivedAtMs,
         coverage: entryCoverage,
-        device: entry.device === undefined ? record.device ?? null : entry.device,
+        device: entry.device === undefined ? sourceRecord.device ?? null : entry.device,
         entry,
       };
       observations.push(observation);
       addDiscoveryEntry(discovery, {
         metricId: entry.metricId,
-        provider: record.source.provider,
+        provider: sourceRecord.source.provider,
         valueType: entry.valueType,
         canonicalUnit: entryCanonicalUnit(entry),
         aggregation: entry.aggregation,
         semanticVariant: entry.semanticVariant,
         origin: entry.origin,
         recordingMethod: entry.recordingMethod,
-        calendarDate: record.calendarDate,
+        calendarDate: sourceRecord.calendarDate,
         hasSamples: false,
       });
       addCoverage(coverage, {
         metricId: entry.metricId,
-        provider: record.source.provider,
-        accountKey: record.source.accountKey,
+        provider: sourceRecord.source.provider,
+        accountKey: sourceRecord.source.accountKey,
         aggregation: entry.aggregation,
         semanticVariant: entry.semanticVariant,
         origin: entry.origin,
         recordingMethod: entry.recordingMethod,
-        calendarDate: record.calendarDate,
+        calendarDate: sourceRecord.calendarDate,
         status: entryCoverage.status,
       });
       const expectedUpdateIntervalMs = entryCoverage.expectedUpdateIntervalMs;
       addFreshness(freshness, {
         metricId: entry.metricId,
-        provider: record.source.provider,
-        accountKey: record.source.accountKey,
+        provider: sourceRecord.source.provider,
+        accountKey: sourceRecord.source.accountKey,
         aggregation: entry.aggregation,
         semanticVariant: entry.semanticVariant,
         origin: entry.origin,
         recordingMethod: entry.recordingMethod,
-        lastObservedAtMs: record.endTimeMs,
-        lastReceivedAtMs: record.source.receivedAtMs,
+        lastObservedAtMs: sourceRecord.endTimeMs,
+        lastReceivedAtMs: sourceRecord.source.receivedAtMs,
         staleAfterMs: typeof expectedUpdateIntervalMs === 'number' && expectedUpdateIntervalMs > 0
           ? expectedUpdateIntervalMs
           : null,
@@ -710,13 +715,13 @@ export function projectHealthRange(
     freshness: freshnessResult,
     conflicts: findHealthConflicts(observations),
     pageInfo: {
-      recordsTruncated,
+      sourceRecordsTruncated,
       samplesTruncated,
       sampleRevisionMismatchCount,
-      recordAggregateComplete: query.recordCursor === null && !recordsTruncated,
+      sourceRecordAggregateComplete: query.sourceRecordCursor === null && !sourceRecordsTruncated,
       sampleAggregateComplete: !query.includeSamples
         || (query.chunkCursor === null && !samplesTruncated && sampleRevisionMismatchCount === 0),
-      recordCursor: recordsTruncated ? cursorForLast(selectedRecords) : null,
+      sourceRecordCursor: sourceRecordsTruncated ? cursorForLast(selectedSourceRecords) : null,
       chunkCursor: samplesTruncated && lastConsumedChunk ? cursorForLast([lastConsumedChunk]) : null,
       returnedSamplePoints,
     },

--- a/shared/health-query.ts
+++ b/shared/health-query.ts
@@ -1,0 +1,586 @@
+import {
+  HEALTH_COVERAGE_STATUSES,
+  HEALTH_DEFAULT_CHUNK_PAGE_SIZE,
+  HEALTH_DEFAULT_RECORD_PAGE_SIZE,
+  HEALTH_DEFAULT_SAMPLE_POINT_LIMIT,
+  HEALTH_MAX_CHUNK_PAGE_SIZE,
+  HEALTH_MAX_RECORD_PAGE_SIZE,
+  HEALTH_MAX_SAMPLE_POINT_LIMIT,
+  HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK,
+  HEALTH_MAX_SAMPLE_RANGE_DAYS,
+  HEALTH_MAX_SUMMARY_RANGE_DAYS,
+  HEALTH_NORMALIZATION_STATUSES,
+  HealthConflict,
+  HealthDailySummary,
+  HealthFreshnessResult,
+  HealthMetricCoverageResult,
+  HealthMetricDiscovery,
+  HealthMetricEntry,
+  HealthMetricId,
+  HealthMetricValue,
+  HealthObservation,
+  HealthProvider,
+  HealthQueryCursor,
+  HealthRangeQuery,
+  HealthRangeResult,
+  HealthSampleChunk,
+  HealthSourceRecord,
+  HealthUnit,
+  HealthValueType,
+  NormalizedHealthRangeQuery,
+  getHealthMetricDefinition,
+  isHealthMetricId,
+  isHealthProvider,
+} from './health';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const SAFE_DOCUMENT_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+export class HealthQueryValidationError extends Error {
+  public readonly name = 'HealthQueryValidationError';
+
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+function parseCalendarDate(value: unknown, field: string): number {
+  if (typeof value !== 'string' || !ISO_DATE_PATTERN.test(value)) {
+    throw new HealthQueryValidationError(`${field} must use YYYY-MM-DD.`);
+  }
+  const timestamp = Date.parse(`${value}T00:00:00.000Z`);
+  if (!Number.isFinite(timestamp) || new Date(timestamp).toISOString().slice(0, 10) !== value) {
+    throw new HealthQueryValidationError(`${field} must be a valid calendar date.`);
+  }
+  return timestamp;
+}
+
+function normalizeLimit(value: unknown, fallback: number, maximum: number, field: string, minimum = 1): number {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  if (!Number.isSafeInteger(value) || Number(value) < minimum || Number(value) > maximum) {
+    throw new HealthQueryValidationError(`${field} must be an integer from ${minimum} to ${maximum}.`);
+  }
+  return Number(value);
+}
+
+function normalizeCursor(value: unknown, field: string): HealthQueryCursor | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new HealthQueryValidationError(`${field} must be a cursor object.`);
+  }
+  const cursor = value as Record<string, unknown>;
+  parseCalendarDate(cursor.calendarDate, `${field}.calendarDate`);
+  if (typeof cursor.id !== 'string'
+    || cursor.id !== cursor.id.trim()
+    || !SAFE_DOCUMENT_ID_PATTERN.test(cursor.id)) {
+    throw new HealthQueryValidationError(`${field}.id must be a safe bounded document ID.`);
+  }
+  return { calendarDate: cursor.calendarDate as string, id: cursor.id };
+}
+
+function normalizeProviders(value: unknown): HealthProvider[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  if (!Array.isArray(value) || value.length > 5 || value.some(provider => !isHealthProvider(provider))) {
+    throw new HealthQueryValidationError('providers must contain at most five supported providers.');
+  }
+  return [...new Set(value as HealthProvider[])];
+}
+
+function normalizeMetricIds(value: unknown): HealthMetricId[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  if (!Array.isArray(value) || value.length > 30 || value.some(metricId => !isHealthMetricId(metricId))) {
+    throw new HealthQueryValidationError('metricIds must contain at most 30 supported metric IDs.');
+  }
+  return [...new Set(value as HealthMetricId[])];
+}
+
+export function normalizeHealthRangeQuery(value: HealthRangeQuery | unknown): NormalizedHealthRangeQuery {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new HealthQueryValidationError('Health range query must be an object.');
+  }
+  const query = value as Record<string, unknown>;
+  const startMs = parseCalendarDate(query.startDate, 'startDate');
+  const endMs = parseCalendarDate(query.endDate, 'endDate');
+  if (endMs < startMs) {
+    throw new HealthQueryValidationError('endDate must be on or after startDate.');
+  }
+  const requestedDays = Math.floor((endMs - startMs) / DAY_MS) + 1;
+  const includeSamples = query.includeSamples === true;
+  const maximumDays = includeSamples ? HEALTH_MAX_SAMPLE_RANGE_DAYS : HEALTH_MAX_SUMMARY_RANGE_DAYS;
+  if (requestedDays > maximumDays) {
+    throw new HealthQueryValidationError(`Requested range exceeds the ${maximumDays}-day limit.`);
+  }
+  if (query.includeSamples !== undefined && typeof query.includeSamples !== 'boolean') {
+    throw new HealthQueryValidationError('includeSamples must be a boolean.');
+  }
+
+  return {
+    startDate: query.startDate as string,
+    endDate: query.endDate as string,
+    providers: normalizeProviders(query.providers),
+    metricIds: normalizeMetricIds(query.metricIds),
+    includeSamples,
+    recordLimit: normalizeLimit(query.recordLimit, HEALTH_DEFAULT_RECORD_PAGE_SIZE, HEALTH_MAX_RECORD_PAGE_SIZE, 'recordLimit'),
+    chunkLimit: normalizeLimit(query.chunkLimit, HEALTH_DEFAULT_CHUNK_PAGE_SIZE, HEALTH_MAX_CHUNK_PAGE_SIZE, 'chunkLimit'),
+    samplePointLimit: normalizeLimit(
+      query.samplePointLimit,
+      HEALTH_DEFAULT_SAMPLE_POINT_LIMIT,
+      HEALTH_MAX_SAMPLE_POINT_LIMIT,
+      'samplePointLimit',
+      HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK,
+    ),
+    recordCursor: normalizeCursor(query.recordCursor, 'recordCursor'),
+    chunkCursor: normalizeCursor(query.chunkCursor, 'chunkCursor'),
+  };
+}
+
+function compareDateAndId(
+  left: Pick<HealthSourceRecord | HealthSampleChunk, 'calendarDate' | 'id'>,
+  right: Pick<HealthSourceRecord | HealthSampleChunk, 'calendarDate' | 'id'>,
+): number {
+  return left.calendarDate.localeCompare(right.calendarDate) || left.id.localeCompare(right.id);
+}
+
+function isAfterCursor(
+  value: Pick<HealthSourceRecord | HealthSampleChunk, 'calendarDate' | 'id'>,
+  cursor: HealthQueryCursor | null,
+): boolean {
+  return !cursor || compareDateAndId(value, cursor as Pick<HealthSourceRecord, 'calendarDate' | 'id'>) > 0;
+}
+
+function providerMatches(provider: HealthProvider, providers: readonly HealthProvider[]): boolean {
+  return providers.length === 0 || providers.includes(provider);
+}
+
+function metricMatches(metricId: HealthMetricId, metricIds: readonly HealthMetricId[]): boolean {
+  return metricIds.length === 0 || metricIds.includes(metricId);
+}
+
+function entryCanonicalUnit(entry: HealthMetricEntry): HealthUnit | null {
+  return entry.kind === 'value' && entry.canonical ? entry.canonical.unit : null;
+}
+
+function observationSort(left: HealthObservation, right: HealthObservation): number {
+  return left.calendarDate.localeCompare(right.calendarDate)
+    || left.startTimeMs - right.startTimeMs
+    || left.provider.localeCompare(right.provider)
+    || left.id.localeCompare(right.id);
+}
+
+function addUnique<T>(values: T[], value: T): void {
+  if (!values.includes(value)) {
+    values.push(value);
+  }
+}
+
+interface DiscoveryAccumulator {
+  metricId: HealthMetricId;
+  providers: HealthProvider[];
+  valueTypes: HealthValueType[];
+  canonicalUnits: HealthUnit[];
+  semanticVariants: string[];
+  firstDate: string;
+  lastDate: string;
+  hasSamples: boolean;
+}
+
+function addDiscoveryEntry(
+  target: Map<HealthMetricId, DiscoveryAccumulator>,
+  input: {
+    metricId: HealthMetricId;
+    provider: HealthProvider;
+    valueType: HealthValueType;
+    canonicalUnit: HealthUnit | null;
+    semanticVariant: string;
+    calendarDate: string;
+    hasSamples: boolean;
+  },
+): void {
+  const current = target.get(input.metricId) || {
+    metricId: input.metricId,
+    providers: [],
+    valueTypes: [],
+    canonicalUnits: [],
+    semanticVariants: [],
+    firstDate: input.calendarDate,
+    lastDate: input.calendarDate,
+    hasSamples: false,
+  };
+  addUnique(current.providers, input.provider);
+  addUnique(current.valueTypes, input.valueType);
+  if (input.canonicalUnit) {
+    addUnique(current.canonicalUnits, input.canonicalUnit);
+  }
+  addUnique(current.semanticVariants, input.semanticVariant);
+  current.firstDate = current.firstDate < input.calendarDate ? current.firstDate : input.calendarDate;
+  current.lastDate = current.lastDate > input.calendarDate ? current.lastDate : input.calendarDate;
+  current.hasSamples ||= input.hasSamples;
+  target.set(input.metricId, current);
+}
+
+interface CoverageAccumulator {
+  metricId: HealthMetricId;
+  provider: HealthProvider;
+  semanticVariant: string;
+  dates: Set<string>;
+  partialDates: Set<string>;
+  latestDate: string;
+}
+
+function coverageKey(metricId: HealthMetricId, provider: HealthProvider, semanticVariant: string): string {
+  return `${metricId}\u0000${provider}\u0000${semanticVariant}`;
+}
+
+function addCoverage(
+  target: Map<string, CoverageAccumulator>,
+  input: {
+    metricId: HealthMetricId;
+    provider: HealthProvider;
+    semanticVariant: string;
+    calendarDate: string;
+    partial: boolean;
+  },
+): void {
+  const key = coverageKey(input.metricId, input.provider, input.semanticVariant);
+  const current = target.get(key) || {
+    metricId: input.metricId,
+    provider: input.provider,
+    semanticVariant: input.semanticVariant,
+    dates: new Set<string>(),
+    partialDates: new Set<string>(),
+    latestDate: input.calendarDate,
+  };
+  current.dates.add(input.calendarDate);
+  if (input.partial) {
+    current.partialDates.add(input.calendarDate);
+  }
+  current.latestDate = current.latestDate > input.calendarDate ? current.latestDate : input.calendarDate;
+  target.set(key, current);
+}
+
+interface FreshnessAccumulator {
+  metricId: HealthMetricId;
+  provider: HealthProvider;
+  semanticVariant: string;
+  lastObservedAtMs: number;
+  lastReceivedAtMs: number;
+  staleAfterMs: number | null;
+}
+
+function addFreshness(
+  target: Map<string, FreshnessAccumulator>,
+  input: FreshnessAccumulator,
+): void {
+  const key = coverageKey(input.metricId, input.provider, input.semanticVariant);
+  const current = target.get(key);
+  if (!current || input.lastObservedAtMs > current.lastObservedAtMs) {
+    target.set(key, input);
+    return;
+  }
+  if (input.lastObservedAtMs === current.lastObservedAtMs) {
+    current.lastReceivedAtMs = Math.max(current.lastReceivedAtMs, input.lastReceivedAtMs);
+    current.staleAfterMs = input.staleAfterMs ?? current.staleAfterMs;
+  }
+}
+
+function scalarEqual(left: unknown, right: unknown): boolean {
+  if (typeof left === 'number' && typeof right === 'number') {
+    const tolerance = Math.max(1e-6, Math.abs(left) * 1e-9, Math.abs(right) * 1e-9);
+    return Math.abs(left - right) <= tolerance;
+  }
+  return left === right;
+}
+
+function intervalsOverlap(left: HealthObservation, right: HealthObservation): boolean {
+  return left.startTimeMs <= right.endTimeMs && right.startTimeMs <= left.endTimeMs;
+}
+
+function buildConflicts(observations: readonly HealthObservation[]): HealthConflict[] {
+  const candidates = new Map<string, HealthObservation[]>();
+  for (const observation of observations) {
+    const entry = observation.entry;
+    if (
+      entry.kind !== 'value'
+      || entry.normalizationStatus !== HEALTH_NORMALIZATION_STATUSES.Canonical
+      || !entry.canonical
+    ) {
+      continue;
+    }
+    const key = [
+      entry.metricId,
+      observation.calendarDate,
+      entry.aggregation,
+      entry.semanticVariant,
+      entry.origin,
+      entry.canonical.unit,
+    ].join('\u0000');
+    candidates.set(key, [...(candidates.get(key) || []), observation]);
+  }
+
+  const conflicts: HealthConflict[] = [];
+  for (const group of candidates.values()) {
+    const conflictingIds = new Set<string>();
+    for (let leftIndex = 0; leftIndex < group.length; leftIndex += 1) {
+      for (let rightIndex = leftIndex + 1; rightIndex < group.length; rightIndex += 1) {
+        const left = group[leftIndex];
+        const right = group[rightIndex];
+        const sameSource = left.provider === right.provider && left.accountKey === right.accountKey;
+        if (sameSource || !intervalsOverlap(left, right)) {
+          continue;
+        }
+        const leftValue = (left.entry as HealthMetricValue).canonical?.value;
+        const rightValue = (right.entry as HealthMetricValue).canonical?.value;
+        if (!scalarEqual(leftValue, rightValue)) {
+          conflictingIds.add(left.id);
+          conflictingIds.add(right.id);
+        }
+      }
+    }
+    if (conflictingIds.size < 2) {
+      continue;
+    }
+    const conflicting = group.filter(item => conflictingIds.has(item.id));
+    const first = conflicting[0];
+    const firstEntry = first.entry as HealthMetricValue;
+    conflicts.push({
+      metricId: firstEntry.metricId,
+      calendarDate: first.calendarDate,
+      aggregation: firstEntry.aggregation,
+      semanticVariant: firstEntry.semanticVariant,
+      canonicalUnit: firstEntry.canonical!.unit,
+      observationIds: conflicting.map(item => item.id).sort(),
+      providers: [...new Set(conflicting.map(item => item.provider))].sort(),
+    });
+  }
+  return conflicts.sort((left, right) => left.calendarDate.localeCompare(right.calendarDate)
+    || left.metricId.localeCompare(right.metricId)
+    || left.semanticVariant.localeCompare(right.semanticVariant));
+}
+
+function cursorForLast(values: readonly Pick<HealthSourceRecord | HealthSampleChunk, 'calendarDate' | 'id'>[]): HealthQueryCursor | null {
+  const last = values[values.length - 1];
+  return last ? { calendarDate: last.calendarDate, id: last.id } : null;
+}
+
+function requestedDayCount(query: NormalizedHealthRangeQuery): number {
+  const startMs = Date.parse(`${query.startDate}T00:00:00.000Z`);
+  const endMs = Date.parse(`${query.endDate}T00:00:00.000Z`);
+  return Math.floor((endMs - startMs) / DAY_MS) + 1;
+}
+
+export function projectHealthRange(
+  records: readonly HealthSourceRecord[],
+  chunks: readonly HealthSampleChunk[],
+  queryValue: HealthRangeQuery | NormalizedHealthRangeQuery,
+  nowMs = Date.now(),
+): HealthRangeResult {
+  const query = normalizeHealthRangeQuery(queryValue);
+  const matchingRecords = records
+    .filter(record => record.calendarDate >= query.startDate && record.calendarDate <= query.endDate)
+    .filter(record => providerMatches(record.source.provider, query.providers))
+    .filter(record => query.providers.length > 0
+      || query.metricIds.length === 0
+      || record.metricIds.some(metricId => metricMatches(metricId, query.metricIds)))
+    .filter(record => isAfterCursor(record, query.recordCursor))
+    .sort(compareDateAndId);
+  const recordsTruncated = matchingRecords.length > query.recordLimit;
+  const selectedRecords = matchingRecords.slice(0, query.recordLimit);
+
+  const primaryMatchingChunks = query.includeSamples
+    ? chunks
+      .filter(chunk => chunk.calendarDate >= query.startDate && chunk.calendarDate <= query.endDate)
+      .filter(chunk => providerMatches(chunk.provider, query.providers))
+      .filter(chunk => query.providers.length > 0 || metricMatches(chunk.metricId, query.metricIds))
+      .filter(chunk => isAfterCursor(chunk, query.chunkCursor))
+      .sort(compareDateAndId)
+    : [];
+  const chunkPageTruncated = primaryMatchingChunks.length > query.chunkLimit;
+  const selectedChunkPage = primaryMatchingChunks.slice(0, query.chunkLimit);
+  const selectedChunks: HealthSampleChunk[] = [];
+  let returnedSamplePoints = 0;
+  let pointLimitTruncated = false;
+  let lastConsumedChunk: HealthSampleChunk | null = null;
+  for (const chunk of selectedChunkPage) {
+    if (!metricMatches(chunk.metricId, query.metricIds)) {
+      lastConsumedChunk = chunk;
+      continue;
+    }
+    const pointCount = chunk.offsetMs.length;
+    if (returnedSamplePoints + pointCount > query.samplePointLimit) {
+      pointLimitTruncated = true;
+      break;
+    }
+    selectedChunks.push(chunk);
+    returnedSamplePoints += pointCount;
+    lastConsumedChunk = chunk;
+  }
+
+  const observations: HealthObservation[] = [];
+  const discovery = new Map<HealthMetricId, DiscoveryAccumulator>();
+  const coverage = new Map<string, CoverageAccumulator>();
+  const freshness = new Map<string, FreshnessAccumulator>();
+
+  for (const record of selectedRecords) {
+    record.metrics.forEach((entry, index) => {
+      if (!metricMatches(entry.metricId, query.metricIds)) {
+        return;
+      }
+      const observation: HealthObservation = {
+        id: `${record.id}:${index}`,
+        recordId: record.id,
+        provider: record.source.provider,
+        accountKey: record.source.accountKey,
+        calendarDate: record.calendarDate,
+        startTimeMs: record.startTimeMs,
+        endTimeMs: record.endTimeMs,
+        timezoneOffsetSeconds: record.timezoneOffsetSeconds,
+        sourceRecordType: record.source.sourceRecordType,
+        sourceRecordKey: record.source.sourceRecordKey,
+        receivedAtMs: record.source.receivedAtMs,
+        entry,
+      };
+      observations.push(observation);
+      addDiscoveryEntry(discovery, {
+        metricId: entry.metricId,
+        provider: record.source.provider,
+        valueType: entry.valueType,
+        canonicalUnit: entryCanonicalUnit(entry),
+        semanticVariant: entry.semanticVariant,
+        calendarDate: record.calendarDate,
+        hasSamples: false,
+      });
+      const entryCoverage = entry.coverage || record.coverage;
+      addCoverage(coverage, {
+        metricId: entry.metricId,
+        provider: record.source.provider,
+        semanticVariant: entry.semanticVariant,
+        calendarDate: record.calendarDate,
+        partial: entryCoverage.status === HEALTH_COVERAGE_STATUSES.Partial,
+      });
+      const expectedUpdateIntervalMs = entryCoverage.expectedUpdateIntervalMs;
+      addFreshness(freshness, {
+        metricId: entry.metricId,
+        provider: record.source.provider,
+        semanticVariant: entry.semanticVariant,
+        lastObservedAtMs: record.endTimeMs,
+        lastReceivedAtMs: record.source.receivedAtMs,
+        staleAfterMs: typeof expectedUpdateIntervalMs === 'number' && expectedUpdateIntervalMs > 0
+          ? expectedUpdateIntervalMs
+          : null,
+      });
+    });
+  }
+  observations.sort(observationSort);
+
+  for (const chunk of selectedChunks) {
+    addDiscoveryEntry(discovery, {
+      metricId: chunk.metricId,
+      provider: chunk.provider,
+      valueType: chunk.valueType,
+      canonicalUnit: chunk.canonicalUnit || null,
+      semanticVariant: chunk.semanticVariant,
+      calendarDate: chunk.calendarDate,
+      hasSamples: true,
+    });
+    addCoverage(coverage, {
+      metricId: chunk.metricId,
+      provider: chunk.provider,
+      semanticVariant: chunk.semanticVariant,
+      calendarDate: chunk.calendarDate,
+      partial: chunk.coverage.status === HEALTH_COVERAGE_STATUSES.Partial,
+    });
+    const expectedUpdateIntervalMs = chunk.coverage.expectedUpdateIntervalMs;
+    addFreshness(freshness, {
+      metricId: chunk.metricId,
+      provider: chunk.provider,
+      semanticVariant: chunk.semanticVariant,
+      lastObservedAtMs: chunk.endTimeMs,
+      lastReceivedAtMs: chunk.updatedAtMs,
+      staleAfterMs: typeof expectedUpdateIntervalMs === 'number' && expectedUpdateIntervalMs > 0
+        ? expectedUpdateIntervalMs
+        : null,
+    });
+  }
+
+  const daily = new Map<string, HealthDailySummary>();
+  for (const observation of observations) {
+    const current = daily.get(observation.calendarDate) || {
+      calendarDate: observation.calendarDate,
+      observationIds: [],
+      providers: [],
+      sleepReferenceIds: [],
+    };
+    current.observationIds.push(observation.id);
+    addUnique(current.providers, observation.provider);
+    if (observation.entry.kind === 'sleep_reference') {
+      addUnique(current.sleepReferenceIds, observation.entry.reference.documentId);
+    }
+    daily.set(observation.calendarDate, current);
+  }
+
+  const days = requestedDayCount(query);
+  const coverageResult: HealthMetricCoverageResult[] = [...coverage.values()].map(item => ({
+    metricId: item.metricId,
+    provider: item.provider,
+    semanticVariant: item.semanticVariant,
+    requestedDays: days,
+    recordedDays: item.dates.size,
+    partialDays: item.partialDates.size,
+    latestDate: item.latestDate,
+  })).sort((left, right) => left.metricId.localeCompare(right.metricId)
+    || left.provider.localeCompare(right.provider)
+    || left.semanticVariant.localeCompare(right.semanticVariant));
+
+  const freshnessResult: HealthFreshnessResult[] = [...freshness.values()].map((item): HealthFreshnessResult => {
+    const ageMs = Math.max(0, nowMs - item.lastObservedAtMs);
+    return {
+      ...item,
+      ageMs,
+      status: item.staleAfterMs === null
+        ? 'unknown'
+        : ageMs > item.staleAfterMs ? 'stale' : 'fresh',
+    };
+  }).sort((left, right) => left.metricId.localeCompare(right.metricId)
+    || left.provider.localeCompare(right.provider)
+    || left.semanticVariant.localeCompare(right.semanticVariant));
+
+  const discoveryResult: HealthMetricDiscovery[] = [...discovery.values()].map(item => ({
+    ...item,
+    providers: item.providers.sort(),
+    valueTypes: item.valueTypes.sort(),
+    canonicalUnits: item.canonicalUnits.sort(),
+    semanticVariants: item.semanticVariants.sort(),
+  })).sort((left, right) => left.metricId.localeCompare(right.metricId));
+
+  const samplesTruncated = chunkPageTruncated || pointLimitTruncated;
+  return {
+    query,
+    observations,
+    sampleChunks: selectedChunks,
+    dailySummaries: [...daily.values()].sort((left, right) => left.calendarDate.localeCompare(right.calendarDate)),
+    discovery: discoveryResult,
+    coverage: coverageResult,
+    freshness: freshnessResult,
+    conflicts: buildConflicts(observations),
+    pageInfo: {
+      recordsTruncated,
+      samplesTruncated,
+      recordCursor: recordsTruncated ? cursorForLast(selectedRecords) : null,
+      chunkCursor: samplesTruncated && lastConsumedChunk ? cursorForLast([lastConsumedChunk]) : null,
+      returnedSamplePoints,
+    },
+  };
+}
+
+export function canonicalUnitForMetric(metricId: HealthMetricId): HealthUnit {
+  return getHealthMetricDefinition(metricId).canonicalUnit;
+}

--- a/shared/health.ts
+++ b/shared/health.ts
@@ -1,25 +1,25 @@
 export const HEALTH_SCHEMA_VERSION = 1 as const;
 
-export const HEALTH_RECORDS_COLLECTION_ID = 'healthRecords';
+export const HEALTH_SOURCE_RECORDS_COLLECTION_ID = 'healthSourceRecords';
 export const HEALTH_SAMPLE_CHUNKS_COLLECTION_ID = 'healthSampleChunks';
 export const HEALTH_SYNC_STATE_COLLECTION_ID = 'healthSyncState';
 
-export const HEALTH_MAX_METRICS_PER_RECORD = 128;
+export const HEALTH_MAX_METRICS_PER_SOURCE_RECORD = 128;
 export const HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK = 1_440;
-export const HEALTH_MAX_SAMPLE_CHUNKS_PER_RECORD = 200;
-export const HEALTH_MAX_RECORD_DOCUMENT_BYTES = 256 * 1024;
+export const HEALTH_MAX_SAMPLE_CHUNKS_PER_SOURCE_RECORD = 200;
+export const HEALTH_MAX_SOURCE_RECORD_DOCUMENT_BYTES = 256 * 1024;
 export const HEALTH_MAX_SAMPLE_CHUNK_DOCUMENT_BYTES = 900 * 1024;
 // A replacement can include both the incoming revision and deletion of the
 // previous revision. Keep each side below half Firestore's 10 MiB request cap,
 // leaving headroom for document names, index entries, and protocol overhead.
 export const HEALTH_MAX_WRITE_BYTES = 4 * 1024 * 1024;
-export const HEALTH_DEFAULT_RECORD_PAGE_SIZE = 32;
-export const HEALTH_MAX_RECORD_PAGE_SIZE = 32;
+export const HEALTH_DEFAULT_SOURCE_RECORD_PAGE_SIZE = 32;
+export const HEALTH_MAX_SOURCE_RECORD_PAGE_SIZE = 32;
 export const HEALTH_DEFAULT_CHUNK_PAGE_SIZE = 8;
 export const HEALTH_MAX_CHUNK_PAGE_SIZE = 8;
 export const HEALTH_DEFAULT_SAMPLE_POINT_LIMIT = 10_000;
 export const HEALTH_MAX_SAMPLE_POINT_LIMIT = HEALTH_MAX_CHUNK_PAGE_SIZE * HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK;
-export const HEALTH_MAX_QUERY_FETCH_BYTES = (HEALTH_MAX_RECORD_PAGE_SIZE + 1) * HEALTH_MAX_RECORD_DOCUMENT_BYTES
+export const HEALTH_MAX_QUERY_FETCH_BYTES = (HEALTH_MAX_SOURCE_RECORD_PAGE_SIZE + 1) * HEALTH_MAX_SOURCE_RECORD_DOCUMENT_BYTES
   + (HEALTH_MAX_CHUNK_PAGE_SIZE + 1) * HEALTH_MAX_SAMPLE_CHUNK_DOCUMENT_BYTES;
 export const HEALTH_MAX_SUMMARY_RANGE_DAYS = 366;
 export const HEALTH_MAX_SAMPLE_RANGE_DAYS = 31;
@@ -34,14 +34,14 @@ export const HEALTH_PROVIDERS = {
 
 export type HealthProvider = typeof HEALTH_PROVIDERS[keyof typeof HEALTH_PROVIDERS];
 
-export const HEALTH_RECORD_KINDS = {
+export const HEALTH_SOURCE_RECORD_KINDS = {
   DailySummary: 'daily_summary',
   IntervalSummary: 'interval_summary',
   PointMeasurement: 'point_measurement',
   ProfileSnapshot: 'profile_snapshot',
 } as const;
 
-export type HealthRecordKind = typeof HEALTH_RECORD_KINDS[keyof typeof HEALTH_RECORD_KINDS];
+export type HealthSourceRecordKind = typeof HEALTH_SOURCE_RECORD_KINDS[keyof typeof HEALTH_SOURCE_RECORD_KINDS];
 
 export const HEALTH_VALUE_ORIGINS = {
   Recorded: 'recorded',
@@ -314,7 +314,7 @@ export interface HealthSleepMetricReference extends HealthMetricBase {
 
 export type HealthMetricEntry = HealthMetricValue | HealthSleepMetricReference;
 
-export interface HealthRecordRevision {
+export interface HealthSourceRecordRevision {
   order: number;
   token: string;
   digest: string;
@@ -325,7 +325,7 @@ export interface HealthSourceMetadata {
   accountKey: string;
   sourceRecordType: string;
   sourceRecordKey: string;
-  revision: HealthRecordRevision;
+  revision: HealthSourceRecordRevision;
   receivedAtMs: number;
 }
 
@@ -333,7 +333,7 @@ export interface HealthSourceRecord {
   schemaVersion: typeof HEALTH_SCHEMA_VERSION;
   id: string;
   userID: string;
-  kind: HealthRecordKind;
+  kind: HealthSourceRecordKind;
   source: HealthSourceMetadata;
   calendarDate: string;
   startTimeMs: number;
@@ -352,7 +352,7 @@ export interface HealthSampleChunk {
   schemaVersion: typeof HEALTH_SCHEMA_VERSION;
   id: string;
   userID: string;
-  parentRecordId: string;
+  parentSourceRecordId: string;
   provider: HealthProvider;
   accountKey: string;
   metricId: HealthMetricId;
@@ -378,7 +378,7 @@ export interface HealthSampleChunk {
   qualityCodes?: string[] | null;
   coverage: HealthCoverage;
   device?: HealthDeviceAttribution | null;
-  revision: HealthRecordRevision;
+  revision: HealthSourceRecordRevision;
   createdAtMs: number;
   updatedAtMs: number;
 }
@@ -416,10 +416,10 @@ export interface HealthRangeQuery {
   providers?: HealthProvider[];
   metricIds?: HealthMetricId[];
   includeSamples?: boolean;
-  recordLimit?: number;
+  sourceRecordLimit?: number;
   chunkLimit?: number;
   samplePointLimit?: number;
-  recordCursor?: HealthQueryCursor | null;
+  sourceRecordCursor?: HealthQueryCursor | null;
   chunkCursor?: HealthQueryCursor | null;
 }
 
@@ -427,16 +427,16 @@ export interface NormalizedHealthRangeQuery extends HealthRangeQuery {
   providers: HealthProvider[];
   metricIds: HealthMetricId[];
   includeSamples: boolean;
-  recordLimit: number;
+  sourceRecordLimit: number;
   chunkLimit: number;
   samplePointLimit: number;
-  recordCursor: HealthQueryCursor | null;
+  sourceRecordCursor: HealthQueryCursor | null;
   chunkCursor: HealthQueryCursor | null;
 }
 
 export interface HealthObservation {
   id: string;
-  recordId: string;
+  sourceRecordId: string;
   provider: HealthProvider;
   accountKey: string;
   calendarDate: string;
@@ -520,12 +520,12 @@ export interface HealthConflict {
 }
 
 export interface HealthRangePageInfo {
-  recordsTruncated: boolean;
+  sourceRecordsTruncated: boolean;
   samplesTruncated: boolean;
   sampleRevisionMismatchCount: number;
-  recordAggregateComplete: boolean;
+  sourceRecordAggregateComplete: boolean;
   sampleAggregateComplete: boolean;
-  recordCursor: HealthQueryCursor | null;
+  sourceRecordCursor: HealthQueryCursor | null;
   chunkCursor: HealthQueryCursor | null;
   returnedSamplePoints: number;
 }

--- a/shared/health.ts
+++ b/shared/health.ts
@@ -1,0 +1,524 @@
+export const HEALTH_SCHEMA_VERSION = 1 as const;
+
+export const HEALTH_RECORDS_COLLECTION_ID = 'healthRecords';
+export const HEALTH_SAMPLE_CHUNKS_COLLECTION_ID = 'healthSampleChunks';
+export const HEALTH_SYNC_STATE_COLLECTION_ID = 'healthSyncState';
+
+export const HEALTH_MAX_METRICS_PER_RECORD = 128;
+export const HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK = 1_440;
+export const HEALTH_MAX_SAMPLE_CHUNKS_PER_RECORD = 200;
+export const HEALTH_MAX_DOCUMENT_BYTES = 900 * 1024;
+export const HEALTH_MAX_WRITE_BYTES = 8 * 1024 * 1024;
+export const HEALTH_DEFAULT_RECORD_PAGE_SIZE = 250;
+export const HEALTH_MAX_RECORD_PAGE_SIZE = 1_000;
+export const HEALTH_DEFAULT_CHUNK_PAGE_SIZE = 100;
+export const HEALTH_MAX_CHUNK_PAGE_SIZE = 500;
+export const HEALTH_DEFAULT_SAMPLE_POINT_LIMIT = 25_000;
+export const HEALTH_MAX_SAMPLE_POINT_LIMIT = 50_000;
+export const HEALTH_MAX_SUMMARY_RANGE_DAYS = 366;
+export const HEALTH_MAX_SAMPLE_RANGE_DAYS = 31;
+
+export const HEALTH_PROVIDERS = {
+  GarminAPI: 'GarminAPI',
+  SuuntoApp: 'SuuntoApp',
+  COROSAPI: 'COROSAPI',
+  WahooAPI: 'WahooAPI',
+  QuantifiedSelf: 'QuantifiedSelf',
+} as const;
+
+export type HealthProvider = typeof HEALTH_PROVIDERS[keyof typeof HEALTH_PROVIDERS];
+
+export const HEALTH_RECORD_KINDS = {
+  DailySummary: 'daily_summary',
+  IntervalSummary: 'interval_summary',
+  PointMeasurement: 'point_measurement',
+  ProfileSnapshot: 'profile_snapshot',
+} as const;
+
+export type HealthRecordKind = typeof HEALTH_RECORD_KINDS[keyof typeof HEALTH_RECORD_KINDS];
+
+export const HEALTH_VALUE_ORIGINS = {
+  Recorded: 'recorded',
+  ProviderSummary: 'provider_summary',
+  QuantifiedSelfDerived: 'quantified_self_derived',
+} as const;
+
+export type HealthValueOrigin = typeof HEALTH_VALUE_ORIGINS[keyof typeof HEALTH_VALUE_ORIGINS];
+
+export const HEALTH_RECORDING_METHODS = {
+  Device: 'device',
+  Manual: 'manual',
+  ProviderCalculated: 'provider_calculated',
+  QuantifiedSelfCalculated: 'quantified_self_calculated',
+  Unknown: 'unknown',
+} as const;
+
+export type HealthRecordingMethod = typeof HEALTH_RECORDING_METHODS[keyof typeof HEALTH_RECORDING_METHODS];
+
+export const HEALTH_NORMALIZATION_STATUSES = {
+  Canonical: 'canonical',
+  NativeOnly: 'native_only',
+  NotComparable: 'not_comparable',
+} as const;
+
+export type HealthNormalizationStatus = typeof HEALTH_NORMALIZATION_STATUSES[keyof typeof HEALTH_NORMALIZATION_STATUSES];
+
+export const HEALTH_QUALITY_STATUSES = {
+  Valid: 'valid',
+  Estimated: 'estimated',
+  Partial: 'partial',
+  Unknown: 'unknown',
+} as const;
+
+export type HealthQualityStatus = typeof HEALTH_QUALITY_STATUSES[keyof typeof HEALTH_QUALITY_STATUSES];
+
+export const HEALTH_COVERAGE_STATUSES = {
+  Complete: 'complete',
+  Partial: 'partial',
+  Unknown: 'unknown',
+} as const;
+
+export type HealthCoverageStatus = typeof HEALTH_COVERAGE_STATUSES[keyof typeof HEALTH_COVERAGE_STATUSES];
+
+export const HEALTH_VALUE_TYPES = {
+  Number: 'number',
+  Category: 'category',
+  Boolean: 'boolean',
+} as const;
+
+export type HealthValueType = typeof HEALTH_VALUE_TYPES[keyof typeof HEALTH_VALUE_TYPES];
+export type HealthScalar = number | string | boolean;
+export type HealthQualifierValue = string | number | boolean | null;
+
+export const HEALTH_UNITS = {
+  Count: 'count',
+  Meter: 'm',
+  Second: 's',
+  Kilocalorie: 'kcal',
+  BeatsPerMinute: 'bpm',
+  Millisecond: 'ms',
+  Percent: 'percent',
+  BreathsPerMinute: 'brpm',
+  Kilogram: 'kg',
+  KilogramsPerSquareMeter: 'kg_per_m2',
+  MillimetersMercury: 'mmHg',
+  Celsius: 'celsius',
+  MillilitersPerKilogramPerMinute: 'ml_per_kg_per_min',
+  Years: 'years',
+  Score: 'score',
+  Category: 'category',
+} as const;
+
+export type HealthUnit = typeof HEALTH_UNITS[keyof typeof HEALTH_UNITS];
+
+export const HEALTH_METRIC_IDS = {
+  Steps: 'steps',
+  WheelchairPushes: 'wheelchair_pushes',
+  Distance: 'distance',
+  WheelchairPushDistance: 'wheelchair_push_distance',
+  FloorsClimbed: 'floors_climbed',
+  ActiveDuration: 'active_duration',
+  ModerateIntensityDuration: 'moderate_intensity_duration',
+  VigorousIntensityDuration: 'vigorous_intensity_duration',
+  Altitude: 'altitude',
+  ActiveEnergy: 'active_energy',
+  BasalEnergy: 'basal_energy',
+  TotalEnergy: 'total_energy',
+  HeartRate: 'heart_rate',
+  RestingHeartRate: 'resting_heart_rate',
+  HeartRateVariability: 'heart_rate_variability',
+  BloodOxygenSaturation: 'blood_oxygen_saturation',
+  RespirationRate: 'respiration_rate',
+  StressLevel: 'stress_level',
+  StressState: 'stress_state',
+  StressDuration: 'stress_duration',
+  BodyEnergy: 'body_energy',
+  BodyEnergyChange: 'body_energy_change',
+  RecoveryScore: 'recovery_score',
+  BodyWeight: 'body_weight',
+  BodyMassIndex: 'body_mass_index',
+  BodyFat: 'body_fat',
+  BodyWater: 'body_water',
+  MuscleMass: 'muscle_mass',
+  BoneMass: 'bone_mass',
+  BloodPressureSystolic: 'blood_pressure_systolic',
+  BloodPressureDiastolic: 'blood_pressure_diastolic',
+  PulseRate: 'pulse_rate',
+  SkinTemperatureDeviation: 'skin_temperature_deviation',
+  Vo2Max: 'vo2_max',
+  FitnessAge: 'fitness_age',
+  SleepDuration: 'sleep_duration',
+  SleepScore: 'sleep_score',
+} as const;
+
+export type HealthMetricId = typeof HEALTH_METRIC_IDS[keyof typeof HEALTH_METRIC_IDS];
+
+export interface HealthMetricDefinition {
+  id: HealthMetricId;
+  label: string;
+  category: 'movement' | 'energy' | 'cardiovascular' | 'wellness' | 'body' | 'fitness' | 'sleep';
+  valueType: HealthValueType;
+  canonicalUnit: HealthUnit;
+}
+
+function metric(
+  id: HealthMetricId,
+  label: string,
+  category: HealthMetricDefinition['category'],
+  canonicalUnit: HealthUnit,
+  valueType: HealthValueType = HEALTH_VALUE_TYPES.Number,
+): HealthMetricDefinition {
+  return { id, label, category, canonicalUnit, valueType };
+}
+
+export const HEALTH_METRIC_CATALOG: Readonly<Record<HealthMetricId, HealthMetricDefinition>> = {
+  [HEALTH_METRIC_IDS.Steps]: metric(HEALTH_METRIC_IDS.Steps, 'Steps', 'movement', HEALTH_UNITS.Count),
+  [HEALTH_METRIC_IDS.WheelchairPushes]: metric(HEALTH_METRIC_IDS.WheelchairPushes, 'Wheelchair pushes', 'movement', HEALTH_UNITS.Count),
+  [HEALTH_METRIC_IDS.Distance]: metric(HEALTH_METRIC_IDS.Distance, 'Distance', 'movement', HEALTH_UNITS.Meter),
+  [HEALTH_METRIC_IDS.WheelchairPushDistance]: metric(HEALTH_METRIC_IDS.WheelchairPushDistance, 'Wheelchair push distance', 'movement', HEALTH_UNITS.Meter),
+  [HEALTH_METRIC_IDS.FloorsClimbed]: metric(HEALTH_METRIC_IDS.FloorsClimbed, 'Floors climbed', 'movement', HEALTH_UNITS.Count),
+  [HEALTH_METRIC_IDS.ActiveDuration]: metric(HEALTH_METRIC_IDS.ActiveDuration, 'Active duration', 'movement', HEALTH_UNITS.Second),
+  [HEALTH_METRIC_IDS.ModerateIntensityDuration]: metric(HEALTH_METRIC_IDS.ModerateIntensityDuration, 'Moderate intensity duration', 'movement', HEALTH_UNITS.Second),
+  [HEALTH_METRIC_IDS.VigorousIntensityDuration]: metric(HEALTH_METRIC_IDS.VigorousIntensityDuration, 'Vigorous intensity duration', 'movement', HEALTH_UNITS.Second),
+  [HEALTH_METRIC_IDS.Altitude]: metric(HEALTH_METRIC_IDS.Altitude, 'Altitude', 'movement', HEALTH_UNITS.Meter),
+  [HEALTH_METRIC_IDS.ActiveEnergy]: metric(HEALTH_METRIC_IDS.ActiveEnergy, 'Active energy', 'energy', HEALTH_UNITS.Kilocalorie),
+  [HEALTH_METRIC_IDS.BasalEnergy]: metric(HEALTH_METRIC_IDS.BasalEnergy, 'Basal energy', 'energy', HEALTH_UNITS.Kilocalorie),
+  [HEALTH_METRIC_IDS.TotalEnergy]: metric(HEALTH_METRIC_IDS.TotalEnergy, 'Total energy', 'energy', HEALTH_UNITS.Kilocalorie),
+  [HEALTH_METRIC_IDS.HeartRate]: metric(HEALTH_METRIC_IDS.HeartRate, 'Heart rate', 'cardiovascular', HEALTH_UNITS.BeatsPerMinute),
+  [HEALTH_METRIC_IDS.RestingHeartRate]: metric(HEALTH_METRIC_IDS.RestingHeartRate, 'Resting heart rate', 'cardiovascular', HEALTH_UNITS.BeatsPerMinute),
+  [HEALTH_METRIC_IDS.HeartRateVariability]: metric(HEALTH_METRIC_IDS.HeartRateVariability, 'Heart rate variability', 'cardiovascular', HEALTH_UNITS.Millisecond),
+  [HEALTH_METRIC_IDS.BloodOxygenSaturation]: metric(HEALTH_METRIC_IDS.BloodOxygenSaturation, 'Blood oxygen saturation', 'cardiovascular', HEALTH_UNITS.Percent),
+  [HEALTH_METRIC_IDS.RespirationRate]: metric(HEALTH_METRIC_IDS.RespirationRate, 'Respiration rate', 'cardiovascular', HEALTH_UNITS.BreathsPerMinute),
+  [HEALTH_METRIC_IDS.StressLevel]: metric(HEALTH_METRIC_IDS.StressLevel, 'Stress level', 'wellness', HEALTH_UNITS.Score),
+  [HEALTH_METRIC_IDS.StressState]: metric(HEALTH_METRIC_IDS.StressState, 'Stress state', 'wellness', HEALTH_UNITS.Category, HEALTH_VALUE_TYPES.Category),
+  [HEALTH_METRIC_IDS.StressDuration]: metric(HEALTH_METRIC_IDS.StressDuration, 'Stress duration', 'wellness', HEALTH_UNITS.Second),
+  [HEALTH_METRIC_IDS.BodyEnergy]: metric(HEALTH_METRIC_IDS.BodyEnergy, 'Body energy', 'wellness', HEALTH_UNITS.Percent),
+  [HEALTH_METRIC_IDS.BodyEnergyChange]: metric(HEALTH_METRIC_IDS.BodyEnergyChange, 'Body energy change', 'wellness', HEALTH_UNITS.Percent),
+  [HEALTH_METRIC_IDS.RecoveryScore]: metric(HEALTH_METRIC_IDS.RecoveryScore, 'Recovery score', 'wellness', HEALTH_UNITS.Score),
+  [HEALTH_METRIC_IDS.BodyWeight]: metric(HEALTH_METRIC_IDS.BodyWeight, 'Body weight', 'body', HEALTH_UNITS.Kilogram),
+  [HEALTH_METRIC_IDS.BodyMassIndex]: metric(HEALTH_METRIC_IDS.BodyMassIndex, 'Body mass index', 'body', HEALTH_UNITS.KilogramsPerSquareMeter),
+  [HEALTH_METRIC_IDS.BodyFat]: metric(HEALTH_METRIC_IDS.BodyFat, 'Body fat', 'body', HEALTH_UNITS.Percent),
+  [HEALTH_METRIC_IDS.BodyWater]: metric(HEALTH_METRIC_IDS.BodyWater, 'Body water', 'body', HEALTH_UNITS.Percent),
+  [HEALTH_METRIC_IDS.MuscleMass]: metric(HEALTH_METRIC_IDS.MuscleMass, 'Muscle mass', 'body', HEALTH_UNITS.Kilogram),
+  [HEALTH_METRIC_IDS.BoneMass]: metric(HEALTH_METRIC_IDS.BoneMass, 'Bone mass', 'body', HEALTH_UNITS.Kilogram),
+  [HEALTH_METRIC_IDS.BloodPressureSystolic]: metric(HEALTH_METRIC_IDS.BloodPressureSystolic, 'Systolic blood pressure', 'cardiovascular', HEALTH_UNITS.MillimetersMercury),
+  [HEALTH_METRIC_IDS.BloodPressureDiastolic]: metric(HEALTH_METRIC_IDS.BloodPressureDiastolic, 'Diastolic blood pressure', 'cardiovascular', HEALTH_UNITS.MillimetersMercury),
+  [HEALTH_METRIC_IDS.PulseRate]: metric(HEALTH_METRIC_IDS.PulseRate, 'Pulse rate', 'cardiovascular', HEALTH_UNITS.BeatsPerMinute),
+  [HEALTH_METRIC_IDS.SkinTemperatureDeviation]: metric(HEALTH_METRIC_IDS.SkinTemperatureDeviation, 'Skin temperature deviation', 'body', HEALTH_UNITS.Celsius),
+  [HEALTH_METRIC_IDS.Vo2Max]: metric(HEALTH_METRIC_IDS.Vo2Max, 'VO2 max', 'fitness', HEALTH_UNITS.MillilitersPerKilogramPerMinute),
+  [HEALTH_METRIC_IDS.FitnessAge]: metric(HEALTH_METRIC_IDS.FitnessAge, 'Fitness age', 'fitness', HEALTH_UNITS.Years),
+  [HEALTH_METRIC_IDS.SleepDuration]: metric(HEALTH_METRIC_IDS.SleepDuration, 'Sleep duration', 'sleep', HEALTH_UNITS.Second),
+  [HEALTH_METRIC_IDS.SleepScore]: metric(HEALTH_METRIC_IDS.SleepScore, 'Sleep score', 'sleep', HEALTH_UNITS.Score),
+};
+
+export interface HealthDeviceAttribution {
+  deviceKey?: string | null;
+  manufacturer?: string | null;
+  model?: string | null;
+  displayName?: string | null;
+}
+
+export interface HealthQuality {
+  status: HealthQualityStatus;
+  nativeCode?: string | null;
+}
+
+export interface HealthCoverage {
+  status: HealthCoverageStatus;
+  expectedStartTimeMs?: number | null;
+  expectedEndTimeMs?: number | null;
+  observedDurationSeconds?: number | null;
+  expectedDurationSeconds?: number | null;
+  sampleCount?: number | null;
+  expectedSampleCount?: number | null;
+  expectedUpdateIntervalMs?: number | null;
+}
+
+export interface HealthNativeValue {
+  metric: string;
+  value: HealthScalar;
+  unit?: string | null;
+  qualifiers?: Record<string, HealthQualifierValue> | null;
+}
+
+export interface HealthCanonicalValue {
+  value: HealthScalar;
+  unit: HealthUnit;
+}
+
+export interface HealthMetricGoal {
+  native?: HealthNativeValue | null;
+  canonical?: HealthCanonicalValue | null;
+}
+
+export interface HealthMetricBase {
+  metricId: HealthMetricId;
+  valueType: HealthValueType;
+  aggregation: string;
+  semanticVariant: string;
+  origin: HealthValueOrigin;
+  recordingMethod: HealthRecordingMethod;
+  quality: HealthQuality;
+  coverage?: HealthCoverage | null;
+  device?: HealthDeviceAttribution | null;
+}
+
+export interface HealthMetricValue extends HealthMetricBase {
+  kind: 'value';
+  normalizationStatus: HealthNormalizationStatus;
+  native: HealthNativeValue;
+  canonical?: HealthCanonicalValue | null;
+  goal?: HealthMetricGoal | null;
+}
+
+export const HEALTH_SLEEP_REFERENCE_FIELDS = {
+  DurationSeconds: 'durationSeconds',
+  Score: 'score.value',
+  AverageHeartRate: 'vitals.averageHeartRateBpm',
+  MinimumHeartRate: 'vitals.minimumHeartRateBpm',
+  RestingHeartRate: 'vitals.restingHeartRateBpm',
+  AverageHrv: 'vitals.averageHrvMs',
+  OvernightHrv: 'vitals.overnightHrvMs',
+  MaximumSpo2: 'vitals.maxSpo2Percent',
+  AverageRespiration: 'vitals.averageRespirationBrpm',
+} as const;
+
+export type HealthSleepReferenceField = typeof HEALTH_SLEEP_REFERENCE_FIELDS[keyof typeof HEALTH_SLEEP_REFERENCE_FIELDS];
+
+export const HEALTH_SLEEP_REFERENCE_METRIC_IDS: Readonly<Record<HealthSleepReferenceField, readonly HealthMetricId[]>> = {
+  [HEALTH_SLEEP_REFERENCE_FIELDS.DurationSeconds]: [HEALTH_METRIC_IDS.SleepDuration],
+  [HEALTH_SLEEP_REFERENCE_FIELDS.Score]: [HEALTH_METRIC_IDS.SleepScore],
+  [HEALTH_SLEEP_REFERENCE_FIELDS.AverageHeartRate]: [HEALTH_METRIC_IDS.HeartRate],
+  [HEALTH_SLEEP_REFERENCE_FIELDS.MinimumHeartRate]: [HEALTH_METRIC_IDS.HeartRate],
+  [HEALTH_SLEEP_REFERENCE_FIELDS.RestingHeartRate]: [HEALTH_METRIC_IDS.RestingHeartRate],
+  [HEALTH_SLEEP_REFERENCE_FIELDS.AverageHrv]: [HEALTH_METRIC_IDS.HeartRateVariability],
+  [HEALTH_SLEEP_REFERENCE_FIELDS.OvernightHrv]: [HEALTH_METRIC_IDS.HeartRateVariability],
+  [HEALTH_SLEEP_REFERENCE_FIELDS.MaximumSpo2]: [HEALTH_METRIC_IDS.BloodOxygenSaturation],
+  [HEALTH_SLEEP_REFERENCE_FIELDS.AverageRespiration]: [HEALTH_METRIC_IDS.RespirationRate],
+};
+
+export interface HealthSleepMetricReference extends HealthMetricBase {
+  kind: 'sleep_reference';
+  reference: {
+    domain: 'sleep';
+    documentId: string;
+    field: HealthSleepReferenceField;
+  };
+}
+
+export type HealthMetricEntry = HealthMetricValue | HealthSleepMetricReference;
+
+export interface HealthRecordRevision {
+  order: number;
+  token: string;
+  digest: string;
+}
+
+export interface HealthSourceMetadata {
+  provider: HealthProvider;
+  accountKey: string;
+  sourceRecordType: string;
+  sourceRecordKey: string;
+  revision: HealthRecordRevision;
+  receivedAtMs: number;
+}
+
+export interface HealthSourceRecord {
+  schemaVersion: typeof HEALTH_SCHEMA_VERSION;
+  id: string;
+  userID: string;
+  kind: HealthRecordKind;
+  source: HealthSourceMetadata;
+  calendarDate: string;
+  startTimeMs: number;
+  endTimeMs: number;
+  timezoneOffsetSeconds?: number | null;
+  metrics: HealthMetricEntry[];
+  metricIds: HealthMetricId[];
+  coverage: HealthCoverage;
+  device?: HealthDeviceAttribution | null;
+  sampleChunkIds: string[];
+  createdAtMs: number;
+  updatedAtMs: number;
+}
+
+export interface HealthSampleChunk {
+  schemaVersion: typeof HEALTH_SCHEMA_VERSION;
+  id: string;
+  userID: string;
+  parentRecordId: string;
+  provider: HealthProvider;
+  accountKey: string;
+  metricId: HealthMetricId;
+  valueType: HealthValueType;
+  aggregation: string;
+  semanticVariant: string;
+  origin: HealthValueOrigin;
+  recordingMethod: HealthRecordingMethod;
+  normalizationStatus: HealthNormalizationStatus;
+  nativeMetric: string;
+  nativeUnit?: string | null;
+  canonicalUnit?: HealthUnit | null;
+  calendarDate: string;
+  startTimeMs: number;
+  endTimeMs: number;
+  timezoneOffsetSeconds?: number | null;
+  seriesKey: string;
+  chunkIndex: number;
+  offsetMs: number[];
+  nativeValues: HealthScalar[];
+  canonicalValues?: HealthScalar[] | null;
+  qualityCodes?: string[] | null;
+  coverage: HealthCoverage;
+  device?: HealthDeviceAttribution | null;
+  revision: HealthRecordRevision;
+  createdAtMs: number;
+  updatedAtMs: number;
+}
+
+export const HEALTH_SYNC_STATUSES = {
+  Ready: 'ready',
+  PermissionMissing: 'permission_missing',
+  ReconnectRequired: 'reconnect_required',
+  Failed: 'failed',
+  Unsupported: 'unsupported',
+  Disconnected: 'disconnected',
+} as const;
+
+export type HealthSyncStatus = typeof HEALTH_SYNC_STATUSES[keyof typeof HEALTH_SYNC_STATUSES];
+
+export interface HealthSyncState {
+  provider: HealthProvider;
+  status: HealthSyncStatus;
+  lastWebhookAtMs?: number | null;
+  lastPollAtMs?: number | null;
+  lastSyncedAtMs?: number | null;
+  lastObservedAtMs?: number | null;
+  lastErrorCode?: string | null;
+  updatedAtMs: number;
+}
+
+export interface HealthQueryCursor {
+  calendarDate: string;
+  id: string;
+}
+
+export interface HealthRangeQuery {
+  startDate: string;
+  endDate: string;
+  providers?: HealthProvider[];
+  metricIds?: HealthMetricId[];
+  includeSamples?: boolean;
+  recordLimit?: number;
+  chunkLimit?: number;
+  samplePointLimit?: number;
+  recordCursor?: HealthQueryCursor | null;
+  chunkCursor?: HealthQueryCursor | null;
+}
+
+export interface NormalizedHealthRangeQuery extends HealthRangeQuery {
+  providers: HealthProvider[];
+  metricIds: HealthMetricId[];
+  includeSamples: boolean;
+  recordLimit: number;
+  chunkLimit: number;
+  samplePointLimit: number;
+  recordCursor: HealthQueryCursor | null;
+  chunkCursor: HealthQueryCursor | null;
+}
+
+export interface HealthObservation {
+  id: string;
+  recordId: string;
+  provider: HealthProvider;
+  accountKey: string;
+  calendarDate: string;
+  startTimeMs: number;
+  endTimeMs: number;
+  timezoneOffsetSeconds?: number | null;
+  sourceRecordType: string;
+  sourceRecordKey: string;
+  receivedAtMs: number;
+  entry: HealthMetricEntry;
+}
+
+export interface HealthDailySummary {
+  calendarDate: string;
+  observationIds: string[];
+  providers: HealthProvider[];
+  sleepReferenceIds: string[];
+}
+
+export interface HealthMetricDiscovery {
+  metricId: HealthMetricId;
+  providers: HealthProvider[];
+  valueTypes: HealthValueType[];
+  canonicalUnits: HealthUnit[];
+  semanticVariants: string[];
+  firstDate: string;
+  lastDate: string;
+  hasSamples: boolean;
+}
+
+export interface HealthMetricCoverageResult {
+  metricId: HealthMetricId;
+  provider: HealthProvider;
+  semanticVariant: string;
+  requestedDays: number;
+  recordedDays: number;
+  partialDays: number;
+  latestDate: string;
+}
+
+export interface HealthFreshnessResult {
+  metricId: HealthMetricId;
+  provider: HealthProvider;
+  semanticVariant: string;
+  lastObservedAtMs: number;
+  lastReceivedAtMs: number;
+  ageMs: number;
+  staleAfterMs: number | null;
+  status: 'fresh' | 'stale' | 'unknown';
+}
+
+export interface HealthConflict {
+  metricId: HealthMetricId;
+  calendarDate: string;
+  aggregation: string;
+  semanticVariant: string;
+  canonicalUnit: HealthUnit;
+  observationIds: string[];
+  providers: HealthProvider[];
+}
+
+export interface HealthRangePageInfo {
+  recordsTruncated: boolean;
+  samplesTruncated: boolean;
+  recordCursor: HealthQueryCursor | null;
+  chunkCursor: HealthQueryCursor | null;
+  returnedSamplePoints: number;
+}
+
+export interface HealthRangeResult {
+  query: NormalizedHealthRangeQuery;
+  observations: HealthObservation[];
+  sampleChunks: HealthSampleChunk[];
+  dailySummaries: HealthDailySummary[];
+  discovery: HealthMetricDiscovery[];
+  coverage: HealthMetricCoverageResult[];
+  freshness: HealthFreshnessResult[];
+  conflicts: HealthConflict[];
+  pageInfo: HealthRangePageInfo;
+}
+
+export function isHealthProvider(value: unknown): value is HealthProvider {
+  return typeof value === 'string' && Object.values(HEALTH_PROVIDERS).includes(value as HealthProvider);
+}
+
+export function isHealthMetricId(value: unknown): value is HealthMetricId {
+  return typeof value === 'string' && Object.prototype.hasOwnProperty.call(HEALTH_METRIC_CATALOG, value);
+}
+
+export function getHealthMetricDefinition(metricId: HealthMetricId): HealthMetricDefinition {
+  return HEALTH_METRIC_CATALOG[metricId];
+}

--- a/shared/health.ts
+++ b/shared/health.ts
@@ -7,14 +7,20 @@ export const HEALTH_SYNC_STATE_COLLECTION_ID = 'healthSyncState';
 export const HEALTH_MAX_METRICS_PER_RECORD = 128;
 export const HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK = 1_440;
 export const HEALTH_MAX_SAMPLE_CHUNKS_PER_RECORD = 200;
-export const HEALTH_MAX_DOCUMENT_BYTES = 900 * 1024;
-export const HEALTH_MAX_WRITE_BYTES = 8 * 1024 * 1024;
-export const HEALTH_DEFAULT_RECORD_PAGE_SIZE = 250;
-export const HEALTH_MAX_RECORD_PAGE_SIZE = 1_000;
-export const HEALTH_DEFAULT_CHUNK_PAGE_SIZE = 100;
-export const HEALTH_MAX_CHUNK_PAGE_SIZE = 500;
-export const HEALTH_DEFAULT_SAMPLE_POINT_LIMIT = 25_000;
-export const HEALTH_MAX_SAMPLE_POINT_LIMIT = 50_000;
+export const HEALTH_MAX_RECORD_DOCUMENT_BYTES = 256 * 1024;
+export const HEALTH_MAX_SAMPLE_CHUNK_DOCUMENT_BYTES = 900 * 1024;
+// A replacement can include both the incoming revision and deletion of the
+// previous revision. Keep each side below half Firestore's 10 MiB request cap,
+// leaving headroom for document names, index entries, and protocol overhead.
+export const HEALTH_MAX_WRITE_BYTES = 4 * 1024 * 1024;
+export const HEALTH_DEFAULT_RECORD_PAGE_SIZE = 32;
+export const HEALTH_MAX_RECORD_PAGE_SIZE = 32;
+export const HEALTH_DEFAULT_CHUNK_PAGE_SIZE = 8;
+export const HEALTH_MAX_CHUNK_PAGE_SIZE = 8;
+export const HEALTH_DEFAULT_SAMPLE_POINT_LIMIT = 10_000;
+export const HEALTH_MAX_SAMPLE_POINT_LIMIT = HEALTH_MAX_CHUNK_PAGE_SIZE * HEALTH_MAX_SAMPLE_POINTS_PER_CHUNK;
+export const HEALTH_MAX_QUERY_FETCH_BYTES = (HEALTH_MAX_RECORD_PAGE_SIZE + 1) * HEALTH_MAX_RECORD_DOCUMENT_BYTES
+  + (HEALTH_MAX_CHUNK_PAGE_SIZE + 1) * HEALTH_MAX_SAMPLE_CHUNK_DOCUMENT_BYTES;
 export const HEALTH_MAX_SUMMARY_RANGE_DAYS = 366;
 export const HEALTH_MAX_SAMPLE_RANGE_DAYS = 31;
 
@@ -167,11 +173,11 @@ function metric(
   category: HealthMetricDefinition['category'],
   canonicalUnit: HealthUnit,
   valueType: HealthValueType = HEALTH_VALUE_TYPES.Number,
-): HealthMetricDefinition {
-  return { id, label, category, canonicalUnit, valueType };
+): Readonly<HealthMetricDefinition> {
+  return Object.freeze({ id, label, category, canonicalUnit, valueType });
 }
 
-export const HEALTH_METRIC_CATALOG: Readonly<Record<HealthMetricId, HealthMetricDefinition>> = {
+export const HEALTH_METRIC_CATALOG: Readonly<Record<HealthMetricId, Readonly<HealthMetricDefinition>>> = Object.freeze({
   [HEALTH_METRIC_IDS.Steps]: metric(HEALTH_METRIC_IDS.Steps, 'Steps', 'movement', HEALTH_UNITS.Count),
   [HEALTH_METRIC_IDS.WheelchairPushes]: metric(HEALTH_METRIC_IDS.WheelchairPushes, 'Wheelchair pushes', 'movement', HEALTH_UNITS.Count),
   [HEALTH_METRIC_IDS.Distance]: metric(HEALTH_METRIC_IDS.Distance, 'Distance', 'movement', HEALTH_UNITS.Meter),
@@ -209,7 +215,7 @@ export const HEALTH_METRIC_CATALOG: Readonly<Record<HealthMetricId, HealthMetric
   [HEALTH_METRIC_IDS.FitnessAge]: metric(HEALTH_METRIC_IDS.FitnessAge, 'Fitness age', 'fitness', HEALTH_UNITS.Years),
   [HEALTH_METRIC_IDS.SleepDuration]: metric(HEALTH_METRIC_IDS.SleepDuration, 'Sleep duration', 'sleep', HEALTH_UNITS.Second),
   [HEALTH_METRIC_IDS.SleepScore]: metric(HEALTH_METRIC_IDS.SleepScore, 'Sleep score', 'sleep', HEALTH_UNITS.Score),
-};
+});
 
 export interface HealthDeviceAttribution {
   deviceKey?: string | null;
@@ -285,17 +291,17 @@ export const HEALTH_SLEEP_REFERENCE_FIELDS = {
 
 export type HealthSleepReferenceField = typeof HEALTH_SLEEP_REFERENCE_FIELDS[keyof typeof HEALTH_SLEEP_REFERENCE_FIELDS];
 
-export const HEALTH_SLEEP_REFERENCE_METRIC_IDS: Readonly<Record<HealthSleepReferenceField, readonly HealthMetricId[]>> = {
-  [HEALTH_SLEEP_REFERENCE_FIELDS.DurationSeconds]: [HEALTH_METRIC_IDS.SleepDuration],
-  [HEALTH_SLEEP_REFERENCE_FIELDS.Score]: [HEALTH_METRIC_IDS.SleepScore],
-  [HEALTH_SLEEP_REFERENCE_FIELDS.AverageHeartRate]: [HEALTH_METRIC_IDS.HeartRate],
-  [HEALTH_SLEEP_REFERENCE_FIELDS.MinimumHeartRate]: [HEALTH_METRIC_IDS.HeartRate],
-  [HEALTH_SLEEP_REFERENCE_FIELDS.RestingHeartRate]: [HEALTH_METRIC_IDS.RestingHeartRate],
-  [HEALTH_SLEEP_REFERENCE_FIELDS.AverageHrv]: [HEALTH_METRIC_IDS.HeartRateVariability],
-  [HEALTH_SLEEP_REFERENCE_FIELDS.OvernightHrv]: [HEALTH_METRIC_IDS.HeartRateVariability],
-  [HEALTH_SLEEP_REFERENCE_FIELDS.MaximumSpo2]: [HEALTH_METRIC_IDS.BloodOxygenSaturation],
-  [HEALTH_SLEEP_REFERENCE_FIELDS.AverageRespiration]: [HEALTH_METRIC_IDS.RespirationRate],
-};
+export const HEALTH_SLEEP_REFERENCE_METRIC_IDS: Readonly<Record<HealthSleepReferenceField, readonly HealthMetricId[]>> = Object.freeze({
+  [HEALTH_SLEEP_REFERENCE_FIELDS.DurationSeconds]: Object.freeze([HEALTH_METRIC_IDS.SleepDuration]),
+  [HEALTH_SLEEP_REFERENCE_FIELDS.Score]: Object.freeze([HEALTH_METRIC_IDS.SleepScore]),
+  [HEALTH_SLEEP_REFERENCE_FIELDS.AverageHeartRate]: Object.freeze([HEALTH_METRIC_IDS.HeartRate]),
+  [HEALTH_SLEEP_REFERENCE_FIELDS.MinimumHeartRate]: Object.freeze([HEALTH_METRIC_IDS.HeartRate]),
+  [HEALTH_SLEEP_REFERENCE_FIELDS.RestingHeartRate]: Object.freeze([HEALTH_METRIC_IDS.RestingHeartRate]),
+  [HEALTH_SLEEP_REFERENCE_FIELDS.AverageHrv]: Object.freeze([HEALTH_METRIC_IDS.HeartRateVariability]),
+  [HEALTH_SLEEP_REFERENCE_FIELDS.OvernightHrv]: Object.freeze([HEALTH_METRIC_IDS.HeartRateVariability]),
+  [HEALTH_SLEEP_REFERENCE_FIELDS.MaximumSpo2]: Object.freeze([HEALTH_METRIC_IDS.BloodOxygenSaturation]),
+  [HEALTH_SLEEP_REFERENCE_FIELDS.AverageRespiration]: Object.freeze([HEALTH_METRIC_IDS.RespirationRate]),
+});
 
 export interface HealthSleepMetricReference extends HealthMetricBase {
   kind: 'sleep_reference';
@@ -362,6 +368,7 @@ export interface HealthSampleChunk {
   calendarDate: string;
   startTimeMs: number;
   endTimeMs: number;
+  receivedAtMs: number;
   timezoneOffsetSeconds?: number | null;
   seriesKey: string;
   chunkIndex: number;
@@ -439,6 +446,8 @@ export interface HealthObservation {
   sourceRecordType: string;
   sourceRecordKey: string;
   receivedAtMs: number;
+  coverage: HealthCoverage;
+  device: HealthDeviceAttribution | null;
   entry: HealthMetricEntry;
 }
 
@@ -454,7 +463,10 @@ export interface HealthMetricDiscovery {
   providers: HealthProvider[];
   valueTypes: HealthValueType[];
   canonicalUnits: HealthUnit[];
+  aggregations: string[];
   semanticVariants: string[];
+  origins: HealthValueOrigin[];
+  recordingMethods: HealthRecordingMethod[];
   firstDate: string;
   lastDate: string;
   hasSamples: boolean;
@@ -463,17 +475,27 @@ export interface HealthMetricDiscovery {
 export interface HealthMetricCoverageResult {
   metricId: HealthMetricId;
   provider: HealthProvider;
+  accountKey: string;
+  aggregation: string;
   semanticVariant: string;
+  origin: HealthValueOrigin;
+  recordingMethod: HealthRecordingMethod;
   requestedDays: number;
   recordedDays: number;
+  missingDays: number;
   partialDays: number;
+  unknownDays: number;
   latestDate: string;
 }
 
 export interface HealthFreshnessResult {
   metricId: HealthMetricId;
   provider: HealthProvider;
+  accountKey: string;
+  aggregation: string;
   semanticVariant: string;
+  origin: HealthValueOrigin;
+  recordingMethod: HealthRecordingMethod;
   lastObservedAtMs: number;
   lastReceivedAtMs: number;
   ageMs: number;
@@ -486,14 +508,23 @@ export interface HealthConflict {
   calendarDate: string;
   aggregation: string;
   semanticVariant: string;
+  origin: HealthValueOrigin;
   canonicalUnit: HealthUnit;
   observationIds: string[];
   providers: HealthProvider[];
+  sources: Array<{
+    provider: HealthProvider;
+    accountKey: string;
+  }>;
+  recordingMethods: HealthRecordingMethod[];
 }
 
 export interface HealthRangePageInfo {
   recordsTruncated: boolean;
   samplesTruncated: boolean;
+  sampleRevisionMismatchCount: number;
+  recordAggregateComplete: boolean;
+  sampleAggregateComplete: boolean;
   recordCursor: HealthQueryCursor | null;
   chunkCursor: HealthQueryCursor | null;
   returnedSamplePoints: number;
@@ -519,6 +550,6 @@ export function isHealthMetricId(value: unknown): value is HealthMetricId {
   return typeof value === 'string' && Object.prototype.hasOwnProperty.call(HEALTH_METRIC_CATALOG, value);
 }
 
-export function getHealthMetricDefinition(metricId: HealthMetricId): HealthMetricDefinition {
+export function getHealthMetricDefinition(metricId: HealthMetricId): Readonly<HealthMetricDefinition> {
   return HEALTH_METRIC_CATALOG[metricId];
 }

--- a/shared/health.ts
+++ b/shared/health.ts
@@ -316,6 +316,7 @@ export type HealthMetricEntry = HealthMetricValue | HealthSleepMetricReference;
 
 export interface HealthSourceRecordRevision {
   order: number;
+  /** Source-record-scoped opaque hash of the adapter's revision token. */
   token: string;
   digest: string;
 }
@@ -324,6 +325,7 @@ export interface HealthSourceMetadata {
   provider: HealthProvider;
   accountKey: string;
   sourceRecordType: string;
+  /** Account-scoped opaque hash of the adapter's source-record key. */
   sourceRecordKey: string;
   revision: HealthSourceRecordRevision;
   receivedAtMs: number;
@@ -444,6 +446,7 @@ export interface HealthObservation {
   endTimeMs: number;
   timezoneOffsetSeconds?: number | null;
   sourceRecordType: string;
+  /** Account-scoped opaque hash; never the raw adapter source-record key. */
   sourceRecordKey: string;
   receivedAtMs: number;
   coverage: HealthCoverage;

--- a/src/app/services/app.health.service.spec.ts
+++ b/src/app/services/app.health.service.spec.ts
@@ -1,0 +1,176 @@
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom, of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    HEALTH_COVERAGE_STATUSES,
+    HEALTH_METRIC_IDS,
+    HEALTH_NORMALIZATION_STATUSES,
+    HEALTH_PROVIDERS,
+    HEALTH_QUALITY_STATUSES,
+    HEALTH_RECORDING_METHODS,
+    HEALTH_RECORD_KINDS,
+    HEALTH_SCHEMA_VERSION,
+    HEALTH_UNITS,
+    HEALTH_VALUE_ORIGINS,
+    HEALTH_VALUE_TYPES,
+    HealthSourceRecord,
+} from '@shared/health';
+import {
+    Firestore,
+    collection,
+    collectionData,
+    documentId,
+    limit,
+    orderBy,
+    query,
+    startAfter,
+    where,
+} from 'app/firebase/firestore';
+import { AppFunctionsService } from './app.functions.service';
+import { AppHealthService } from './app.health.service';
+
+vi.mock('app/firebase/firestore', () => {
+    class MockFirestore { }
+    return {
+        Firestore: MockFirestore,
+        collection: vi.fn((_firestore, ...path: string[]) => ({ path })),
+        collectionData: vi.fn(() => of([])),
+        documentId: vi.fn(() => '__name__'),
+        limit: vi.fn((value: number) => ({ type: 'limit', value })),
+        orderBy: vi.fn((field: string, direction: string) => ({ type: 'orderBy', field, direction })),
+        query: vi.fn((collectionRef: unknown, ...constraints: unknown[]) => ({ collectionRef, constraints })),
+        startAfter: vi.fn((...values: unknown[]) => ({ type: 'startAfter', values })),
+        where: vi.fn((field: string, operator: string, value: unknown) => ({ type: 'where', field, operator, value })),
+    };
+});
+
+function healthRecord(): HealthSourceRecord {
+    const startTimeMs = Date.parse('2026-01-01T00:00:00.000Z');
+    return {
+        schemaVersion: HEALTH_SCHEMA_VERSION,
+        id: 'record-1',
+        userID: 'user-1',
+        kind: HEALTH_RECORD_KINDS.DailySummary,
+        source: {
+            provider: HEALTH_PROVIDERS.GarminAPI,
+            accountKey: 'opaque-account',
+            sourceRecordType: 'daily',
+            sourceRecordKey: '2026-01-01',
+            revision: { order: 1, token: 'one', digest: 'digest' },
+            receivedAtMs: startTimeMs + 1000,
+        },
+        calendarDate: '2026-01-01',
+        startTimeMs,
+        endTimeMs: startTimeMs + 86_399_999,
+        metrics: [{
+            kind: 'value',
+            metricId: HEALTH_METRIC_IDS.Steps,
+            valueType: HEALTH_VALUE_TYPES.Number,
+            aggregation: 'total',
+            semanticVariant: 'provider_daily_summary',
+            origin: HEALTH_VALUE_ORIGINS.ProviderSummary,
+            recordingMethod: HEALTH_RECORDING_METHODS.ProviderCalculated,
+            quality: { status: HEALTH_QUALITY_STATUSES.Valid },
+            normalizationStatus: HEALTH_NORMALIZATION_STATUSES.Canonical,
+            native: { metric: 'steps', value: 100 },
+            canonical: { value: 100, unit: HEALTH_UNITS.Count },
+        }],
+        metricIds: [HEALTH_METRIC_IDS.Steps],
+        coverage: { status: HEALTH_COVERAGE_STATUSES.Complete },
+        sampleChunkIds: [],
+        createdAtMs: startTimeMs,
+        updatedAtMs: startTimeMs,
+    };
+}
+
+describe('AppHealthService', () => {
+    let service: AppHealthService;
+    let functions: { call: ReturnType<typeof vi.fn> };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(collectionData).mockReturnValue(of([]));
+        functions = { call: vi.fn() };
+        TestBed.configureTestingModule({
+            providers: [
+                AppHealthService,
+                { provide: Firestore, useValue: {} },
+                { provide: AppFunctionsService, useValue: functions },
+            ],
+        });
+        service = TestBed.inject(AppHealthService);
+    });
+
+    it('returns the typed empty projection without creating listeners when the user is absent', async () => {
+        const result = await firstValueFrom(service.watchRange('', {
+            startDate: '2026-01-01',
+            endDate: '2026-01-02',
+        }));
+
+        expect(result.observations).toEqual([]);
+        expect(result.query.recordLimit).toBe(250);
+        expect(collection).not.toHaveBeenCalled();
+    });
+
+    it('uses the shared provider-first plan for the default direct Firestore read', async () => {
+        vi.mocked(collectionData).mockImplementation((target: unknown) => {
+            const path = (target as { collectionRef?: { path?: string[] } }).collectionRef?.path || [];
+            return of(path.at(-1) === 'healthRecords' ? [healthRecord()] : []) as never;
+        });
+
+        const result = await firstValueFrom(service.watchRange('user-1', {
+            startDate: '2026-01-01',
+            endDate: '2026-01-07',
+            providers: [HEALTH_PROVIDERS.GarminAPI],
+            metricIds: [HEALTH_METRIC_IDS.Steps],
+            includeSamples: true,
+            recordLimit: 10,
+            chunkLimit: 20,
+            recordCursor: { calendarDate: '2025-12-31', id: 'previous-record' },
+        }));
+
+        expect(result.observations).toHaveLength(1);
+        expect(collection).toHaveBeenCalledWith(expect.anything(), 'users', 'user-1', 'healthRecords');
+        expect(collection).toHaveBeenCalledWith(expect.anything(), 'users', 'user-1', 'healthSampleChunks');
+        expect(where).toHaveBeenCalledWith('source.provider', '==', HEALTH_PROVIDERS.GarminAPI);
+        expect(where).toHaveBeenCalledWith('provider', '==', HEALTH_PROVIDERS.GarminAPI);
+        expect(where).not.toHaveBeenCalledWith('metricIds', 'array-contains', HEALTH_METRIC_IDS.Steps);
+        expect(documentId).toHaveBeenCalled();
+        expect(startAfter).toHaveBeenCalledWith('2025-12-31', 'previous-record');
+        expect(limit).toHaveBeenCalledWith(11);
+        expect(limit).toHaveBeenCalledWith(21);
+    });
+
+    it('uses the metric index when no provider is requested', async () => {
+        await firstValueFrom(service.watchRange('user-1', {
+            startDate: '2026-01-01',
+            endDate: '2026-01-07',
+            metricIds: [HEALTH_METRIC_IDS.HeartRate],
+        }));
+
+        expect(where).toHaveBeenCalledWith('metricIds', 'array-contains', HEALTH_METRIC_IDS.HeartRate);
+    });
+
+    it('offers the authenticated callable as an explicit server-read alternative', async () => {
+        const expected = { observations: [] };
+        functions.call.mockResolvedValue({ data: expected });
+        const queryValue = { startDate: '2026-01-01', endDate: '2026-01-02' };
+
+        await expect(service.queryRangeViaServer(queryValue)).resolves.toBe(expected);
+        expect(functions.call).toHaveBeenCalledWith('queryHealthRange', queryValue);
+    });
+
+    it('keeps sync-state listeners owner-scoped and bounded', async () => {
+        await firstValueFrom(service.watchSyncStates('user-1'));
+
+        expect(collection).toHaveBeenCalledWith(expect.anything(), 'users', 'user-1', 'healthSyncState');
+        expect(limit).toHaveBeenCalledWith(6);
+        expect(query).toHaveBeenCalled();
+    });
+
+    it('does not create a sync-state listener without a user', async () => {
+        await expect(firstValueFrom(service.watchSyncStates(null))).resolves.toEqual([]);
+        expect(collection).not.toHaveBeenCalled();
+        expect(orderBy).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/services/app.health.service.spec.ts
+++ b/src/app/services/app.health.service.spec.ts
@@ -8,7 +8,7 @@ import {
     HEALTH_PROVIDERS,
     HEALTH_QUALITY_STATUSES,
     HEALTH_RECORDING_METHODS,
-    HEALTH_RECORD_KINDS,
+    HEALTH_SOURCE_RECORD_KINDS,
     HEALTH_SCHEMA_VERSION,
     HEALTH_UNITS,
     HEALTH_VALUE_ORIGINS,
@@ -44,13 +44,13 @@ vi.mock('app/firebase/firestore', () => {
     };
 });
 
-function healthRecord(): HealthSourceRecord {
+function healthSourceRecord(): HealthSourceRecord {
     const startTimeMs = Date.parse('2026-01-01T00:00:00.000Z');
     return {
         schemaVersion: HEALTH_SCHEMA_VERSION,
         id: 'record-1',
         userID: 'user-1',
-        kind: HEALTH_RECORD_KINDS.DailySummary,
+        kind: HEALTH_SOURCE_RECORD_KINDS.DailySummary,
         source: {
             provider: HEALTH_PROVIDERS.GarminAPI,
             accountKey: 'opaque-account',
@@ -108,14 +108,14 @@ describe('AppHealthService', () => {
         }));
 
         expect(result.observations).toEqual([]);
-        expect(result.query.recordLimit).toBe(32);
+        expect(result.query.sourceRecordLimit).toBe(32);
         expect(collection).not.toHaveBeenCalled();
     });
 
     it('uses the shared provider-first plan for the default direct Firestore read', async () => {
         vi.mocked(collectionData).mockImplementation((target: unknown) => {
             const path = (target as { collectionRef?: { path?: string[] } }).collectionRef?.path || [];
-            return of(path.at(-1) === 'healthRecords' ? [healthRecord()] : []) as never;
+            return of(path.at(-1) === 'healthSourceRecords' ? [healthSourceRecord()] : []) as never;
         });
 
         const result = await firstValueFrom(service.watchRange('user-1', {
@@ -124,13 +124,13 @@ describe('AppHealthService', () => {
             providers: [HEALTH_PROVIDERS.GarminAPI],
             metricIds: [HEALTH_METRIC_IDS.Steps],
             includeSamples: true,
-            recordLimit: 10,
+            sourceRecordLimit: 10,
             chunkLimit: 8,
-            recordCursor: { calendarDate: '2025-12-31', id: 'previous-record' },
+            sourceRecordCursor: { calendarDate: '2025-12-31', id: 'previous-record' },
         }));
 
         expect(result.observations).toHaveLength(1);
-        expect(collection).toHaveBeenCalledWith(expect.anything(), 'users', 'user-1', 'healthRecords');
+        expect(collection).toHaveBeenCalledWith(expect.anything(), 'users', 'user-1', 'healthSourceRecords');
         expect(collection).toHaveBeenCalledWith(expect.anything(), 'users', 'user-1', 'healthSampleChunks');
         expect(where).toHaveBeenCalledWith('source.provider', '==', HEALTH_PROVIDERS.GarminAPI);
         expect(where).toHaveBeenCalledWith('provider', '==', HEALTH_PROVIDERS.GarminAPI);

--- a/src/app/services/app.health.service.spec.ts
+++ b/src/app/services/app.health.service.spec.ts
@@ -108,7 +108,7 @@ describe('AppHealthService', () => {
         }));
 
         expect(result.observations).toEqual([]);
-        expect(result.query.recordLimit).toBe(250);
+        expect(result.query.recordLimit).toBe(32);
         expect(collection).not.toHaveBeenCalled();
     });
 
@@ -125,7 +125,7 @@ describe('AppHealthService', () => {
             metricIds: [HEALTH_METRIC_IDS.Steps],
             includeSamples: true,
             recordLimit: 10,
-            chunkLimit: 20,
+            chunkLimit: 8,
             recordCursor: { calendarDate: '2025-12-31', id: 'previous-record' },
         }));
 
@@ -138,7 +138,7 @@ describe('AppHealthService', () => {
         expect(documentId).toHaveBeenCalled();
         expect(startAfter).toHaveBeenCalledWith('2025-12-31', 'previous-record');
         expect(limit).toHaveBeenCalledWith(11);
-        expect(limit).toHaveBeenCalledWith(21);
+        expect(limit).toHaveBeenCalledWith(9);
     });
 
     it('uses the metric index when no provider is requested', async () => {

--- a/src/app/services/app.health.service.ts
+++ b/src/app/services/app.health.service.ts
@@ -1,0 +1,102 @@
+import { Injectable, inject } from '@angular/core';
+import {
+    Firestore,
+    collection,
+    collectionData,
+    documentId,
+    limit,
+    orderBy,
+    query,
+    startAfter,
+    where,
+} from 'app/firebase/firestore';
+import type { QueryConstraint } from 'firebase/firestore';
+import { Observable, combineLatest, of } from 'rxjs';
+import { map, shareReplay } from 'rxjs/operators';
+import {
+    HEALTH_SYNC_STATE_COLLECTION_ID,
+    HealthRangeQuery,
+    HealthRangeResult,
+    HealthSampleChunk,
+    HealthSourceRecord,
+    HealthSyncState,
+} from '@shared/health';
+import {
+    HealthFirestoreQueryPlan,
+    planHealthFirestoreQueries,
+} from '@shared/health-firestore-query';
+import { projectHealthRange } from '@shared/health-query';
+import { AppFunctionsService } from './app.functions.service';
+
+@Injectable({
+    providedIn: 'root',
+})
+export class AppHealthService {
+    private static readonly MAX_SYNC_STATE_DOCUMENTS = 6;
+
+    private firestore = inject(Firestore);
+    private functions = inject(AppFunctionsService);
+
+    /**
+     * Default Health Hub read path. Firestore supplies bounded source pages and
+     * the shared projector produces the exact same result shape as the callable.
+     */
+    watchRange(
+        userID: string | null | undefined,
+        queryValue: HealthRangeQuery,
+    ): Observable<HealthRangeResult> {
+        const plans = planHealthFirestoreQueries(queryValue);
+        const uid = `${userID || ''}`.trim();
+        if (!uid) {
+            return of(projectHealthRange([], [], plans.query));
+        }
+
+        const records$ = this.watchCollection<HealthSourceRecord>(uid, plans.records);
+        const chunks$ = plans.chunks
+            ? this.watchCollection<HealthSampleChunk>(uid, plans.chunks)
+            : of([] as HealthSampleChunk[]);
+        return combineLatest([records$, chunks$]).pipe(
+            map(([records, chunks]) => projectHealthRange(records, chunks, plans.query)),
+            shareReplay({ bufferSize: 1, refCount: true }),
+        );
+    }
+
+    async queryRangeViaServer(queryValue: HealthRangeQuery): Promise<HealthRangeResult> {
+        const response = await this.functions.call<HealthRangeQuery, HealthRangeResult>(
+            'queryHealthRange',
+            queryValue,
+        );
+        return response.data;
+    }
+
+    watchSyncStates(userID: string | null | undefined): Observable<HealthSyncState[]> {
+        const uid = `${userID || ''}`.trim();
+        if (!uid) {
+            return of([]);
+        }
+        const stateCollection = collection(this.firestore, 'users', uid, HEALTH_SYNC_STATE_COLLECTION_ID);
+        const stateQuery = query(stateCollection, limit(AppHealthService.MAX_SYNC_STATE_DOCUMENTS));
+        return collectionData(stateQuery, { idField: 'provider' }) as Observable<HealthSyncState[]>;
+    }
+
+    private watchCollection<T>(userID: string, plan: HealthFirestoreQueryPlan): Observable<T[]> {
+        const targetCollection = collection(this.firestore, 'users', userID, plan.collectionId);
+        const constraints: QueryConstraint[] = [
+            where('calendarDate', '>=', plan.startDate),
+            where('calendarDate', '<=', plan.endDate),
+        ];
+        if (plan.filter) {
+            constraints.push(where(plan.filter.field, plan.filter.operator, plan.filter.value));
+        }
+        constraints.push(
+            orderBy('calendarDate', 'asc'),
+            orderBy(documentId(), 'asc'),
+        );
+        if (plan.cursor) {
+            constraints.push(startAfter(plan.cursor.calendarDate, plan.cursor.id));
+        }
+        constraints.push(limit(plan.fetchLimit));
+        const targetQuery = query(targetCollection, ...constraints);
+        return collectionData(targetQuery, { idField: 'id' }) as Observable<T[]>;
+    }
+}

--- a/src/app/services/app.health.service.ts
+++ b/src/app/services/app.health.service.ts
@@ -51,12 +51,12 @@ export class AppHealthService {
             return of(projectHealthRange([], [], plans.query));
         }
 
-        const records$ = this.watchCollection<HealthSourceRecord>(uid, plans.records);
+        const sourceRecords$ = this.watchCollection<HealthSourceRecord>(uid, plans.sourceRecords);
         const chunks$ = plans.chunks
             ? this.watchCollection<HealthSampleChunk>(uid, plans.chunks)
             : of([] as HealthSampleChunk[]);
-        return combineLatest([records$, chunks$]).pipe(
-            map(([records, chunks]) => projectHealthRange(records, chunks, plans.query)),
+        return combineLatest([sourceRecords$, chunks$]).pipe(
+            map(([sourceRecords, chunks]) => projectHealthRange(sourceRecords, chunks, plans.query)),
             shareReplay({ bufferSize: 1, refCount: true }),
         );
     }

--- a/src/app/shared/health.shared.spec.ts
+++ b/src/app/shared/health.shared.spec.ts
@@ -1,5 +1,6 @@
 import {
     HEALTH_COVERAGE_STATUSES,
+    HEALTH_MAX_QUERY_FETCH_BYTES,
     HEALTH_METRIC_CATALOG,
     HEALTH_METRIC_IDS,
     HEALTH_NORMALIZATION_STATUSES,
@@ -8,6 +9,7 @@ import {
     HEALTH_RECORDING_METHODS,
     HEALTH_RECORD_KINDS,
     HEALTH_SCHEMA_VERSION,
+    HEALTH_SLEEP_REFERENCE_METRIC_IDS,
     HEALTH_SLEEP_REFERENCE_FIELDS,
     HEALTH_UNITS,
     HEALTH_VALUE_ORIGINS,
@@ -22,6 +24,7 @@ import {
 import {
     HealthQueryValidationError,
     canonicalUnitForMetric,
+    findHealthConflicts,
     normalizeHealthRangeQuery,
     projectHealthRange,
 } from '@shared/health-query';
@@ -57,6 +60,7 @@ function sourceRecord(input: {
     calendarDate?: string;
     metrics?: HealthMetricEntry[];
     coverageStatus?: 'complete' | 'partial' | 'unknown';
+    deviceKey?: string;
     startTimeMs?: number;
     endTimeMs?: number;
 }): HealthSourceRecord {
@@ -82,6 +86,7 @@ function sourceRecord(input: {
         metrics: input.metrics || [valueEntry()],
         metricIds: [...new Set((input.metrics || [valueEntry()]).map(metric => metric.metricId))],
         coverage: { status: input.coverageStatus || HEALTH_COVERAGE_STATUSES.Complete },
+        device: input.deviceKey ? { deviceKey: input.deviceKey } : undefined,
         sampleChunkIds: [],
         createdAtMs: startTimeMs + DAY_MS,
         updatedAtMs: startTimeMs + DAY_MS,
@@ -119,6 +124,7 @@ function sampleChunk(input: {
         calendarDate,
         startTimeMs,
         endTimeMs: startTimeMs + (offsetMs.at(-1) || 0),
+        receivedAtMs: startTimeMs + DAY_MS + 1_000,
         timezoneOffsetSeconds: 0,
         seriesKey: 'heart-rate',
         chunkIndex: Number(input.id.replace(/\D/g, '')) || 0,
@@ -126,7 +132,7 @@ function sampleChunk(input: {
         nativeValues: offsetMs.map((_, index) => 60 + index),
         canonicalValues: offsetMs.map((_, index) => 60 + index),
         coverage: { status: HEALTH_COVERAGE_STATUSES.Complete, sampleCount: input.pointCount },
-        revision: { order: 1, token: 'revision-1', digest: 'digest-record' },
+        revision: { order: 1, token: 'revision-1', digest: 'digest-garmin-record' },
         createdAtMs: startTimeMs + DAY_MS,
         updatedAtMs: startTimeMs + DAY_MS,
     };
@@ -134,6 +140,10 @@ function sampleChunk(input: {
 
 describe('unified health shared contract', () => {
     it('publishes stable metric definitions and canonical units', () => {
+        expect(Object.isFrozen(HEALTH_METRIC_CATALOG)).toBe(true);
+        expect(Object.isFrozen(HEALTH_METRIC_CATALOG[HEALTH_METRIC_IDS.ActiveEnergy])).toBe(true);
+        expect(Object.isFrozen(HEALTH_SLEEP_REFERENCE_METRIC_IDS)).toBe(true);
+        expect(Object.isFrozen(HEALTH_SLEEP_REFERENCE_METRIC_IDS[HEALTH_SLEEP_REFERENCE_FIELDS.AverageHrv])).toBe(true);
         expect(HEALTH_METRIC_CATALOG[HEALTH_METRIC_IDS.ActiveEnergy]).toMatchObject({
             valueType: HEALTH_VALUE_TYPES.Number,
             canonicalUnit: HEALTH_UNITS.Kilocalorie,
@@ -158,9 +168,9 @@ describe('unified health shared contract', () => {
             providers: [HEALTH_PROVIDERS.GarminAPI],
             metricIds: [],
             includeSamples: false,
-            recordLimit: 250,
-            chunkLimit: 100,
-            samplePointLimit: 25_000,
+            recordLimit: 32,
+            chunkLimit: 8,
+            samplePointLimit: 10_000,
             recordCursor: null,
             chunkCursor: null,
         });
@@ -172,8 +182,11 @@ describe('unified health shared contract', () => {
         [{ startDate: '2025-01-01', endDate: '2026-01-02' }, '366-day limit'],
         [{ startDate: '2026-01-01', endDate: '2026-02-01', includeSamples: true }, '31-day limit'],
         [{ startDate: '2026-01-01', endDate: '2026-01-01', metricIds: ['unknown'] }, 'supported metric IDs'],
-        [{ startDate: '2026-01-01', endDate: '2026-01-01', recordLimit: 1_001 }, '1 to 1000'],
-        [{ startDate: '2026-01-01', endDate: '2026-01-01', samplePointLimit: 1_439 }, '1440 to 50000'],
+        [{ startDate: '2026-01-01', endDate: '2026-01-01', providers: new Array(1) }, 'supported providers'],
+        [{ startDate: '2026-01-01', endDate: '2026-01-01', metricIds: new Array(1) }, 'supported metric IDs'],
+        [{ startDate: '2026-01-01', endDate: '2026-01-01', recordLimit: 33 }, '1 to 32'],
+        [{ startDate: '2026-01-01', endDate: '2026-01-01', chunkLimit: 9 }, '1 to 8'],
+        [{ startDate: '2026-01-01', endDate: '2026-01-01', samplePointLimit: 1_439 }, '1440 to 11520'],
         [{
             startDate: '2026-01-01',
             endDate: '2026-01-01',
@@ -182,6 +195,10 @@ describe('unified health shared contract', () => {
     ])('rejects invalid or unbounded query input %#', (query, message) => {
         expect(() => normalizeHealthRangeQuery(query)).toThrowError(new RegExp(message));
         expect(() => normalizeHealthRangeQuery(query)).toThrow(HealthQueryValidationError);
+    });
+
+    it('keeps the maximum source-page fetch below a bounded callable response envelope', () => {
+        expect(HEALTH_MAX_QUERY_FETCH_BYTES).toBeLessThan(17 * 1024 * 1024);
     });
 
     it('projects provider-aware observations without hiding conflicts or data gaps', () => {
@@ -204,6 +221,7 @@ describe('unified health shared contract', () => {
             sourceRecord({
                 id: 'garmin-record',
                 provider: HEALTH_PROVIDERS.GarminAPI,
+                deviceKey: 'garmin-watch-1',
                 metrics: [valueEntry(), sleepReference],
             }),
             sourceRecord({
@@ -232,6 +250,7 @@ describe('unified health shared contract', () => {
                     normalizationStatus: HEALTH_NORMALIZATION_STATUSES.NativeOnly,
                     native: { metric: 'vendorWellness', value: 'good' },
                     canonical: null,
+                    coverage: { status: HEALTH_COVERAGE_STATUSES.Unknown },
                 })],
             }),
         ];
@@ -245,17 +264,37 @@ describe('unified health shared contract', () => {
         expect(result.conflicts).toEqual([expect.objectContaining({
             metricId: HEALTH_METRIC_IDS.Steps,
             providers: [HEALTH_PROVIDERS.COROSAPI, HEALTH_PROVIDERS.GarminAPI],
+            sources: [
+                { provider: HEALTH_PROVIDERS.COROSAPI, accountKey: `account-${HEALTH_PROVIDERS.COROSAPI}` },
+                { provider: HEALTH_PROVIDERS.GarminAPI, accountKey: `account-${HEALTH_PROVIDERS.GarminAPI}` },
+            ],
             semanticVariant: 'provider_daily_summary',
+            origin: HEALTH_VALUE_ORIGINS.ProviderSummary,
+            recordingMethods: [HEALTH_RECORDING_METHODS.ProviderCalculated],
         })]);
+        expect(result.observations.find(item => item.recordId === 'garmin-record')?.device).toEqual({
+            deviceKey: 'garmin-watch-1',
+        });
+        expect(result.observations.find(item => item.recordId === 'coros-record')?.coverage.status)
+            .toBe(HEALTH_COVERAGE_STATUSES.Partial);
         expect(result.dailySummaries[0].sleepReferenceIds).toEqual(['sleep-session-1']);
         expect(result.coverage.find(item => item.provider === HEALTH_PROVIDERS.GarminAPI && item.metricId === HEALTH_METRIC_IDS.Steps)).toMatchObject({
             requestedDays: 3,
             recordedDays: 1,
+            missingDays: 2,
             partialDays: 0,
+            unknownDays: 0,
         });
         expect(result.coverage.find(item => item.provider === HEALTH_PROVIDERS.COROSAPI)).toMatchObject({
             recordedDays: 1,
             partialDays: 1,
+            unknownDays: 0,
+        });
+        expect(result.coverage.find(item => item.provider === HEALTH_PROVIDERS.WahooAPI)).toMatchObject({
+            recordedDays: 1,
+            missingDays: 2,
+            partialDays: 0,
+            unknownDays: 1,
         });
         expect(result.freshness.find(item => item.provider === HEALTH_PROVIDERS.GarminAPI && item.metricId === HEALTH_METRIC_IDS.Steps)).toMatchObject({
             status: 'stale',
@@ -269,7 +308,226 @@ describe('unified health shared contract', () => {
                 HEALTH_PROVIDERS.WahooAPI,
             ],
             semanticVariants: ['provider_daily_summary', 'ten_minute_bucket_total'],
+            aggregations: ['total'],
+            origins: [HEALTH_VALUE_ORIGINS.ProviderSummary],
+            recordingMethods: [HEALTH_RECORDING_METHODS.ProviderCalculated],
         });
+    });
+
+    it('keeps coverage and freshness separate across aggregation, origin, and recording method', () => {
+        const record = sourceRecord({
+            id: 'separate-semantics',
+            provider: HEALTH_PROVIDERS.GarminAPI,
+            metrics: [
+                valueEntry(),
+                valueEntry({
+                    aggregation: 'average',
+                    origin: HEALTH_VALUE_ORIGINS.Recorded,
+                    recordingMethod: HEALTH_RECORDING_METHODS.Device,
+                }),
+            ],
+        });
+
+        const result = projectHealthRange([record], [], {
+            startDate: '2026-01-01',
+            endDate: '2026-01-01',
+        });
+
+        expect(result.coverage).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                aggregation: 'average',
+                origin: HEALTH_VALUE_ORIGINS.Recorded,
+                recordingMethod: HEALTH_RECORDING_METHODS.Device,
+            }),
+            expect.objectContaining({
+                aggregation: 'total',
+                origin: HEALTH_VALUE_ORIGINS.ProviderSummary,
+                recordingMethod: HEALTH_RECORDING_METHODS.ProviderCalculated,
+            }),
+        ]));
+        expect(result.coverage).toHaveLength(2);
+        expect(result.freshness).toHaveLength(2);
+    });
+
+    it('keeps coverage and freshness separate for multiple accounts at one provider', () => {
+        const records = [
+            sourceRecord({
+                id: 'garmin-primary',
+                provider: HEALTH_PROVIDERS.GarminAPI,
+                accountKey: 'garmin-account-primary',
+            }),
+            sourceRecord({
+                id: 'garmin-secondary',
+                provider: HEALTH_PROVIDERS.GarminAPI,
+                accountKey: 'garmin-account-secondary',
+                metrics: [valueEntry({
+                    native: { metric: 'steps', value: 120, unit: 'count' },
+                    canonical: { value: 120, unit: HEALTH_UNITS.Count },
+                })],
+            }),
+        ];
+
+        const result = projectHealthRange(records, [], {
+            startDate: '2026-01-01',
+            endDate: '2026-01-01',
+        });
+
+        expect(result.coverage.map(item => item.accountKey)).toEqual([
+            'garmin-account-primary',
+            'garmin-account-secondary',
+        ]);
+        expect(result.freshness.map(item => item.accountKey)).toEqual([
+            'garmin-account-primary',
+            'garmin-account-secondary',
+        ]);
+        expect(result.conflicts).toEqual([expect.objectContaining({
+            providers: [HEALTH_PROVIDERS.GarminAPI],
+            sources: [
+                { provider: HEALTH_PROVIDERS.GarminAPI, accountKey: 'garmin-account-primary' },
+                { provider: HEALTH_PROVIDERS.GarminAPI, accountKey: 'garmin-account-secondary' },
+            ],
+        })]);
+    });
+
+    it('does not merge distinct conflict identities containing delimiter characters', () => {
+        const records = [
+            sourceRecord({
+                id: 'garmin-delimiter-record',
+                provider: HEALTH_PROVIDERS.GarminAPI,
+                metrics: [valueEntry({
+                    aggregation: 'average\u0000overnight',
+                    semanticVariant: 'provider_summary',
+                    canonical: { value: 60, unit: HEALTH_UNITS.Count },
+                })],
+            }),
+            sourceRecord({
+                id: 'coros-delimiter-record',
+                provider: HEALTH_PROVIDERS.COROSAPI,
+                metrics: [valueEntry({
+                    aggregation: 'average',
+                    semanticVariant: 'overnight\u0000provider_summary',
+                    canonical: { value: 70, unit: HEALTH_UNITS.Count },
+                })],
+            }),
+        ];
+
+        const result = projectHealthRange(records, [], {
+            startDate: '2026-01-01',
+            endDate: '2026-01-01',
+        });
+
+        expect(result.conflicts).toEqual([]);
+    });
+
+    it('orders conflict groups by their complete semantic identity', () => {
+        const total = valueEntry({ aggregation: 'total', canonical: { value: 100, unit: HEALTH_UNITS.Count } });
+        const average = valueEntry({ aggregation: 'average', canonical: { value: 10, unit: HEALTH_UNITS.Count } });
+        const records = [
+            sourceRecord({
+                id: 'garmin-conflicts',
+                provider: HEALTH_PROVIDERS.GarminAPI,
+                metrics: [total, average],
+            }),
+            sourceRecord({
+                id: 'coros-conflicts',
+                provider: HEALTH_PROVIDERS.COROSAPI,
+                metrics: [
+                    valueEntry({ aggregation: 'average', canonical: { value: 20, unit: HEALTH_UNITS.Count } }),
+                    valueEntry({ aggregation: 'total', canonical: { value: 200, unit: HEALTH_UNITS.Count } }),
+                ],
+            }),
+        ];
+
+        const result = projectHealthRange(records, [], {
+            startDate: '2026-01-01',
+            endDate: '2026-01-01',
+        });
+
+        expect(result.conflicts.map(conflict => conflict.aggregation)).toEqual(['average', 'total']);
+    });
+
+    it('does not report same-day values whose observation intervals do not overlap', () => {
+        const dayStartMs = Date.parse('2026-01-01T00:00:00.000Z');
+        const records = [
+            sourceRecord({
+                id: 'garmin-morning',
+                provider: HEALTH_PROVIDERS.GarminAPI,
+                startTimeMs: dayStartMs,
+                endTimeMs: dayStartMs + 60_000,
+                metrics: [valueEntry({ canonical: { value: 60, unit: HEALTH_UNITS.Count } })],
+            }),
+            sourceRecord({
+                id: 'coros-evening',
+                provider: HEALTH_PROVIDERS.COROSAPI,
+                startTimeMs: dayStartMs + 12 * 60 * 60 * 1_000,
+                endTimeMs: dayStartMs + 12 * 60 * 60 * 1_000 + 60_000,
+                metrics: [valueEntry({ canonical: { value: 70, unit: HEALTH_UNITS.Count } })],
+            }),
+        ];
+
+        const result = projectHealthRange(records, [], {
+            startDate: '2026-01-01',
+            endDate: '2026-01-01',
+        });
+
+        expect(result.conflicts).toEqual([]);
+    });
+
+    it('orders provider semantic variants independently of the runtime locale', () => {
+        const records = [
+            sourceRecord({
+                id: 'unicode-variant',
+                provider: HEALTH_PROVIDERS.GarminAPI,
+                metrics: [
+                    valueEntry({ semanticVariant: 'ä-provider-summary' }),
+                    valueEntry({ semanticVariant: 'z-provider-summary' }),
+                ],
+            }),
+        ];
+
+        const result = projectHealthRange(records, [], {
+            startDate: '2026-01-01',
+            endDate: '2026-01-01',
+        });
+
+        expect(result.discovery[0].semanticVariants).toEqual([
+            'z-provider-summary',
+            'ä-provider-summary',
+        ]);
+    });
+
+    it('keeps provider calendar dates and offsets stable across a DST transition', () => {
+        const beforeTransition = sourceRecord({
+            id: 'before-dst',
+            provider: HEALTH_PROVIDERS.GarminAPI,
+            calendarDate: '2026-03-07',
+            startTimeMs: Date.parse('2026-03-07T05:00:00.000Z'),
+            endTimeMs: Date.parse('2026-03-08T04:59:59.999Z'),
+        });
+        beforeTransition.timezoneOffsetSeconds = -5 * 60 * 60;
+        const transitionDay = sourceRecord({
+            id: 'dst-day',
+            provider: HEALTH_PROVIDERS.GarminAPI,
+            calendarDate: '2026-03-08',
+            startTimeMs: Date.parse('2026-03-08T05:00:00.000Z'),
+            endTimeMs: Date.parse('2026-03-09T03:59:59.999Z'),
+        });
+        transitionDay.timezoneOffsetSeconds = -4 * 60 * 60;
+
+        const result = projectHealthRange([transitionDay, beforeTransition], [], {
+            startDate: '2026-03-07',
+            endDate: '2026-03-08',
+        });
+
+        expect(result.dailySummaries.map(summary => summary.calendarDate)).toEqual(['2026-03-07', '2026-03-08']);
+        expect(result.observations.map(observation => ({
+            date: observation.calendarDate,
+            offset: observation.timezoneOffsetSeconds,
+            durationMs: observation.endTimeMs - observation.startTimeMs + 1,
+        }))).toEqual([
+            { date: '2026-03-07', offset: -18_000, durationMs: DAY_MS },
+            { date: '2026-03-08', offset: -14_400, durationMs: 23 * 60 * 60 * 1000 },
+        ]);
     });
 
     it('keeps sample chunks whole when enforcing the point budget', () => {
@@ -301,11 +559,35 @@ describe('unified health shared contract', () => {
         expect(result.pageInfo).toMatchObject({
             returnedSamplePoints: 1_000,
             samplesTruncated: true,
+            sampleAggregateComplete: false,
             chunkCursor: { calendarDate: '2026-01-01', id: 'chunk-1' },
         });
         expect(result.discovery[0]).toMatchObject({
             metricId: HEALTH_METRIC_IDS.HeartRate,
             hasSamples: true,
+        });
+        expect(result.freshness.find(item => item.semanticVariant === 'device_sample')?.lastReceivedAtMs)
+            .toBe(chunks[0].receivedAtMs);
+    });
+
+    it('suppresses sample chunks from a mismatched known parent revision', () => {
+        const record = sourceRecord({
+            id: 'garmin-record',
+            provider: HEALTH_PROVIDERS.GarminAPI,
+        });
+        const staleChunk = sampleChunk({ id: 'chunk-1', pointCount: 10 });
+        staleChunk.revision = { order: 0, token: 'stale', digest: 'stale-digest' };
+
+        const result = projectHealthRange([record], [staleChunk], {
+            startDate: '2026-01-01',
+            endDate: '2026-01-01',
+            includeSamples: true,
+        });
+
+        expect(result.sampleChunks).toEqual([]);
+        expect(result.pageInfo).toMatchObject({
+            sampleRevisionMismatchCount: 1,
+            sampleAggregateComplete: false,
         });
     });
 
@@ -324,6 +606,7 @@ describe('unified health shared contract', () => {
         });
         expect(firstPage.observations.map(item => item.recordId)).toEqual(['a']);
         expect(firstPage.pageInfo.recordCursor).toEqual({ calendarDate: '2026-01-01', id: 'a' });
+        expect(firstPage.pageInfo.recordAggregateComplete).toBe(false);
 
         const secondPage = projectHealthRange(records, [], {
             startDate: '2026-01-01',
@@ -333,6 +616,41 @@ describe('unified health shared contract', () => {
             recordCursor: firstPage.pageInfo.recordCursor,
         });
         expect(secondPage.observations.map(item => item.recordId)).toEqual(['c']);
+        expect(secondPage.pageInfo.recordAggregateComplete).toBe(false);
+    });
+
+    it('supports deterministic conflict recomputation across record page boundaries', () => {
+        const records = [
+            sourceRecord({
+                id: 'a-garmin',
+                provider: HEALTH_PROVIDERS.GarminAPI,
+                metrics: [valueEntry({ canonical: { value: 100, unit: HEALTH_UNITS.Count } })],
+            }),
+            sourceRecord({
+                id: 'b-coros',
+                provider: HEALTH_PROVIDERS.COROSAPI,
+                metrics: [valueEntry({ canonical: { value: 120, unit: HEALTH_UNITS.Count } })],
+            }),
+        ];
+        const query = {
+            startDate: '2026-01-01',
+            endDate: '2026-01-01',
+            recordLimit: 1,
+        };
+        const firstPage = projectHealthRange(records, [], query);
+        const secondPage = projectHealthRange(records, [], {
+            ...query,
+            recordCursor: firstPage.pageInfo.recordCursor,
+        });
+
+        expect(firstPage.conflicts).toEqual([]);
+        expect(secondPage.conflicts).toEqual([]);
+        expect(findHealthConflicts([...firstPage.observations, ...secondPage.observations])).toEqual([
+            expect.objectContaining({
+                metricId: HEALTH_METRIC_IDS.Steps,
+                observationIds: ['a-garmin:0', 'b-coros:0'],
+            }),
+        ]);
     });
 
     it('mirrors metric-index paging when no provider filter is requested', () => {
@@ -398,7 +716,7 @@ describe('unified health shared contract', () => {
             metricIds: [HEALTH_METRIC_IDS.HeartRate],
             includeSamples: true,
             recordLimit: 10,
-            chunkLimit: 20,
+            chunkLimit: 8,
         });
 
         expect(plans.records).toMatchObject({
@@ -415,7 +733,7 @@ describe('unified health shared contract', () => {
                 operator: 'in',
                 value: [HEALTH_PROVIDERS.GarminAPI, HEALTH_PROVIDERS.COROSAPI],
             },
-            fetchLimit: 21,
+            fetchLimit: 9,
         });
     });
 

--- a/src/app/shared/health.shared.spec.ts
+++ b/src/app/shared/health.shared.spec.ts
@@ -312,6 +312,9 @@ describe('unified health shared contract', () => {
             origins: [HEALTH_VALUE_ORIGINS.ProviderSummary],
             recordingMethods: [HEALTH_RECORDING_METHODS.ProviderCalculated],
         });
+        expect(result.discovery.find(item => item.metricId === HEALTH_METRIC_IDS.HeartRate)).toMatchObject({
+            canonicalUnits: [HEALTH_UNITS.BeatsPerMinute],
+        });
     });
 
     it('keeps coverage and freshness separate across aggregation, origin, and recording method', () => {

--- a/src/app/shared/health.shared.spec.ts
+++ b/src/app/shared/health.shared.spec.ts
@@ -1,0 +1,433 @@
+import {
+    HEALTH_COVERAGE_STATUSES,
+    HEALTH_METRIC_CATALOG,
+    HEALTH_METRIC_IDS,
+    HEALTH_NORMALIZATION_STATUSES,
+    HEALTH_PROVIDERS,
+    HEALTH_QUALITY_STATUSES,
+    HEALTH_RECORDING_METHODS,
+    HEALTH_RECORD_KINDS,
+    HEALTH_SCHEMA_VERSION,
+    HEALTH_SLEEP_REFERENCE_FIELDS,
+    HEALTH_UNITS,
+    HEALTH_VALUE_ORIGINS,
+    HEALTH_VALUE_TYPES,
+    HealthMetricEntry,
+    HealthMetricId,
+    HealthMetricValue,
+    HealthProvider,
+    HealthSampleChunk,
+    HealthSourceRecord,
+} from '@shared/health';
+import {
+    HealthQueryValidationError,
+    canonicalUnitForMetric,
+    normalizeHealthRangeQuery,
+    projectHealthRange,
+} from '@shared/health-query';
+import { planHealthFirestoreQueries } from '@shared/health-firestore-query';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function valueEntry(overrides: Partial<HealthMetricValue> = {}): HealthMetricValue {
+    return {
+        kind: 'value',
+        metricId: HEALTH_METRIC_IDS.Steps,
+        valueType: HEALTH_VALUE_TYPES.Number,
+        aggregation: 'total',
+        semanticVariant: 'provider_daily_summary',
+        origin: HEALTH_VALUE_ORIGINS.ProviderSummary,
+        recordingMethod: HEALTH_RECORDING_METHODS.ProviderCalculated,
+        quality: { status: HEALTH_QUALITY_STATUSES.Valid },
+        coverage: {
+            status: HEALTH_COVERAGE_STATUSES.Complete,
+            expectedUpdateIntervalMs: DAY_MS,
+        },
+        normalizationStatus: HEALTH_NORMALIZATION_STATUSES.Canonical,
+        native: { metric: 'steps', value: 100, unit: 'count' },
+        canonical: { value: 100, unit: HEALTH_UNITS.Count },
+        ...overrides,
+    };
+}
+
+function sourceRecord(input: {
+    id: string;
+    provider: HealthProvider;
+    accountKey?: string;
+    calendarDate?: string;
+    metrics?: HealthMetricEntry[];
+    coverageStatus?: 'complete' | 'partial' | 'unknown';
+    startTimeMs?: number;
+    endTimeMs?: number;
+}): HealthSourceRecord {
+    const calendarDate = input.calendarDate || '2026-01-01';
+    const startTimeMs = input.startTimeMs ?? Date.parse(`${calendarDate}T00:00:00.000Z`);
+    return {
+        schemaVersion: HEALTH_SCHEMA_VERSION,
+        id: input.id,
+        userID: 'user-1',
+        kind: HEALTH_RECORD_KINDS.DailySummary,
+        source: {
+            provider: input.provider,
+            accountKey: input.accountKey || `account-${input.provider}`,
+            sourceRecordType: 'daily',
+            sourceRecordKey: input.id,
+            revision: { order: 1, token: 'revision-1', digest: `digest-${input.id}` },
+            receivedAtMs: startTimeMs + DAY_MS,
+        },
+        calendarDate,
+        startTimeMs,
+        endTimeMs: input.endTimeMs ?? startTimeMs + DAY_MS - 1,
+        timezoneOffsetSeconds: 0,
+        metrics: input.metrics || [valueEntry()],
+        metricIds: [...new Set((input.metrics || [valueEntry()]).map(metric => metric.metricId))],
+        coverage: { status: input.coverageStatus || HEALTH_COVERAGE_STATUSES.Complete },
+        sampleChunkIds: [],
+        createdAtMs: startTimeMs + DAY_MS,
+        updatedAtMs: startTimeMs + DAY_MS,
+    };
+}
+
+function sampleChunk(input: {
+    id: string;
+    pointCount: number;
+    calendarDate?: string;
+    provider?: HealthProvider;
+    metricId?: HealthMetricId;
+}): HealthSampleChunk {
+    const calendarDate = input.calendarDate || '2026-01-01';
+    const startTimeMs = Date.parse(`${calendarDate}T00:00:00.000Z`);
+    const offsetMs = Array.from({ length: input.pointCount }, (_, index) => index * 60_000);
+    const metricId = input.metricId || HEALTH_METRIC_IDS.HeartRate;
+    return {
+        schemaVersion: HEALTH_SCHEMA_VERSION,
+        id: input.id,
+        userID: 'user-1',
+        parentRecordId: 'garmin-record',
+        provider: input.provider || HEALTH_PROVIDERS.GarminAPI,
+        accountKey: 'garmin-account',
+        metricId,
+        valueType: HEALTH_VALUE_TYPES.Number,
+        aggregation: 'sample',
+        semanticVariant: 'device_sample',
+        origin: HEALTH_VALUE_ORIGINS.Recorded,
+        recordingMethod: HEALTH_RECORDING_METHODS.Device,
+        normalizationStatus: HEALTH_NORMALIZATION_STATUSES.Canonical,
+        nativeMetric: metricId,
+        nativeUnit: HEALTH_METRIC_CATALOG[metricId].canonicalUnit,
+        canonicalUnit: HEALTH_METRIC_CATALOG[metricId].canonicalUnit,
+        calendarDate,
+        startTimeMs,
+        endTimeMs: startTimeMs + (offsetMs.at(-1) || 0),
+        timezoneOffsetSeconds: 0,
+        seriesKey: 'heart-rate',
+        chunkIndex: Number(input.id.replace(/\D/g, '')) || 0,
+        offsetMs,
+        nativeValues: offsetMs.map((_, index) => 60 + index),
+        canonicalValues: offsetMs.map((_, index) => 60 + index),
+        coverage: { status: HEALTH_COVERAGE_STATUSES.Complete, sampleCount: input.pointCount },
+        revision: { order: 1, token: 'revision-1', digest: 'digest-record' },
+        createdAtMs: startTimeMs + DAY_MS,
+        updatedAtMs: startTimeMs + DAY_MS,
+    };
+}
+
+describe('unified health shared contract', () => {
+    it('publishes stable metric definitions and canonical units', () => {
+        expect(HEALTH_METRIC_CATALOG[HEALTH_METRIC_IDS.ActiveEnergy]).toMatchObject({
+            valueType: HEALTH_VALUE_TYPES.Number,
+            canonicalUnit: HEALTH_UNITS.Kilocalorie,
+        });
+        expect(HEALTH_METRIC_CATALOG[HEALTH_METRIC_IDS.StressState]).toMatchObject({
+            valueType: HEALTH_VALUE_TYPES.Category,
+            canonicalUnit: HEALTH_UNITS.Category,
+        });
+        expect(HEALTH_METRIC_CATALOG[HEALTH_METRIC_IDS.SleepDuration]).toMatchObject({
+            category: 'sleep',
+            canonicalUnit: HEALTH_UNITS.Second,
+        });
+        expect(canonicalUnitForMetric(HEALTH_METRIC_IDS.HeartRateVariability)).toBe(HEALTH_UNITS.Millisecond);
+    });
+
+    it('normalizes a bounded summary query', () => {
+        expect(normalizeHealthRangeQuery({
+            startDate: '2026-01-01',
+            endDate: '2026-01-03',
+            providers: [HEALTH_PROVIDERS.GarminAPI, HEALTH_PROVIDERS.GarminAPI],
+        })).toMatchObject({
+            providers: [HEALTH_PROVIDERS.GarminAPI],
+            metricIds: [],
+            includeSamples: false,
+            recordLimit: 250,
+            chunkLimit: 100,
+            samplePointLimit: 25_000,
+            recordCursor: null,
+            chunkCursor: null,
+        });
+    });
+
+    it.each([
+        [{ startDate: '2026-02-30', endDate: '2026-03-01' }, 'valid calendar date'],
+        [{ startDate: '2026-01-02', endDate: '2026-01-01' }, 'on or after'],
+        [{ startDate: '2025-01-01', endDate: '2026-01-02' }, '366-day limit'],
+        [{ startDate: '2026-01-01', endDate: '2026-02-01', includeSamples: true }, '31-day limit'],
+        [{ startDate: '2026-01-01', endDate: '2026-01-01', metricIds: ['unknown'] }, 'supported metric IDs'],
+        [{ startDate: '2026-01-01', endDate: '2026-01-01', recordLimit: 1_001 }, '1 to 1000'],
+        [{ startDate: '2026-01-01', endDate: '2026-01-01', samplePointLimit: 1_439 }, '1440 to 50000'],
+        [{
+            startDate: '2026-01-01',
+            endDate: '2026-01-01',
+            recordCursor: { calendarDate: '2026-01-01', id: 'nested/path' },
+        }, 'safe bounded document ID'],
+    ])('rejects invalid or unbounded query input %#', (query, message) => {
+        expect(() => normalizeHealthRangeQuery(query)).toThrowError(new RegExp(message));
+        expect(() => normalizeHealthRangeQuery(query)).toThrow(HealthQueryValidationError);
+    });
+
+    it('projects provider-aware observations without hiding conflicts or data gaps', () => {
+        const sleepReference: HealthMetricEntry = {
+            kind: 'sleep_reference',
+            metricId: HEALTH_METRIC_IDS.HeartRate,
+            valueType: HEALTH_VALUE_TYPES.Number,
+            aggregation: 'average',
+            semanticVariant: 'sleep_session',
+            origin: HEALTH_VALUE_ORIGINS.ProviderSummary,
+            recordingMethod: HEALTH_RECORDING_METHODS.ProviderCalculated,
+            quality: { status: HEALTH_QUALITY_STATUSES.Valid },
+            reference: {
+                domain: 'sleep',
+                documentId: 'sleep-session-1',
+                field: HEALTH_SLEEP_REFERENCE_FIELDS.AverageHeartRate,
+            },
+        };
+        const records = [
+            sourceRecord({
+                id: 'garmin-record',
+                provider: HEALTH_PROVIDERS.GarminAPI,
+                metrics: [valueEntry(), sleepReference],
+            }),
+            sourceRecord({
+                id: 'coros-record',
+                provider: HEALTH_PROVIDERS.COROSAPI,
+                coverageStatus: HEALTH_COVERAGE_STATUSES.Partial,
+                metrics: [valueEntry({
+                    native: { metric: 'step', value: 120 },
+                    canonical: { value: 120, unit: HEALTH_UNITS.Count },
+                    coverage: { status: HEALTH_COVERAGE_STATUSES.Partial, expectedUpdateIntervalMs: DAY_MS },
+                })],
+            }),
+            sourceRecord({
+                id: 'suunto-record',
+                provider: HEALTH_PROVIDERS.SuuntoApp,
+                metrics: [valueEntry({
+                    semanticVariant: 'ten_minute_bucket_total',
+                    native: { metric: 'steps', value: 20 },
+                    canonical: { value: 20, unit: HEALTH_UNITS.Count },
+                })],
+            }),
+            sourceRecord({
+                id: 'native-only-record',
+                provider: HEALTH_PROVIDERS.WahooAPI,
+                metrics: [valueEntry({
+                    normalizationStatus: HEALTH_NORMALIZATION_STATUSES.NativeOnly,
+                    native: { metric: 'vendorWellness', value: 'good' },
+                    canonical: null,
+                })],
+            }),
+        ];
+
+        const result = projectHealthRange(records, [], {
+            startDate: '2026-01-01',
+            endDate: '2026-01-03',
+        }, Date.parse('2026-01-05T00:00:00.000Z'));
+
+        expect(result.observations).toHaveLength(5);
+        expect(result.conflicts).toEqual([expect.objectContaining({
+            metricId: HEALTH_METRIC_IDS.Steps,
+            providers: [HEALTH_PROVIDERS.COROSAPI, HEALTH_PROVIDERS.GarminAPI],
+            semanticVariant: 'provider_daily_summary',
+        })]);
+        expect(result.dailySummaries[0].sleepReferenceIds).toEqual(['sleep-session-1']);
+        expect(result.coverage.find(item => item.provider === HEALTH_PROVIDERS.GarminAPI && item.metricId === HEALTH_METRIC_IDS.Steps)).toMatchObject({
+            requestedDays: 3,
+            recordedDays: 1,
+            partialDays: 0,
+        });
+        expect(result.coverage.find(item => item.provider === HEALTH_PROVIDERS.COROSAPI)).toMatchObject({
+            recordedDays: 1,
+            partialDays: 1,
+        });
+        expect(result.freshness.find(item => item.provider === HEALTH_PROVIDERS.GarminAPI && item.metricId === HEALTH_METRIC_IDS.Steps)).toMatchObject({
+            status: 'stale',
+            staleAfterMs: DAY_MS,
+        });
+        expect(result.discovery.find(item => item.metricId === HEALTH_METRIC_IDS.Steps)).toMatchObject({
+            providers: [
+                HEALTH_PROVIDERS.COROSAPI,
+                HEALTH_PROVIDERS.GarminAPI,
+                HEALTH_PROVIDERS.SuuntoApp,
+                HEALTH_PROVIDERS.WahooAPI,
+            ],
+            semanticVariants: ['provider_daily_summary', 'ten_minute_bucket_total'],
+        });
+    });
+
+    it('keeps sample chunks whole when enforcing the point budget', () => {
+        const record = sourceRecord({
+            id: 'garmin-record',
+            provider: HEALTH_PROVIDERS.GarminAPI,
+            metrics: [valueEntry({
+                metricId: HEALTH_METRIC_IDS.HeartRate,
+                aggregation: 'average',
+                semanticVariant: 'daily_average',
+                native: { metric: 'averageHeartRate', value: 65, unit: 'bpm' },
+                canonical: { value: 65, unit: HEALTH_UNITS.BeatsPerMinute },
+            })],
+        });
+        const chunks = [
+            sampleChunk({ id: 'chunk-1', pointCount: 1_000 }),
+            sampleChunk({ id: 'chunk-2', pointCount: 700 }),
+        ];
+
+        const result = projectHealthRange([record], chunks, {
+            startDate: '2026-01-01',
+            endDate: '2026-01-01',
+            metricIds: [HEALTH_METRIC_IDS.HeartRate],
+            includeSamples: true,
+            samplePointLimit: 1_440,
+        });
+
+        expect(result.sampleChunks.map(chunk => chunk.id)).toEqual(['chunk-1']);
+        expect(result.pageInfo).toMatchObject({
+            returnedSamplePoints: 1_000,
+            samplesTruncated: true,
+            chunkCursor: { calendarDate: '2026-01-01', id: 'chunk-1' },
+        });
+        expect(result.discovery[0]).toMatchObject({
+            metricId: HEALTH_METRIC_IDS.HeartRate,
+            hasSamples: true,
+        });
+    });
+
+    it('returns deterministic record cursors and respects provider filters', () => {
+        const records = [
+            sourceRecord({ id: 'a', provider: HEALTH_PROVIDERS.GarminAPI }),
+            sourceRecord({ id: 'b', provider: HEALTH_PROVIDERS.COROSAPI }),
+            sourceRecord({ id: 'c', provider: HEALTH_PROVIDERS.GarminAPI }),
+        ];
+
+        const firstPage = projectHealthRange(records, [], {
+            startDate: '2026-01-01',
+            endDate: '2026-01-01',
+            providers: [HEALTH_PROVIDERS.GarminAPI],
+            recordLimit: 1,
+        });
+        expect(firstPage.observations.map(item => item.recordId)).toEqual(['a']);
+        expect(firstPage.pageInfo.recordCursor).toEqual({ calendarDate: '2026-01-01', id: 'a' });
+
+        const secondPage = projectHealthRange(records, [], {
+            startDate: '2026-01-01',
+            endDate: '2026-01-01',
+            providers: [HEALTH_PROVIDERS.GarminAPI],
+            recordLimit: 1,
+            recordCursor: firstPage.pageInfo.recordCursor,
+        });
+        expect(secondPage.observations.map(item => item.recordId)).toEqual(['c']);
+    });
+
+    it('mirrors metric-index paging when no provider filter is requested', () => {
+        const records = [
+            sourceRecord({
+                id: 'a-heart-rate',
+                provider: HEALTH_PROVIDERS.GarminAPI,
+                metrics: [valueEntry({ metricId: HEALTH_METRIC_IDS.HeartRate })],
+            }),
+            sourceRecord({ id: 'b-steps', provider: HEALTH_PROVIDERS.GarminAPI }),
+            sourceRecord({ id: 'c-steps', provider: HEALTH_PROVIDERS.COROSAPI }),
+        ];
+
+        const result = projectHealthRange(records, [], {
+            startDate: '2026-01-01',
+            endDate: '2026-01-01',
+            metricIds: [HEALTH_METRIC_IDS.Steps],
+            recordLimit: 1,
+        });
+
+        expect(result.observations.map(item => item.recordId)).toEqual(['b-steps']);
+        expect(result.pageInfo).toMatchObject({
+            recordsTruncated: true,
+            recordCursor: { calendarDate: '2026-01-01', id: 'b-steps' },
+        });
+    });
+
+    it('advances through sparse provider pages before applying the secondary metric filter', () => {
+        const chunks = [
+            sampleChunk({ id: 'chunk-a', pointCount: 1, metricId: HEALTH_METRIC_IDS.Steps }),
+            sampleChunk({ id: 'chunk-b', pointCount: 1, metricId: HEALTH_METRIC_IDS.Steps }),
+            sampleChunk({ id: 'chunk-c', pointCount: 1, metricId: HEALTH_METRIC_IDS.HeartRate }),
+        ];
+        const query = {
+            startDate: '2026-01-01',
+            endDate: '2026-01-01',
+            providers: [HEALTH_PROVIDERS.GarminAPI],
+            metricIds: [HEALTH_METRIC_IDS.HeartRate],
+            includeSamples: true,
+            chunkLimit: 2,
+        };
+
+        const firstPage = projectHealthRange([], chunks, query);
+        expect(firstPage.sampleChunks).toEqual([]);
+        expect(firstPage.pageInfo).toMatchObject({
+            samplesTruncated: true,
+            chunkCursor: { calendarDate: '2026-01-01', id: 'chunk-b' },
+        });
+
+        const secondPage = projectHealthRange([], chunks, {
+            ...query,
+            chunkCursor: firstPage.pageInfo.chunkCursor,
+        });
+        expect(secondPage.sampleChunks.map(chunk => chunk.id)).toEqual(['chunk-c']);
+        expect(secondPage.pageInfo.samplesTruncated).toBe(false);
+    });
+
+    it('uses one bounded Firestore predicate per collection and leaves secondary filtering to the projector', () => {
+        const plans = planHealthFirestoreQueries({
+            startDate: '2026-01-01',
+            endDate: '2026-01-07',
+            providers: [HEALTH_PROVIDERS.GarminAPI, HEALTH_PROVIDERS.COROSAPI],
+            metricIds: [HEALTH_METRIC_IDS.HeartRate],
+            includeSamples: true,
+            recordLimit: 10,
+            chunkLimit: 20,
+        });
+
+        expect(plans.records).toMatchObject({
+            filter: {
+                field: 'source.provider',
+                operator: 'in',
+                value: [HEALTH_PROVIDERS.GarminAPI, HEALTH_PROVIDERS.COROSAPI],
+            },
+            fetchLimit: 11,
+        });
+        expect(plans.chunks).toMatchObject({
+            filter: {
+                field: 'provider',
+                operator: 'in',
+                value: [HEALTH_PROVIDERS.GarminAPI, HEALTH_PROVIDERS.COROSAPI],
+            },
+            fetchLimit: 21,
+        });
+    });
+
+    it('uses metric indexes when no provider predicate is requested', () => {
+        const plans = planHealthFirestoreQueries({
+            startDate: '2026-01-01',
+            endDate: '2026-01-07',
+            metricIds: [HEALTH_METRIC_IDS.HeartRate, HEALTH_METRIC_IDS.HeartRateVariability],
+            includeSamples: true,
+        });
+
+        expect(plans.records.filter).toMatchObject({ field: 'metricIds', operator: 'array-contains-any' });
+        expect(plans.chunks?.filter).toMatchObject({ field: 'metricId', operator: 'in' });
+    });
+});

--- a/src/app/shared/health.shared.spec.ts
+++ b/src/app/shared/health.shared.spec.ts
@@ -7,7 +7,7 @@ import {
     HEALTH_PROVIDERS,
     HEALTH_QUALITY_STATUSES,
     HEALTH_RECORDING_METHODS,
-    HEALTH_RECORD_KINDS,
+    HEALTH_SOURCE_RECORD_KINDS,
     HEALTH_SCHEMA_VERSION,
     HEALTH_SLEEP_REFERENCE_METRIC_IDS,
     HEALTH_SLEEP_REFERENCE_FIELDS,
@@ -70,7 +70,7 @@ function sourceRecord(input: {
         schemaVersion: HEALTH_SCHEMA_VERSION,
         id: input.id,
         userID: 'user-1',
-        kind: HEALTH_RECORD_KINDS.DailySummary,
+        kind: HEALTH_SOURCE_RECORD_KINDS.DailySummary,
         source: {
             provider: input.provider,
             accountKey: input.accountKey || `account-${input.provider}`,
@@ -108,7 +108,7 @@ function sampleChunk(input: {
         schemaVersion: HEALTH_SCHEMA_VERSION,
         id: input.id,
         userID: 'user-1',
-        parentRecordId: 'garmin-record',
+        parentSourceRecordId: 'garmin-record',
         provider: input.provider || HEALTH_PROVIDERS.GarminAPI,
         accountKey: 'garmin-account',
         metricId,
@@ -168,10 +168,10 @@ describe('unified health shared contract', () => {
             providers: [HEALTH_PROVIDERS.GarminAPI],
             metricIds: [],
             includeSamples: false,
-            recordLimit: 32,
+            sourceRecordLimit: 32,
             chunkLimit: 8,
             samplePointLimit: 10_000,
-            recordCursor: null,
+            sourceRecordCursor: null,
             chunkCursor: null,
         });
     });
@@ -184,13 +184,13 @@ describe('unified health shared contract', () => {
         [{ startDate: '2026-01-01', endDate: '2026-01-01', metricIds: ['unknown'] }, 'supported metric IDs'],
         [{ startDate: '2026-01-01', endDate: '2026-01-01', providers: new Array(1) }, 'supported providers'],
         [{ startDate: '2026-01-01', endDate: '2026-01-01', metricIds: new Array(1) }, 'supported metric IDs'],
-        [{ startDate: '2026-01-01', endDate: '2026-01-01', recordLimit: 33 }, '1 to 32'],
+        [{ startDate: '2026-01-01', endDate: '2026-01-01', sourceRecordLimit: 33 }, '1 to 32'],
         [{ startDate: '2026-01-01', endDate: '2026-01-01', chunkLimit: 9 }, '1 to 8'],
         [{ startDate: '2026-01-01', endDate: '2026-01-01', samplePointLimit: 1_439 }, '1440 to 11520'],
         [{
             startDate: '2026-01-01',
             endDate: '2026-01-01',
-            recordCursor: { calendarDate: '2026-01-01', id: 'nested/path' },
+            sourceRecordCursor: { calendarDate: '2026-01-01', id: 'nested/path' },
         }, 'safe bounded document ID'],
     ])('rejects invalid or unbounded query input %#', (query, message) => {
         expect(() => normalizeHealthRangeQuery(query)).toThrowError(new RegExp(message));
@@ -272,10 +272,10 @@ describe('unified health shared contract', () => {
             origin: HEALTH_VALUE_ORIGINS.ProviderSummary,
             recordingMethods: [HEALTH_RECORDING_METHODS.ProviderCalculated],
         })]);
-        expect(result.observations.find(item => item.recordId === 'garmin-record')?.device).toEqual({
+        expect(result.observations.find(item => item.sourceRecordId === 'garmin-record')?.device).toEqual({
             deviceKey: 'garmin-watch-1',
         });
-        expect(result.observations.find(item => item.recordId === 'coros-record')?.coverage.status)
+        expect(result.observations.find(item => item.sourceRecordId === 'coros-record')?.coverage.status)
             .toBe(HEALTH_COVERAGE_STATUSES.Partial);
         expect(result.dailySummaries[0].sleepReferenceIds).toEqual(['sleep-session-1']);
         expect(result.coverage.find(item => item.provider === HEALTH_PROVIDERS.GarminAPI && item.metricId === HEALTH_METRIC_IDS.Steps)).toMatchObject({
@@ -591,7 +591,7 @@ describe('unified health shared contract', () => {
         });
     });
 
-    it('returns deterministic record cursors and respects provider filters', () => {
+    it('returns deterministic source-record cursors and respects provider filters', () => {
         const records = [
             sourceRecord({ id: 'a', provider: HEALTH_PROVIDERS.GarminAPI }),
             sourceRecord({ id: 'b', provider: HEALTH_PROVIDERS.COROSAPI }),
@@ -602,24 +602,24 @@ describe('unified health shared contract', () => {
             startDate: '2026-01-01',
             endDate: '2026-01-01',
             providers: [HEALTH_PROVIDERS.GarminAPI],
-            recordLimit: 1,
+            sourceRecordLimit: 1,
         });
-        expect(firstPage.observations.map(item => item.recordId)).toEqual(['a']);
-        expect(firstPage.pageInfo.recordCursor).toEqual({ calendarDate: '2026-01-01', id: 'a' });
-        expect(firstPage.pageInfo.recordAggregateComplete).toBe(false);
+        expect(firstPage.observations.map(item => item.sourceRecordId)).toEqual(['a']);
+        expect(firstPage.pageInfo.sourceRecordCursor).toEqual({ calendarDate: '2026-01-01', id: 'a' });
+        expect(firstPage.pageInfo.sourceRecordAggregateComplete).toBe(false);
 
         const secondPage = projectHealthRange(records, [], {
             startDate: '2026-01-01',
             endDate: '2026-01-01',
             providers: [HEALTH_PROVIDERS.GarminAPI],
-            recordLimit: 1,
-            recordCursor: firstPage.pageInfo.recordCursor,
+            sourceRecordLimit: 1,
+            sourceRecordCursor: firstPage.pageInfo.sourceRecordCursor,
         });
-        expect(secondPage.observations.map(item => item.recordId)).toEqual(['c']);
-        expect(secondPage.pageInfo.recordAggregateComplete).toBe(false);
+        expect(secondPage.observations.map(item => item.sourceRecordId)).toEqual(['c']);
+        expect(secondPage.pageInfo.sourceRecordAggregateComplete).toBe(false);
     });
 
-    it('supports deterministic conflict recomputation across record page boundaries', () => {
+    it('supports deterministic conflict recomputation across source-record page boundaries', () => {
         const records = [
             sourceRecord({
                 id: 'a-garmin',
@@ -635,12 +635,12 @@ describe('unified health shared contract', () => {
         const query = {
             startDate: '2026-01-01',
             endDate: '2026-01-01',
-            recordLimit: 1,
+            sourceRecordLimit: 1,
         };
         const firstPage = projectHealthRange(records, [], query);
         const secondPage = projectHealthRange(records, [], {
             ...query,
-            recordCursor: firstPage.pageInfo.recordCursor,
+            sourceRecordCursor: firstPage.pageInfo.sourceRecordCursor,
         });
 
         expect(firstPage.conflicts).toEqual([]);
@@ -668,13 +668,13 @@ describe('unified health shared contract', () => {
             startDate: '2026-01-01',
             endDate: '2026-01-01',
             metricIds: [HEALTH_METRIC_IDS.Steps],
-            recordLimit: 1,
+            sourceRecordLimit: 1,
         });
 
-        expect(result.observations.map(item => item.recordId)).toEqual(['b-steps']);
+        expect(result.observations.map(item => item.sourceRecordId)).toEqual(['b-steps']);
         expect(result.pageInfo).toMatchObject({
-            recordsTruncated: true,
-            recordCursor: { calendarDate: '2026-01-01', id: 'b-steps' },
+            sourceRecordsTruncated: true,
+            sourceRecordCursor: { calendarDate: '2026-01-01', id: 'b-steps' },
         });
     });
 
@@ -715,11 +715,11 @@ describe('unified health shared contract', () => {
             providers: [HEALTH_PROVIDERS.GarminAPI, HEALTH_PROVIDERS.COROSAPI],
             metricIds: [HEALTH_METRIC_IDS.HeartRate],
             includeSamples: true,
-            recordLimit: 10,
+            sourceRecordLimit: 10,
             chunkLimit: 8,
         });
 
-        expect(plans.records).toMatchObject({
+        expect(plans.sourceRecords).toMatchObject({
             filter: {
                 field: 'source.provider',
                 operator: 'in',
@@ -745,7 +745,7 @@ describe('unified health shared contract', () => {
             includeSamples: true,
         });
 
-        expect(plans.records.filter).toMatchObject({ field: 'metricIds', operator: 'array-contains-any' });
+        expect(plans.sourceRecords.filter).toMatchObject({ field: 'metricIds', operator: 'array-contains-any' });
         expect(plans.chunks?.filter).toMatchObject({ field: 'metricId', operator: 'in' });
     });
 });

--- a/src/firestore.rules.spec.ts
+++ b/src/firestore.rules.spec.ts
@@ -1320,6 +1320,59 @@ describe('Firestore Security Rules', () => {
             });
         });
 
+        describe('Unified Health Records and Sync State', () => {
+            it('allows owners to get their own health documents', async () => {
+                const db = testEnv.authenticatedContext(userId).firestore();
+
+                await assertSucceeds(db.collection('users').doc(userId).collection('healthRecords').doc('record-1').get());
+                await assertSucceeds(db.collection('users').doc(userId).collection('healthSampleChunks').doc('chunk-1').get());
+                await assertSucceeds(db.collection('users').doc(userId).collection('healthSyncState').doc('GarminAPI').get());
+            });
+
+            it('denies reads from another account and unauthenticated reads', async () => {
+                const ownerDb = testEnv.authenticatedContext(userId).firestore();
+                const anonymousDb = testEnv.unauthenticatedContext().firestore();
+
+                await assertFails(ownerDb.collection('users').doc(otherId).collection('healthRecords').doc('record-1').get());
+                await assertFails(ownerDb.collection('users').doc(otherId).collection('healthSampleChunks').doc('chunk-1').get());
+                await assertFails(ownerDb.collection('users').doc(otherId).collection('healthSyncState').doc('GarminAPI').get());
+                await assertFails(anonymousDb.collection('users').doc(userId).collection('healthRecords').doc('record-1').get());
+            });
+
+            it('allows only explicitly bounded owner list queries', async () => {
+                const db = testEnv.authenticatedContext(userId).firestore();
+                const userRef = db.collection('users').doc(userId);
+
+                await assertSucceeds(userRef.collection('healthRecords').limit(1001).get());
+                await assertFails(userRef.collection('healthRecords').limit(1002).get());
+                await assertFails(userRef.collection('healthRecords').get());
+
+                await assertSucceeds(userRef.collection('healthSampleChunks').limit(501).get());
+                await assertFails(userRef.collection('healthSampleChunks').limit(502).get());
+                await assertFails(userRef.collection('healthSampleChunks').get());
+
+                await assertSucceeds(userRef.collection('healthSyncState').limit(6).get());
+                await assertFails(userRef.collection('healthSyncState').limit(7).get());
+                await assertFails(userRef.collection('healthSyncState').get());
+            });
+
+            it('denies all browser writes to server-owned health collections', async () => {
+                const db = testEnv.authenticatedContext(userId).firestore();
+                const userRef = db.collection('users').doc(userId);
+
+                await assertFails(userRef.collection('healthRecords').doc('record-1').set({ calendarDate: '2026-01-01' }));
+                await assertFails(userRef.collection('healthSampleChunks').doc('chunk-1').set({ offsetMs: [0] }));
+                await assertFails(userRef.collection('healthSyncState').doc('GarminAPI').set({ status: 'ready' }));
+            });
+
+            it('forbids descendants beneath permanent health leaf documents', async () => {
+                const db = testEnv.authenticatedContext(userId).firestore();
+
+                await assertFails(db.doc(`users/${userId}/healthSampleChunks/chunk-1/children/forbidden`).get());
+                await assertFails(db.doc(`users/${userId}/healthSampleChunks/chunk-1/children/forbidden`).set({ value: 1 }));
+            });
+        });
+
         describe('MCP server-owned credential state', () => {
             it('should deny owners reading or writing MCP connection summaries directly', async () => {
                 await testEnv.withSecurityRulesDisabled(async (context) => {

--- a/src/firestore.rules.spec.ts
+++ b/src/firestore.rules.spec.ts
@@ -1320,11 +1320,11 @@ describe('Firestore Security Rules', () => {
             });
         });
 
-        describe('Unified Health Records and Sync State', () => {
+        describe('Unified Health Source Records and Sync State', () => {
             it('allows owners to get their own health documents', async () => {
                 const db = testEnv.authenticatedContext(userId).firestore();
 
-                await assertSucceeds(db.collection('users').doc(userId).collection('healthRecords').doc('record-1').get());
+                await assertSucceeds(db.collection('users').doc(userId).collection('healthSourceRecords').doc('record-1').get());
                 await assertSucceeds(db.collection('users').doc(userId).collection('healthSampleChunks').doc('chunk-1').get());
                 await assertSucceeds(db.collection('users').doc(userId).collection('healthSyncState').doc('GarminAPI').get());
             });
@@ -1333,19 +1333,19 @@ describe('Firestore Security Rules', () => {
                 const ownerDb = testEnv.authenticatedContext(userId).firestore();
                 const anonymousDb = testEnv.unauthenticatedContext().firestore();
 
-                await assertFails(ownerDb.collection('users').doc(otherId).collection('healthRecords').doc('record-1').get());
+                await assertFails(ownerDb.collection('users').doc(otherId).collection('healthSourceRecords').doc('record-1').get());
                 await assertFails(ownerDb.collection('users').doc(otherId).collection('healthSampleChunks').doc('chunk-1').get());
                 await assertFails(ownerDb.collection('users').doc(otherId).collection('healthSyncState').doc('GarminAPI').get());
-                await assertFails(anonymousDb.collection('users').doc(userId).collection('healthRecords').doc('record-1').get());
+                await assertFails(anonymousDb.collection('users').doc(userId).collection('healthSourceRecords').doc('record-1').get());
             });
 
             it('allows only explicitly bounded owner list queries', async () => {
                 const db = testEnv.authenticatedContext(userId).firestore();
                 const userRef = db.collection('users').doc(userId);
 
-                await assertSucceeds(userRef.collection('healthRecords').limit(33).get());
-                await assertFails(userRef.collection('healthRecords').limit(34).get());
-                await assertFails(userRef.collection('healthRecords').get());
+                await assertSucceeds(userRef.collection('healthSourceRecords').limit(33).get());
+                await assertFails(userRef.collection('healthSourceRecords').limit(34).get());
+                await assertFails(userRef.collection('healthSourceRecords').get());
 
                 await assertSucceeds(userRef.collection('healthSampleChunks').limit(9).get());
                 await assertFails(userRef.collection('healthSampleChunks').limit(10).get());
@@ -1360,7 +1360,7 @@ describe('Firestore Security Rules', () => {
                 const db = testEnv.authenticatedContext(userId).firestore();
                 const userRef = db.collection('users').doc(userId);
 
-                await assertFails(userRef.collection('healthRecords').doc('record-1').set({ calendarDate: '2026-01-01' }));
+                await assertFails(userRef.collection('healthSourceRecords').doc('record-1').set({ calendarDate: '2026-01-01' }));
                 await assertFails(userRef.collection('healthSampleChunks').doc('chunk-1').set({ offsetMs: [0] }));
                 await assertFails(userRef.collection('healthSyncState').doc('GarminAPI').set({ status: 'ready' }));
             });

--- a/src/firestore.rules.spec.ts
+++ b/src/firestore.rules.spec.ts
@@ -1343,12 +1343,12 @@ describe('Firestore Security Rules', () => {
                 const db = testEnv.authenticatedContext(userId).firestore();
                 const userRef = db.collection('users').doc(userId);
 
-                await assertSucceeds(userRef.collection('healthRecords').limit(1001).get());
-                await assertFails(userRef.collection('healthRecords').limit(1002).get());
+                await assertSucceeds(userRef.collection('healthRecords').limit(33).get());
+                await assertFails(userRef.collection('healthRecords').limit(34).get());
                 await assertFails(userRef.collection('healthRecords').get());
 
-                await assertSucceeds(userRef.collection('healthSampleChunks').limit(501).get());
-                await assertFails(userRef.collection('healthSampleChunks').limit(502).get());
+                await assertSucceeds(userRef.collection('healthSampleChunks').limit(9).get());
+                await assertFails(userRef.collection('healthSampleChunks').limit(10).get());
                 await assertFails(userRef.collection('healthSampleChunks').get());
 
                 await assertSucceeds(userRef.collection('healthSyncState').limit(6).get());


### PR DESCRIPTION
## Summary

- add the shared, provider-neutral health metric catalog and normalized observation contracts
- add validated, idempotent Firestore writers plus bounded direct and callable query paths
- add source-aware coverage, freshness, conflict, pagination, Rules, indexes, and deletion lifecycle handling
- document the architecture, provider workflow, sleep linkage, and user-data deletion behavior

## Verification

- full frontend test suite: 5,250 tests passed
- full Functions test suite passed
- Firestore Rules/emulator suite: 150 tests passed
- Angular and Functions builds passed
- root and Functions lint passed with existing warnings only
- diff, JSON, and credential checks passed

Closes #610