### PR TITLE
refactor: stop writing legacy health metric scalars

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -980,8 +980,8 @@ resting sleep heart rate; average and overnight HRV plus HRV sample count; maxim
 The field masks also read only the exact internal Sports Lib 20.3 aggregate slots needed by each projection. The loader
 strictly rehydrates their allowlisted scalar classes and projects the same legacy-safe response fields; the envelope,
 Sports Lib canonical type keys, and unified Health source records never enter MCP output. Legacy-only and migrated
-sessions therefore produce the
-same structured content. Negative fixtures cover both formats and prove the storage envelope cannot leak. No tool,
+sessions therefore produce the same structured content as new Sports-Lib-only writes. Negative fixtures cover both
+formats and prove the storage envelope cannot leak. No tool,
 registered output schema, scope, plugin instruction, or starter prompt changes, so this storage transition causes no
 additional registered ChatGPT app rescan or local plugin sync.
 

--- a/docs/sleep-sync-operations.md
+++ b/docs/sleep-sync-operations.md
@@ -35,11 +35,12 @@ The reference validator requires the stable health metric ID to match the refere
 Provider disconnect retains both normalized Sleep sessions and imported unified health history.
 Account deletion recursively removes both because they remain below `users/{uid}`.
 
-Sports Lib 20.3 is the canonical scalar JSON boundary for normalized Health values and Sleep aggregates. New server
-writes persist its versioned `toJSON()` envelope alongside the current legacy scalar fields, while Dashboard, Health,
-Training, derived-metric, and MCP readers strictly rehydrate it through the matching `fromJSON()` class and continue to
-accept legacy-only documents. Session structure, timestamps, stages, samples, provenance, and provider fields remain in
-the existing Sleep model. This storage transition changes no provider polling, OAuth, callback, or disconnect behavior.
+Sports Lib 20.3 is the canonical scalar JSON boundary for normalized Health values and Sleep aggregates. After the
+guarded migration and zero-candidate production dry run, new server writes persist its versioned `toJSON()` envelope
+without a second legacy canonical scalar copy. Dashboard, Health, Training, derived-metric, and MCP readers strictly
+rehydrate it through the matching `fromJSON()` class and continue to accept legacy-only documents. Session structure,
+timestamps, stages, samples, provenance, provider-native values, non-scalar score metadata, and provider fields remain
+in their existing models. This storage transition changes no provider polling, OAuth, callback, or disconnect behavior.
 
 Suunto Activity, daily-statistics, and Recovery values are separate Health source records. They do not
 modify `sleepSessions`, workout events, FIT activity metrics, readiness, Training, or MCP output. Signed
@@ -344,6 +345,11 @@ the returned checkpoint after resolving the cause. Checkpoint resolution complet
 checkpoint user root was deleted between cohorts, restart without `--start-after` and let the idempotent postchecks
 advance through already-current users again. Start with 5 users, review logs and the derived-metrics queues, then increase
 to 25 before processing the remainder.
+
+After the global execution and a complete zero-candidate dry run, deploy the legacy-write cleanup separately. It removes
+duplicate Health `canonical` values and normalized Sleep aggregate paths from new or changed documents while preserving
+the Sports Lib envelope and every non-scalar/source field. Keep dual readers in place through the observation window;
+reader removal is not part of the writer cleanup and requires another reviewed release.
 
 ## Temporarily Disable A Provider
 

--- a/docs/unified-health-data.md
+++ b/docs/unified-health-data.md
@@ -166,11 +166,16 @@ Readers accept legacy scalar-only documents and the versioned representation. Wh
 require the exact envelope version, allowlisted semantic key, canonical Sports Lib type key, one finite scalar, matching
 value type, and an exact `fromJSON()`/`toJSON()` round trip. Unknown, alias, additional, ambiguous, non-finite, or
 legacy-conflicting values fail closed. Successful reads consume and remove the internal envelope before projecting the
-existing domain/result shape. New writers derive the envelope server-side after provider validation; adapters cannot
-supply or override it.
+existing domain/result shape. After the guarded production migration reached a zero-candidate dry run, new writers use
+the Sports Lib envelope as the only persisted canonical scalar copy. Health retains provider-native values and goal
+metadata but omits duplicate `canonical` values; Sleep retains session structure, stages, samples, provenance, and
+non-scalar score metadata but removes the duplicate aggregate paths on changed documents. Adapters cannot supply or
+override the server-derived envelope. Legacy scalar readers remain available for rollback and untouched historical
+documents during the observation window.
 
-Legacy canonical fields remain beside the new representation during the rollback window. Quantified Self still owns
-timestamps, provider/source attribution, opaque account identity, revisions, quality, coverage, conflicts, stages,
+Existing legacy canonical fields may remain beside the new representation on untouched documents during the rollback
+window; new and changed documents do not create another copy. Quantified Self still owns timestamps, provider/source
+attribution, opaque account identity, revisions, quality, coverage, conflicts, stages,
 bounded sample series, and raw provider fields. Sports Lib JSON never wraps a complete source record or Sleep session,
 and no JSON object is added per sample point. Native-only and non-comparable values remain outside this canonical scalar
 boundary.
@@ -343,8 +348,9 @@ Every execution transaction re-reads the document and account-deletion guard, up
 `sportsLibData` for Sleep, and is idempotent. An opaque document ID returned as `nextStartAfter` resumes the next page.
 After execution, repeat the dry run and require zero candidates and zero invalid documents before beginning the
 observation window. The `sleepSessions.sportsLibData` map is excluded from automatic indexing; Health already disables
-automatic indexing for the whole source-record document. A later reviewed cleanup must stop legacy writes first and
-remove legacy reads only after migration and rollback verification.
+automatic indexing for the whole source-record document. Once that verification passes, the reviewed writer cleanup
+stops persisting duplicate canonical scalars while retaining legacy readers. Removing those readers remains a separate
+later change after the observation and rollback window.
 
 Useful local verification:
 

--- a/functions/src/health/sports-lib-data-migration.spec.ts
+++ b/functions/src/health/sports-lib-data-migration.spec.ts
@@ -189,6 +189,20 @@ describe('Health and sleep Sports Lib data migration', () => {
         expect(buildHealthSportsLibDataMigrationDecision(first.update)).toEqual({ status: 'unchanged' });
     });
 
+    it('keeps Sports-Lib-only Health metrics unchanged after legacy-write cleanup', () => {
+        const first = buildHealthSportsLibDataMigrationDecision(healthDocument());
+        if (first.status !== 'update') throw new Error('Expected a Health migration update.');
+        const metrics = first.update.metrics as Array<Record<string, unknown>>;
+        const sportsLibOnly = metrics.map(metric => {
+            const copy = { ...metric };
+            delete copy.canonical;
+            return copy;
+        });
+
+        expect(buildHealthSportsLibDataMigrationDecision({ metrics: sportsLibOnly }))
+            .toEqual({ status: 'unchanged' });
+    });
+
     it('treats a valid series-only Health record with no scalar metrics as unchanged', () => {
         expect(buildHealthSportsLibDataMigrationDecision({ metrics: [] })).toEqual({ status: 'unchanged' });
     });

--- a/functions/src/health/sports-lib-data-migration.ts
+++ b/functions/src/health/sports-lib-data-migration.ts
@@ -190,7 +190,16 @@ export function buildHealthSportsLibDataMigrationDecision(value: unknown): Sport
     try {
         const decoded = metrics.map(metric => decodeHealthMetricSportsLibData(metric as HealthMetricEntry));
         const encoded = decoded.map(encodeHealthMetricSportsLibData);
-        if (stableValueKey(metrics) === stableValueKey(encoded)) return { status: 'unchanged' };
+        const storedSportsLibData = metrics.map(metric => asRecord(metric).sportsLibData);
+        const canonicalSportsLibData = encoded.map(metric => (
+            metric.kind === 'value' ? metric.sportsLibData : undefined
+        ));
+        // The migration remains safe to re-run after the writer cleanup has
+        // removed duplicate canonical scalars. Only the derived Sports Lib
+        // envelope determines whether a record still needs migration.
+        if (stableValueKey(storedSportsLibData) === stableValueKey(canonicalSportsLibData)) {
+            return { status: 'unchanged' };
+        }
         return { status: 'update', update: { metrics: encoded } };
     } catch (error) {
         if (error instanceof SportsLibDataValidationError) return { status: 'invalid' };

--- a/functions/src/health/writer.spec.ts
+++ b/functions/src/health/writer.spec.ts
@@ -184,6 +184,7 @@ describe('health writer', () => {
                 metrics: { value: { Steps: 100 } },
             },
         });
+        expect(built.sourceRecord.metrics[0]).not.toHaveProperty('canonical');
         expect(JSON.stringify(built)).not.toContain('secret-provider-account');
         expect(built.sourceRecord.source.accountKey).toMatch(/^[a-f0-9]{64}$/);
     });
@@ -199,14 +200,35 @@ describe('health writer', () => {
         const baseline = await buildHealthSourceRecordWrite('user-1', validInput(), 10_000, fakeId);
 
         expect(built.sourceRecord.metrics[0]).toMatchObject({
-            canonical: { value: 100, unit: HEALTH_UNITS.Count },
             sportsLibData: {
                 schemaVersion: 1,
                 metrics: { value: { Steps: 100 } },
             },
         });
+        expect(built.sourceRecord.metrics[0]).not.toHaveProperty('canonical');
         expect(JSON.stringify(built.sourceRecord)).not.toContain('999999');
         expect(built.sourceRecord.source.revision).toEqual(baseline.sourceRecord.source.revision);
+    });
+
+    it('retains native goal metadata without persisting a duplicate canonical goal scalar', async () => {
+        const input = validInput();
+        (input.metrics as Array<Record<string, unknown>>)[0].goal = {
+            native: { metric: 'goalSteps', value: 10_000, unit: 'count' },
+            canonical: { value: 10_000, unit: HEALTH_UNITS.Count },
+        };
+
+        const built = await buildHealthSourceRecordWrite('user-1', input, 10_000, fakeId);
+
+        expect(built.sourceRecord.metrics[0]).toMatchObject({
+            goal: {
+                native: { metric: 'goalSteps', value: 10_000, unit: 'count' },
+            },
+            sportsLibData: {
+                schemaVersion: 1,
+                metrics: { goal: { Steps: 10_000 } },
+            },
+        });
+        expect(built.sourceRecord.metrics[0]).not.toHaveProperty('goal.canonical');
     });
 
     it('persists an opaque source key when an adapter key contains the raw provider account ID', async () => {

--- a/functions/src/health/writer.ts
+++ b/functions/src/health/writer.ts
@@ -12,6 +12,7 @@ import {
     HEALTH_SCHEMA_VERSION,
     HEALTH_SYNC_STATE_COLLECTION_ID,
     HEALTH_SYNC_STATUSES,
+    HealthMetricEntry,
     HealthProvider,
     HealthSampleChunk,
     HealthSourceRecord,
@@ -127,6 +128,20 @@ export interface BuiltHealthSourceRecordWrite {
 
 function cleanUndefined<T>(value: T): T {
     return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function encodeHealthMetricFirestoreData(entry: HealthMetricEntry): HealthMetricEntry {
+    const encoded = encodeHealthMetricSportsLibData(entry);
+    if (encoded.kind !== 'value' || !encoded.sportsLibData) return encoded;
+
+    const payload: HealthMetricEntry = { ...encoded };
+    delete payload.canonical;
+    if (payload.goal) {
+        const goal = { ...payload.goal };
+        delete goal.canonical;
+        payload.goal = Object.keys(goal).length > 0 ? goal : undefined;
+    }
+    return cleanUndefined(payload);
 }
 
 function stableComparableValue(value: unknown): unknown {
@@ -374,7 +389,7 @@ export async function buildHealthSourceRecordWrite(
         startTimeMs: input.startTimeMs,
         endTimeMs: input.endTimeMs,
         timezoneOffsetSeconds: input.timezoneOffsetSeconds,
-        metrics: input.metrics.map(encodeHealthMetricSportsLibData),
+        metrics: input.metrics.map(encodeHealthMetricFirestoreData),
         metricIds,
         coverage: input.coverage,
         device: input.device,

--- a/functions/src/scripts/migrate-coros-sleep-to-health.ts
+++ b/functions/src/scripts/migrate-coros-sleep-to-health.ts
@@ -6,6 +6,10 @@ import {
     type HealthMetricEntry,
 } from '../../../shared/health';
 import { SLEEP_PROVIDERS, SLEEP_SESSIONS_COLLECTION_ID } from '../../../shared/sleep';
+import {
+    decodeHealthMetricSportsLibData,
+    SportsLibDataValidationError,
+} from '../../../shared/sports-lib-health-data';
 import { COROSDailyHealthResult, mapCOROSDailyHealth } from '../coros/daily-health';
 import { COROS_DAILY_MAX_HRV_POINTS } from '../coros/constants';
 import {
@@ -165,10 +169,19 @@ function supersedingMetricsMatch(
             return stableValueKey(existingMetric) === stableValueKey(candidateMetric);
         }
         if (candidateMetric.kind !== 'value' || existingMetric.kind !== 'value') return false;
+        let decodedExistingMetric: HealthMetricEntry;
+        try {
+            decodedExistingMetric = decodeHealthMetricSportsLibData(
+                existingMetric as unknown as HealthMetricEntry,
+            );
+        } catch (error) {
+            if (error instanceof SportsLibDataValidationError) return false;
+            throw error;
+        }
         // A newly fetched daily record supersedes the stale scalar retained in
         // Sleep. Only the provider value may differ; its metric semantics and
         // units must remain identical.
-        return stableValueKey(providerValueMetricDefinition(existingMetric))
+        return stableValueKey(providerValueMetricDefinition(decodedExistingMetric))
             === stableValueKey(providerValueMetricDefinition(candidateMetric));
     });
 }

--- a/functions/src/sleep/writer.spec.ts
+++ b/functions/src/sleep/writer.spec.ts
@@ -245,8 +245,11 @@ describe('sleep writer', () => {
 
         expect(result).toEqual({ written: 1, skipped: 0 });
         expect(hoisted.docSet).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
-            durationSeconds: 33300,
-            inBedDurationSeconds: 34260,
+            durationSeconds: hoisted.deleteField,
+            inBedDurationSeconds: hoisted.deleteField,
+            stageDurationsSeconds: hoisted.deleteField,
+            score: hoisted.deleteField,
+            vitals: hoisted.deleteField,
             isNap: false,
             sportsLibData: {
                 schemaVersion: 1,
@@ -304,11 +307,40 @@ describe('sleep writer', () => {
         const writePayload = hoisted.docSet.mock.calls[0][1] as Record<string, unknown>;
         const sportsLibData = writePayload.sportsLibData as Record<string, unknown>;
         const metrics = sportsLibData.metrics as Record<string, unknown>;
+        expect(writePayload.durationSeconds).toBe(hoisted.deleteField);
+        expect(writePayload.inBedDurationSeconds).toBe(hoisted.deleteField);
+        expect(writePayload.stageDurationsSeconds).toBe(hoisted.deleteField);
+        expect(writePayload.score).toBe(hoisted.deleteField);
+        expect(writePayload.vitals).toBe(hoisted.deleteField);
         expect(metrics.inBedDuration).toBe(hoisted.deleteField);
         expect(metrics.score).toBe(hoisted.deleteField);
         expect(metrics.averageHrv).toBe(hoisted.deleteField);
         expect(metrics).not.toHaveProperty('overnightHrv');
         expect(hoisted.docSet).toHaveBeenCalledWith(expect.any(Object), writePayload, { merge: true });
+    });
+
+    it('keeps non-scalar score metadata while removing duplicate aggregate storage', async () => {
+        const result = await upsertSleepSession('user-1', buildMapperResult({
+            score: { value: 88, qualifier: 'good', components: { recovery: 90 } },
+            vitals: { averageHrvMs: 61, averageHeartRateBpm: 54 },
+        }), 3000);
+
+        expect(result.written).toBe(true);
+        const writePayload = hoisted.docSet.mock.calls[0][1] as Record<string, unknown>;
+        expect(writePayload.score).toEqual({
+            value: hoisted.deleteField,
+            qualifier: 'good',
+            components: { recovery: 90 },
+        });
+        expect(writePayload.vitals).toBe(hoisted.deleteField);
+        expect(writePayload.sportsLibData).toEqual({
+            schemaVersion: 1,
+            metrics: expect.objectContaining({
+                score: { 'Sleep Score': 88 },
+                averageHrv: { 'Average Sleep HRV': 61 },
+                averageHeartRate: { 'Average Sleep Heart Rate': 54 },
+            }),
+        });
     });
 
     it('skips unchanged duplicate Garmin sessions even when callback metadata differs', async () => {
@@ -367,7 +399,7 @@ describe('sleep writer', () => {
 
         expect(result).toEqual({ written: 1, skipped: 0 });
         expect(hoisted.docSet).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
-            durationSeconds: 33420,
+            durationSeconds: hoisted.deleteField,
             createdAtMs: 1000,
             updatedAtMs: 3000,
         }), { merge: true });

--- a/functions/src/sleep/writer.spec.ts
+++ b/functions/src/sleep/writer.spec.ts
@@ -248,7 +248,7 @@ describe('sleep writer', () => {
             durationSeconds: hoisted.deleteField,
             inBedDurationSeconds: hoisted.deleteField,
             stageDurationsSeconds: hoisted.deleteField,
-            score: hoisted.deleteField,
+            score: { value: hoisted.deleteField },
             vitals: hoisted.deleteField,
             isNap: false,
             sportsLibData: {
@@ -341,6 +341,23 @@ describe('sleep writer', () => {
                 averageHeartRate: { 'Average Sleep Heart Rate': 54 },
             }),
         });
+    });
+
+    it('preserves existing score metadata when a partial update omits the score', async () => {
+        hoisted.docGet.mockResolvedValue({
+            exists: true,
+            data: () => encodeSleepSessionSportsLibData(buildExistingSuuntoSession({
+                score: { value: 88, qualifier: 'good', components: { recovery: 90 } },
+            })),
+        });
+
+        const result = await upsertSleepSession('user-1', buildMapperResult({
+            durationSeconds: 33_420,
+        }), 3000);
+
+        expect(result.written).toBe(true);
+        const writePayload = hoisted.docSet.mock.calls[0][1] as Record<string, unknown>;
+        expect(writePayload.score).toEqual({ value: hoisted.deleteField });
     });
 
     it('skips unchanged duplicate Garmin sessions even when callback metadata differs', async () => {

--- a/functions/src/sleep/writer.ts
+++ b/functions/src/sleep/writer.ts
@@ -117,6 +117,23 @@ function sleepSessionFirestoreWritePayload(session: SleepSession): Record<string
             metrics[field] = FieldValue.delete();
         }
     }
+
+    // Sports Lib JSON is now the only persisted copy of normalized Sleep
+    // scalars. Delete legacy aggregate paths on merge writes while retaining
+    // non-scalar score metadata and the rest of the session envelope.
+    payload.durationSeconds = FieldValue.delete();
+    payload.inBedDurationSeconds = FieldValue.delete();
+    payload.stageDurationsSeconds = FieldValue.delete();
+    const score = payload.score;
+    if (score && typeof score === 'object' && !Array.isArray(score)) {
+        payload.score = {
+            ...score as Record<string, unknown>,
+            value: FieldValue.delete(),
+        };
+    } else {
+        payload.score = FieldValue.delete();
+    }
+    payload.vitals = FieldValue.delete();
     return payload;
 }
 

--- a/functions/src/sleep/writer.ts
+++ b/functions/src/sleep/writer.ts
@@ -125,13 +125,17 @@ function sleepSessionFirestoreWritePayload(session: SleepSession): Record<string
     payload.inBedDurationSeconds = FieldValue.delete();
     payload.stageDurationsSeconds = FieldValue.delete();
     const score = payload.score;
-    if (score && typeof score === 'object' && !Array.isArray(score)) {
+    if (session.score === null) {
+        payload.score = FieldValue.delete();
+    } else if (score && typeof score === 'object' && !Array.isArray(score)) {
         payload.score = {
             ...score as Record<string, unknown>,
             value: FieldValue.delete(),
         };
     } else {
-        payload.score = FieldValue.delete();
+        // Undefined mapper fields retain existing merge-owned metadata while
+        // removing only the duplicated normalized scalar.
+        payload.score = { value: FieldValue.delete() };
     }
     payload.vitals = FieldValue.delete();
     return payload;


### PR DESCRIPTION
## Summary

- persist Sports Lib JSON as the only canonical scalar copy for new or changed Health and Sleep documents
- retain provider-native values, session structure, score metadata, and all legacy readers during the rollback window
- keep the migration and COROS cleanup verifier compatible with canonical-only Health records
- document the post-migration writer-cleanup stage

## Production migration gate

The final read-only global dry run completed on 2026-09-01 across 139 data-bearing users in six cohorts with zero Health candidates, zero Sleep candidates, and zero failures. This is recorded on #634.

## Verification

- `npm --prefix functions test` — 4,166 tests passed
- `npm --prefix functions run build`
- focused frontend Health/Sleep reader tests — 87 tests passed
- `npm run test:rules` — 161 tests passed
- `npm --prefix functions run mcp:contract:check` — compatible; no contract change from this PR
- `npx tsc --noEmit -p src/tsconfig.app.json`
- `git diff --check`

Part of #634.