### PR TITLE
feat: add manual training planning foundation

### DIFF
--- a/docs/activity-calendar.md
+++ b/docs/activity-calendar.md
@@ -9,7 +9,8 @@ This document is the implementation and maintenance guide for the Activity Calen
 - The authenticated `/calendar` route provides Week, Month, and Year views, period navigation, totals, activity-group bars, and day details.
 - Private [Timeline notes](timeline-notes.md) mark their dates in all three full-calendar views, including note-only days.
   The shared header manager and **Show on charts and calendar** preference apply; dashboard tiles/popovers stay unchanged.
-- Selecting an active day opens an Angular Material bottom sheet with day totals, the shared activity-group duration bars and available distance/ascent/descent totals, plus recorded distance/ascent/descent for each individual activity, and links to individual events.
+- Every rendered date is selectable. Its Angular Material bottom sheet keeps planned workouts separate from completed activity totals and rows, provides active-plan/standalone creation actions, and links to a planned-workout editor or individual event as appropriate.
+- Standalone workouts and workouts from the active plan appear on the full Calendar, dashboard tile, and Dashboard Today mini-calendar. Inactive-plan workouts remain in `/plans`; skipped workouts remain visible with a distinct marker.
 - The public `/features/activity-calendar` route explains the feature without reading or exposing user activity data.
 
 ## Query and state model
@@ -31,6 +32,11 @@ Dashboard migration state uses the shared automatic-tile framework:
 
 `src/app/services/activity-calendar.service.ts` reads lightweight event summary documents by `startDate`. It excludes merge and benchmark documents, maps only calendar-required fields into `EventInterface` values, and sorts results by start time. Exact user and query-window results are cached for five minutes with at most 12 entries; a cached value is emitted immediately while the live listener supplies current data.
 
+`TrainingPlansService.watchSchedule()` independently reads the owner-visible current plan, workout, and state documents.
+`planned-workout-calendar.helper.ts` projects only standalone workouts and workouts belonging to the active plan into a
+local-date map. The activity and planning listeners stay separate so a plan read failure cannot turn recorded activity
+data into an empty result, and a planned workout can never become an `EventInterface` or enter activity summaries.
+
 ## Day markers
 
 Activities are grouped with the shared Sports Lib activity-type groups and app colors. Events containing more than one group are represented as Multisport.
@@ -41,7 +47,8 @@ Activities are grouped with the shared Sports Lib activity-type groups and app c
 - Standard markers range from 8 to 30 px. Compact concentric markers range from 4 to 18 px and preserve at least a 14 percent size difference between visible layers.
 - At most three groups are drawn in a day cell; an overflow count represents additional groups.
 - Week and Month layouts separate markers when space allows. Compact tiles, narrow layouts, and Year view use concentric markers.
-- Date cells do not use Material tooltips. This preserves native touch scrolling; their accessible names contain the date, activity count, duration, and group summary.
+- Planned and skipped-workout icons are independent from the duration-scaled activity markers. Their count does not change marker size or overflow.
+- Date cells do not use Material tooltips. This preserves native touch scrolling; their accessible names contain the date, activity, planned-workout, and visible note counts, duration, and group summary.
 - Note days add an `event_note` indicator and accessible note count, separate from activity circles. Their day sheet lists
   note titles, categories, and actual dates above activities; selecting a note opens the shared editor. Inclusive periods,
   future bounded dates, and ongoing periods through today in their captured zone are supported without changing totals.
@@ -58,6 +65,7 @@ The top summary shows distance, duration, and ascent for the selected primary pe
 
 - Duration is the bar metric. Positive recorded duration, distance, ascent, and descent values appear beneath the bar.
 - The day-details sheet reuses these exact group rows for the selected local day; its bars compare only that day's activity groups.
+- Planned workouts never contribute to distance, duration, ascent, descent, activity counts, group bars, or the activity table. Day details render them in a separate **Planned workouts** section.
 - Missing values remain unavailable rather than being inferred. A group without recorded duration uses `--` and has no progressbar semantics.
 - `AppEventUtilities.shouldExcludeAscent` and `shouldExcludeDescent` apply shared sport rules. Lift-served downhill types can contribute descent without contributing ascent; Diving, Scuba Diving, Free Diving, Snorkeling, and Mermaiding contribute neither elevation metric because their vertical movement is depth.
 - User `removeAscentForEventTypes` and `removeDescentForEventTypes` summary settings are applied in addition to the shared sport rules.
@@ -72,7 +80,7 @@ Keep these interaction contracts:
 - Previous and next controls have period-specific accessible labels.
 - The period label announces navigation changes.
 - Loading occupies a stable progress slot so cached and live emissions do not move the page.
-- Days with activities or visible notes are buttons; entirely empty days are non-interactive cells.
+- Every rendered date is a button, including dates with neither a planned workout nor a completed activity. Empty dates open creation choices.
 - Activity bars expose progressbar semantics only when recorded duration exists.
 - Start-of-week and weekend treatment must follow the user's settings and shared theme tokens.
 
@@ -80,6 +88,7 @@ Keep these interaction contracts:
 
 - `/features/activity-calendar` is a prerendered public page included in the sitemap and public startup-route allowlist.
 - `/calendar` requires authentication, uses `noindex, follow`, is excluded from the sitemap, and is disallowed in `robots.txt`.
+- `/plans` has the same authenticated, client-rendered, `noindex` and sitemap/robots treatment. It is not a public product page.
 - Public page metadata and structured data describe the feature only. They must never include activity values, account identifiers, or examples derived from a user's calendar.
 
 ## Test map
@@ -88,6 +97,7 @@ Keep these interaction contracts:
 - `src/app/services/activity-calendar.service.spec.ts`: summary queries, filtering, mapping, sorting, and cache behavior.
 - `src/app/helpers/dashboard-auto-tile.helper.spec.ts` and `src/app/services/dashboard-auto-tile.service.spec.ts`: Calendar identity, one-time dashboard migration, duplicate prevention, dismissal, Undo, and rollback behavior.
 - `src/app/components/calendar/**.spec.ts`: page, grid, tile, day details, responsive behavior, and Material interaction contracts.
+- `src/app/helpers/planned-workout-calendar.helper.spec.ts` and `src/app/services/training-plans.service.spec.ts`: active-plan/standalone overlay selection, inactive-plan exclusion, skipped visibility, and owner-current schedule reads.
 - `src/app/components/public-seo/public-seo-pages.content.spec.ts`: public page metadata, links, and structured data.
 - `src/app/app.routing.module.spec.ts`, `src/app/app.routes.server.spec.ts`, and `src/app/shared/public-startup-route.spec.ts`: public and authenticated route contracts.
 - `src/firebase-hosting.config.spec.ts`: sitemap, robots, and hosting behavior.

--- a/docs/coros-integration.md
+++ b/docs/coros-integration.md
@@ -148,6 +148,21 @@ The provider route ID is a deterministic digest of the Quantified Self user, act
 
 HTTP 408, 429, 5xx, and transient transport failures are retryable. Authentication failures require reconnect, and HTTP 403 or provider code `30009` is a permission-required failure. Invalid parameters, missing required distance, invalid provider responses, and rejected content are terminal and sanitized before reaching the browser or DLQ.
 
+## Training-planning proof boundary
+
+The ignored local COROS API Reference V2.0.6 (February 2026) is available for development but is never committed. The
+versioned capability matrix and pure serializer under `functions/src/training-plans/providers/` produce a redacted,
+dated Run/Bike Training Plan fixture with deterministic opaque partner workout IDs. The mapping covers fixed repeats,
+time/distance/manual steps, absolute targets, and native FTP, threshold-heart-rate, and threshold-speed percentage
+targets while retaining their canonical reference snapshots.
+
+All COROS planned-workout delivery remains disabled. A second target, recovery-to-rest mapping, fractional lengths or
+percentages, maximum-heart-rate/critical-power/relative-cadence freezing, and other lossy mappings require explicit
+approval; cycling cadence is unsupported by the current contract. Training Plan entitlement, repeated-ID replacement,
+overlapping-window behavior, sandbox CRUD/idempotency, and production certification remain in issues #645 and #648.
+The existing inbound `planWorkoutId` preservation is only a correlation prerequisite; completion reconciliation remains
+tracked separately in issue #651. This proof does not authorize a provider call or deployment.
+
 ## Security and lifecycle controls
 
 - Access/refresh tokens remain in the existing `COROSAPIAccessTokens` tree. The production projection backfill completed and converged in September 2026. The frontend reads the bounded owner-readable connection-account projection exclusively, containing the account identity and connection time needed by existing connection and route UX; an explicit empty projection remains authoritative. OAuth exchange, refresh, disconnect, and projection writes use the Admin SDK. Firestore Rules deny every browser read and write against the COROS token root and descendants. The delivery callables and workers do not return credentials; their browser responses contain only bounded upload/status identifiers and messages.

--- a/docs/garmin-integration.md
+++ b/docs/garmin-integration.md
@@ -67,6 +67,21 @@ Health minimum-start clipping independently adds up to 30 seconds of headroom af
 
 Sleep and Health share the existing 30-day Garmin history cooldown, but their ranges are independent: a provider-discovered Sleep minimum does not shorten another Health family's range. The callable reports `sleepQueued` and `healthQueued` separately while retaining `queued` as the number of Sleep date-range requests. Garmin Summary Resender remains an operational recovery option for a deliberately bounded family/range after live delivery is healthy; it is not the normal user history flow, and no local credential migration script is required.
 
+## Training-planning proof boundary
+
+The ignored local Garmin Training API V2 version 1.0 partner contract is available for development, but it is never
+committed. `shared/planned-workout-providers.ts` and the pure serializer under
+`functions/src/training-plans/providers/` record a redacted Running/Cycling fixture for the portable v1 workout model.
+Workout content and date-only Workout Schedule payloads are deliberately separate because Garmin assigns and manages
+their lifecycles independently. The proof covers fixed repeats, time/distance/manual steps, and absolute
+heart-rate/power/speed/pace/cadence ranges.
+
+All Garmin planned-workout delivery remains disabled. Relative targets require explicit degradation approval because
+the provider percentage fields do not transmit Quantified Self's stored reference snapshot. Secondary targets are
+rejected outside cycling and remain device-dependent for cycling. Evaluation credentials, representative device access,
+create/update/reschedule/delete/duplicate evidence, reconnect behavior, production review, and completed-activity
+correlation remain in issues #645 and #647. This proof does not authorize a provider call or deployment.
+
 ## Production configuration
 
 No new secret is required. The existing Garmin OAuth client credentials authorize callback pulls.

--- a/docs/provider-integration-guide.md
+++ b/docs/provider-integration-guide.md
@@ -45,6 +45,44 @@ Garmin Sleep and Health history recovery must account for a moving provider mini
 
 Garmin stress-validation diagnostics use the existing WARNING with allowlisted family/field/reason, summary index, type, and bounded numeric-only values; never log raw provider strings or objects. Stress sample zeroes are numeric readings; daily average -2 is retained as a native-only availability code because its daily semantics are undocumented. Do not transfer sentinel meanings between summary families or let a recognized non-measurement code discard unrelated valid metrics. A fix does not recover an existing DLQ callback whose pull credentials were removed; use bounded Summary Resender recovery and verify replacement ingestion. See [Garmin delivery diagnostics](garmin-integration.md#delivery-and-trust-boundary) for the exact bound and metadata contract.
 
+### Structured-workout delivery proof (not production support)
+
+Training planning uses a stricter launch boundary than activity or route delivery. Manual plan and standalone-workout
+authoring is free and independent of connected services. Any future provider synchronization is Pro, explicit, and
+directional: a plan needs per-provider opt-in, while a standalone workout needs a user-selected Send action. A provider
+connection alone never opts workouts into delivery.
+
+The versioned research snapshot lives in `shared/planned-workout-providers.ts`; pure fixture serializers live under
+`functions/src/training-plans/providers/`. Every provider delivery flag is currently `false`:
+
+| Provider | Proof state | Truthful model and current gate |
+| --- | --- | --- |
+| Garmin | `blocked-contract` | Garmin documents separate workout and calendar concepts, but the current private Training API contract, limits, update/delete rules, completion markers, and sandbox access are not in this repository. Keep `WORKOUT_IMPORT` scoped to issue #647 and do not guess endpoints or payloads. |
+| COROS | `blocked-contract` | The available partner reference describes dated training-plan batches of at most 30 workouts, a today-through-one-year horizon, stable `planWorkoutId` values, eligible deletion, and completion correlation. Entitlement, repeat-ID replacement, overlapping-window behavior, and sandbox CRUD still require provider confirmation. |
+| Wahoo | `fixture-only` | Public `plan.json` 1.0.0 maps Running/Cycling steps, time/distance/kJ endings, repeats, absolute targets, and supported relative targets. Delivery is a separate app-owned Plan plus dated Workout lifecycle requiring `plans_read`, `plans_write`, `workouts_read`, and `workouts_write`. The device-visible horizon, same-app ownership, and date-only `starts`/`day_code` behavior need sandbox proof. |
+| Suunto | `fixture-only` | A scheduled workout maps to one dated SuuntoPlus Guide, not a native training-plan calendar. Time, distance, manual transition, repeats, and absolute HR/power/speed/pace/cadence targets map to Guide JSON; cadence converts from rpm to hertz. Guide entitlement, ZIP/icon transport, watch storage/pinning, supported-device behavior, CRUD, and FIT correlation need sandbox proof. |
+
+Wahoo mapping follows the official [Cloud API](https://cloud-api.wahooligan.com/) and
+[plan.json 1.0.0 format](https://cloud-api.wahooligan.com/docs/plan-json-format.pdf). Canonical repeat count is total
+passes, while Wahoo's repeat trigger counts passes after the first, so the serializer writes `count - 1`. Wahoo stores
+relative FTP, maximum-HR, threshold-HR, and threshold-speed references in the header. Conflicting snapshots, critical
+power, relative cadence, generic `other` purpose, and multiple targets where ELEMNT uses only the first are explicit
+degradations; unsupported endings fail.
+
+Suunto mapping follows the official [Guide API workflow](https://apizone.suunto.com/how-to-use-suuntoplus-guides-api),
+[Guide JSON reference](https://apizone.suunto.com/suuntoplus-guide-description), and
+[FIT correlation description](https://apizone.suunto.com/fit-description). Guide `externalId` values are deterministic,
+opaque, and at most 64 characters. Relative targets are frozen from the canonical reference snapshot only after explicit
+degradation approval. Text and metadata limits are never truncated silently. The serializer produces `guide.json`
+fixtures only; it must not be described as a completed Guide upload adapter because the API requires a ZIP containing
+that JSON and a valid 300 x 300 PNG.
+
+Fixture compatibility is not delivery readiness. Before any adapter flag changes, record sandbox evidence for create,
+update, reschedule, delete, exact duplicate, ambiguous retry, reconnect, and provider-specific horizon behavior. The
+shared delivery ledger, reconciliation queue, entitlement, disconnect/deletion behavior, provider certification,
+observability, and kill switches are tracked under epic #583. Do not hide an unmet gate in a code comment or silently
+narrow the epic acceptance criteria.
+
 ## 2. Choose the right architecture
 
 Most activity providers should use the shared asynchronous ingestion pattern:

--- a/docs/provider-integration-guide.md
+++ b/docs/provider-integration-guide.md
@@ -57,23 +57,45 @@ The versioned research snapshot lives in `shared/planned-workout-providers.ts`; 
 
 | Provider | Proof state | Truthful model and current gate |
 | --- | --- | --- |
-| Garmin | `blocked-contract` | Garmin documents separate workout and calendar concepts, but the current private Training API contract, limits, update/delete rules, completion markers, and sandbox access are not in this repository. Keep `WORKOUT_IMPORT` scoped to issue #647 and do not guess endpoints or payloads. |
-| COROS | `blocked-contract` | The available partner reference describes dated training-plan batches of at most 30 workouts, a today-through-one-year horizon, stable `planWorkoutId` values, eligible deletion, and completion correlation. Entitlement, repeat-ID replacement, overlapping-window behavior, and sandbox CRUD still require provider confirmation. |
+| Garmin | `fixture-only` | The local ignored Training API V2 partner contract proves separate Workout and Workout Schedule CRUD, `WORKOUT_IMPORT`, 100-step single-sport limits, and primary/secondary target fields. Redacted Running/Cycling fixtures cover time/distance/manual steps and repeats. Evaluation credentials, device coverage, completion correlation, and sandbox CRUD remain unproven. |
+| COROS | `fixture-only` | The local ignored February 2026 partner reference proves dated batches of at most 30 workouts, a today-through-one-year horizon, structured Run/Bike steps, stable partner workout IDs, eligible deletion, and `planWorkoutId` completion correlation. Entitlement, repeat-ID replacement, overlapping-window behavior, and sandbox CRUD still require provider confirmation. |
 | Wahoo | `fixture-only` | Public `plan.json` 1.0.0 maps Running/Cycling steps, time/distance/kJ endings, repeats, absolute targets, and supported relative targets. Delivery is a separate app-owned Plan plus dated Workout lifecycle requiring `plans_read`, `plans_write`, `workouts_read`, and `workouts_write`. The device-visible horizon, same-app ownership, and date-only `starts`/`day_code` behavior need sandbox proof. |
 | Suunto | `fixture-only` | A scheduled workout maps to one dated SuuntoPlus Guide, not a native training-plan calendar. Time, distance, manual transition, repeats, and absolute HR/power/speed/pace/cadence targets map to Guide JSON; cadence converts from rpm to hertz. Guide entitlement, ZIP/icon transport, watch storage/pinning, supported-device behavior, CRUD, and FIT correlation need sandbox proof. |
+
+Garmin mapping follows the local ignored Training API V2 version 1.0 partner contract; the confidential PDF is evidence,
+not a repository artifact. Workout content and its date-only schedule remain separate artifacts because each has its own
+provider ID and CRUD lifecycle. The fixture mapper supports the portable Running/Cycling baseline, fixed repeats,
+time/distance/manual endings, and absolute HR/power/speed/pace/cadence ranges. Garmin's percentage fields do not carry
+the canonical reference snapshot, so relative targets are frozen to their stored absolute range only after explicit
+degradation approval. Secondary targets are rejected outside cycling, must differ from the primary target, and remain
+an explicit device-support degradation even for cycling. The private contract does not document a completed-activity
+workout identifier.
+
+COROS mapping follows the local ignored COROS API Reference V2.0.6 (February 2026); the confidential PDF is likewise
+kept out of Git. Partner athlete/workout IDs in fixtures are redacted or deterministic opaque safe integers. The mapper
+supports dated Run/Bike time/distance/manual steps and fixed repeats. Native FTP, threshold-HR, and threshold-speed
+percentage targets preserve their canonical reference snapshots. Maximum-HR, critical-power, and relative-cadence
+targets freeze to absolute ranges only after approval. COROS accepts one intensity target per step, exposes no distinct
+recovery intensity, documents cadence targets for running but not cycling, and requires integer lengths and percentages;
+each lossy case is surfaced before serialization.
 
 Wahoo mapping follows the official [Cloud API](https://cloud-api.wahooligan.com/) and
 [plan.json 1.0.0 format](https://cloud-api.wahooligan.com/docs/plan-json-format.pdf). Canonical repeat count is total
 passes, while Wahoo's repeat trigger counts passes after the first, so the serializer writes `count - 1`. Wahoo stores
 relative FTP, maximum-HR, threshold-HR, and threshold-speed references in the header. Conflicting snapshots, critical
 power, relative cadence, generic `other` purpose, and multiple targets where ELEMNT uses only the first are explicit
-degradations; unsupported endings fail.
+degradations. FTP and heart-rate header references are integer fields; a fractional canonical snapshot is rounded only
+after explicit degradation approval. Relative threshold/max-heart-rate and threshold-speed targets are also explicit
+device-support degradations: Wahoo documents them for treadmill workouts in the Wahoo app, not ELEMNT computers or
+RIVAL. Unsupported endings fail.
 
 Suunto mapping follows the official [Guide API workflow](https://apizone.suunto.com/how-to-use-suuntoplus-guides-api),
 [Guide JSON reference](https://apizone.suunto.com/suuntoplus-guide-description), and
 [FIT correlation description](https://apizone.suunto.com/fit-description). Guide `externalId` values are deterministic,
 opaque, and at most 64 characters. Relative targets are frozen from the canonical reference snapshot only after explicit
-degradation approval. Text and metadata limits are never truncated silently. The serializer produces `guide.json`
+degradation approval. Text and metadata limits are never truncated silently, truncation counts Unicode code points, and
+text outside Suunto's guaranteed minimum watch character set requires explicit degradation approval because rendering
+remains device-dependent. The serializer produces `guide.json`
 fixtures only; it must not be described as a completed Guide upload adapter because the API requires a ZIP containing
 that JSON and a valid 300 x 300 PNG.
 

--- a/docs/training-workspace.md
+++ b/docs/training-workspace.md
@@ -208,6 +208,86 @@ overview is the indexable search entry point: it describes the curated workspace
 non-prescriptive treatment of readiness and sleep without exposing account-specific data. Keep that public page, the
 Features hub, homepage link, Help link, sitemap, and `robots.txt` aligned when the Training product contract changes.
 
+## Training Planning
+
+Training planning is a separate authored-workout workflow at authenticated `/plans`; it does not change the analytical
+meaning of `/training`. Manual planning is available without a provider connection. A scheduled workout may belong to a
+plan or remain standalone, so a user can add a workout without creating a plan. Provider delivery is a future Pro action
+and must never be inferred from merely connecting a service.
+
+### Canonical workout boundary
+
+Quantified Self currently owns the versioned planned-workout contract in `shared/planned-workout.ts`. It stores only
+plain canonical primitives: Sports Lib `ActivityTypes` strings, seconds, metres, bpm, watts, metres per second, rpm,
+kilojoules, percentage points, and positive repetition counts. It does not persist Sports Lib class instances or
+event-stat JSON. Sports Lib remains authoritative for activity types, canonical unit semantics, conversions, and scalar
+formatting; Quantified Self owns workout ordering, provider compatibility, scheduling, lifecycle, history, entitlement,
+and localized UI language.
+
+`WorkoutStructureV1` has stable node IDs, ordered steps or one-level repeats, purposes, endings, and typed targets. The
+strict codec rejects unknown fields and discriminants, unsupported versions or sports, duplicate IDs, non-finite or
+negative values, non-positive endings/reference snapshots, inverted ranges, more than 100 nodes, repeat counts above
+100, nested repeats, and more than two targets per step. Its JSON output must remain Firestore-safe and must round-trip through stringify/parse without changing
+the persisted v1 value. The initial manual editor intentionally exposes the smaller Running/Cycling, date-only,
+time/distance, fixed-repeat, single absolute HR/power/pace subset. The shared contract is broader so saved v1 data does
+not need a redesign when later UI slices are enabled.
+
+Do not add planned-workout `Data*` types, `DataStore` entries, FIT parser behavior, or MCP fields merely to share this
+recipe. Extract the neutral structure, codec, validator, and reusable analysis to Sports Lib only after Garmin and COROS
+pass sandbox create/update/reschedule/delete round trips, Wahoo and Suunto fixtures are complete, the provider adapters
+have not contaminated the neutral model, and persisted Quantified Self fixtures round-trip unchanged through a locally
+packed Sports Lib package. That gate is tracked by GitHub issue #654 under epic #583.
+
+### Persistence, mutation, and history
+
+- Owner-visible current state is stored at `users/{uid}/trainingPlanState/current`,
+  `users/{uid}/trainingPlans/{planId}`, and `users/{uid}/scheduledWorkouts/{workoutId}`. Browser writes are denied.
+- Authenticated, App Check-enforced callables own mutations, history reads, restore previews/restores, and plan deletion.
+  Every write path is sanitized, fenced against account deletion, idempotent by `mutationId`, and guarded by expected
+  revisions.
+- Multiple plans are allowed, but at most one is active. Activating one plan atomically pauses the previous active plan.
+  Plans are limited to 366 inclusive local dates and an account to 400 current workouts.
+- Workout IDs survive standalone-to-plan, plan-to-standalone, and plan-to-plan moves. An out-of-range add, move, copy, or
+  attach requires explicit confirmation before the plan range is extended atomically. Shifting a plan moves only its
+  range and associated current workouts.
+- Plan-bound changes share the plan revision stream. Standalone changes have workout-scoped complete snapshots. Plan
+  history uses immutable deltas and compressed child-document checkpoint chunks every 20 revisions and after bulk
+  operations, keeping revision envelopes below Firestore document limits. A restore creates a new revision and cannot
+  reclaim a workout that has moved to a different scope or recreate a permanently deleted workout.
+- Ordinary workout deletion remains recoverable through history. Permanent deletion requires its own confirmation. Plan
+  deletion requires choosing whether its current workouts become standalone or are deleted; either choice removes the
+  plan history, while Archive remains the non-destructive choice.
+- Permanent deletion retains only a server-internal hash tombstone for each retired plan or workout ID. Retired IDs
+  cannot be reused, preventing delayed or retried recursive cleanup from deleting a newly created entity.
+
+### UI and calendar contract
+
+`/plans` provides Plans and Standalone views plus create, edit, copy, move/associate, skip, delete, permanent delete,
+history/restore, activation, pause, archive, and date-shift actions. Calendar-originated creation defaults to the active
+plan when one exists and provides an explicit standalone action; without an active plan it defaults to standalone.
+
+The full Calendar, dashboard Activity Calendar tile, and Dashboard Today mini-calendar overlay standalone workouts and
+workouts from the active plan. Inactive-plan workouts remain visible only in `/plans`; skipped workouts stay visible and
+marked. Every rendered date is selectable, including empty dates. Day details keep **Planned workouts** and completed
+activities in separate sections. Planned workouts never enter recorded activity counts, durations, distance, elevation,
+group bars, activity tables, or Training-derived metrics.
+
+`/plans` is authenticated, client-rendered, `noindex, follow`, disallowed by `robots.txt`, and excluded from the sitemap.
+
+### Provider proof status
+
+`shared/planned-workout-providers.ts` is the versioned capability/research snapshot. All four delivery switches remain
+false. Garmin and COROS are `blocked-contract`; no endpoint or payload is guessed without the current private partner
+contract. Wahoo and Suunto are `fixture-only`: pure serializers and redacted fixtures prove the documented mapping, but
+there is no provider transport, token use, schedule write, ZIP upload, or production action.
+
+Every serializer returns `exact`, `degraded`, or `unsupported`. Degraded output requires explicit approval. Current
+examples include Wahoo's first-target-only ELEMNT behavior, unsupported Wahoo relative references frozen to their stored
+absolute snapshot, Suunto relative targets frozen to absolute values, cadence converted from rpm to hertz, and explicit
+text truncation. Unsupported sport or ending combinations fail instead of being approximated. Sandbox CRUD,
+idempotency, retry/reconnect, deletion, reconciliation, rollout, AI, templates, completion matching, and the Sports Lib
+extraction remain separately tracked by subissues #645–#655 under epic #583; they must not be left as anonymous TODOs.
+
 ### Product analytics
 
 The app-wide, consent-gated Firebase `screen_view` already records `/training` route visits, so Training must not emit a

--- a/docs/training-workspace.md
+++ b/docs/training-workspace.md
@@ -257,8 +257,17 @@ packed Sports Lib package. That gate is tracked by GitHub issue #654 under epic 
 - Ordinary workout deletion remains recoverable through history. Permanent deletion requires its own confirmation. Plan
   deletion requires choosing whether its current workouts become standalone or are deleted; either choice removes the
   plan history, while Archive remains the non-destructive choice.
-- Permanent deletion retains only a server-internal hash tombstone for each retired plan or workout ID. Retired IDs
-  cannot be reused, preventing delayed or retried recursive cleanup from deleting a newly created entity.
+- Permanent deletion removes the workout root and its standalone revision subtree, then retains a server-internal hash
+  tombstone so the retired ID cannot be reused. A plan-bound workout can still occur in that plan's immutable revision
+  audit until the plan itself is deleted; it is tombstoned, cannot be restored, and this retention is disclosed in the
+  confirmation UI. Plan deletion removes the complete plan revision subtree.
+- Plan deletion uses a user-scoped durable lock while it prepares bounded tombstones and standalone revision snapshots.
+  An exact retry remains idempotent, and a same-disposition retry with the locked state/plan revisions may resume the
+  original operation after a browser reload even when the caller no longer has the original mutation ID.
+- Resumable processing at the full 400-current-workout boundary, paged recoverable-workout history, and durable retry of
+  post-commit recursive cleanup are tracked explicitly by epic subissue #657. Until that slice lands, unusually large
+  structure payloads may still reach Firestore's atomic request-size limit even when their write count is valid; do not
+  lower the public v1 limits or hide this boundary in an anonymous TODO.
 
 ### UI and calendar contract
 
@@ -277,16 +286,20 @@ group bars, activity tables, or Training-derived metrics.
 ### Provider proof status
 
 `shared/planned-workout-providers.ts` is the versioned capability/research snapshot. All four delivery switches remain
-false. Garmin and COROS are `blocked-contract`; no endpoint or payload is guessed without the current private partner
-contract. Wahoo and Suunto are `fixture-only`: pure serializers and redacted fixtures prove the documented mapping, but
-there is no provider transport, token use, schedule write, ZIP upload, or production action.
+false. Garmin, COROS, Wahoo, and Suunto are `fixture-only`: pure serializers and redacted fixtures prove documented
+mapping behavior, but there is no provider transport, token use, schedule write, ZIP upload, or production action. The
+ignored local Garmin Training API V2 and COROS API Reference PDFs remain evidence only and are never committed.
 
 Every serializer returns `exact`, `degraded`, or `unsupported`. Degraded output requires explicit approval. Current
-examples include Wahoo's first-target-only ELEMNT behavior, unsupported Wahoo relative references frozen to their stored
-absolute snapshot, Suunto relative targets frozen to absolute values, cadence converted from rpm to hertz, and explicit
-text truncation. Unsupported sport or ending combinations fail instead of being approximated. Sandbox CRUD,
-idempotency, retry/reconnect, deletion, reconciliation, rollout, AI, templates, completion matching, and the Sports Lib
-extraction remain separately tracked by subissues #645–#655 under epic #583; they must not be left as anonymous TODOs.
+examples include Garmin relative targets frozen from their stored reference snapshots, Garmin cycling-secondary-target
+device limits, COROS recovery-to-rest and first-target-only behavior, COROS integer rounding, Wahoo's first-target-only
+ELEMNT behavior, unsupported Wahoo relative references frozen to their stored absolute snapshot, integer rounding for
+Wahoo FTP/heart-rate header references, Suunto relative targets frozen to absolute values, Wahoo relative HR/speed
+target support limited to treadmill workouts in its app, cadence converted from rpm to hertz, Unicode-safe text
+truncation, and Suunto text outside the guaranteed minimum watch character set. Unsupported sport, ending, or target
+combinations fail instead of being approximated. Sandbox CRUD, idempotency, retry/reconnect, deletion, reconciliation,
+rollout, AI, templates, completion matching, and the Sports Lib extraction remain separately tracked by subissues
+#645–#655 and #657 under epic #583; they must not be left as anonymous TODOs.
 
 ### Product analytics
 

--- a/firebase.json
+++ b/firebase.json
@@ -134,6 +134,10 @@
           "headers": [{ "key": "X-Robots-Tag", "value": "noindex, nofollow" }]
         },
         {
+          "source": "/plans",
+          "headers": [{ "key": "X-Robots-Tag", "value": "noindex, nofollow" }]
+        },
+        {
           "source": "/training",
           "headers": [{ "key": "X-Robots-Tag", "value": "noindex, nofollow" }]
         },
@@ -328,6 +332,10 @@
         },
         {
           "source": "/calendar",
+          "destination": "/index.csr.html"
+        },
+        {
+          "source": "/plans",
           "destination": "/index.csr.html"
         },
         {
@@ -607,6 +615,10 @@
         },
         {
           "source": "/calendar",
+          "destination": "/index.csr.html"
+        },
+        {
+          "source": "/plans",
           "destination": "/index.csr.html"
         },
         {

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -11,6 +11,48 @@
       "density": "SPARSE_ALL"
     },
     {
+      "collectionGroup": "scheduledWorkouts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "planId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "localDate",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "lifecycle",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "scheduledWorkouts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "planId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "lifecycle",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
       "collectionGroup": "activitySyncQueue",
       "queryScope": "COLLECTION",
       "fields": [
@@ -2361,6 +2403,12 @@
       "collectionGroup": "healthSyncState",
       "fieldPath": "*",
       "ttl": false,
+      "indexes": []
+    },
+    {
+      "collectionGroup": "mutationReceipts",
+      "fieldPath": "expireAt",
+      "ttl": true,
       "indexes": []
     }
   ]

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -2410,6 +2410,24 @@
       "fieldPath": "expireAt",
       "ttl": true,
       "indexes": []
+    },
+    {
+      "collectionGroup": "scheduledWorkouts",
+      "fieldPath": "structure",
+      "ttl": false,
+      "indexes": []
+    },
+    {
+      "collectionGroup": "revisions",
+      "fieldPath": "snapshot",
+      "ttl": false,
+      "indexes": []
+    },
+    {
+      "collectionGroup": "chunks",
+      "fieldPath": "payloadBase64",
+      "ttl": false,
+      "indexes": []
     }
   ]
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -302,7 +302,7 @@ service cloud.firestore {
         // but every mutation is fenced and validated by App Check callables.
         // Nested revisions, receipts, and deletion locks remain server-only.
         match /trainingPlanState/{stateID} {
-          allow read: if isOwner();
+          allow read: if isOwner() && stateID == 'current';
           allow write: if false;
 
           match /{document=**} {

--- a/firestore.rules
+++ b/firestore.rules
@@ -298,6 +298,36 @@ service cloud.firestore {
           allow write: if false;
         }
 
+        // Current training-plan state is owner-readable for live UI listeners,
+        // but every mutation is fenced and validated by App Check callables.
+        // Nested revisions, receipts, and deletion locks remain server-only.
+        match /trainingPlanState/{stateID} {
+          allow read: if isOwner();
+          allow write: if false;
+
+          match /{document=**} {
+            allow read, write: if false;
+          }
+        }
+
+        match /trainingPlans/{planID} {
+          allow read: if isOwner();
+          allow write: if false;
+
+          match /{document=**} {
+            allow read, write: if false;
+          }
+        }
+
+        match /scheduledWorkouts/{workoutID} {
+          allow read: if isOwner();
+          allow write: if false;
+
+          match /{document=**} {
+            allow read, write: if false;
+          }
+        }
+
         match /sleepSessions/{sleepSessionID} {
           allow read: if request.auth.uid == userID;
           allow write: if false;

--- a/functions/src/firestore-indexes.spec.ts
+++ b/functions/src/firestore-indexes.spec.ts
@@ -781,4 +781,38 @@ describe('firestore indexes', () => {
             indexes: [],
         });
     });
+
+    it('supports dated plan overlays, deletion fencing queries, and expiring mutation receipts', () => {
+        const config = loadFirestoreIndexes();
+
+        expect(config.indexes).toEqual(expect.arrayContaining([
+            {
+                collectionGroup: 'scheduledWorkouts',
+                queryScope: 'COLLECTION',
+                fields: [
+                    { fieldPath: 'planId', order: 'ASCENDING' },
+                    { fieldPath: 'localDate', order: 'ASCENDING' },
+                    { fieldPath: 'lifecycle', order: 'ASCENDING' },
+                    { fieldPath: '__name__', order: 'ASCENDING' },
+                ],
+                density: 'SPARSE_ALL',
+            },
+            {
+                collectionGroup: 'scheduledWorkouts',
+                queryScope: 'COLLECTION',
+                fields: [
+                    { fieldPath: 'planId', order: 'ASCENDING' },
+                    { fieldPath: 'lifecycle', order: 'ASCENDING' },
+                    { fieldPath: '__name__', order: 'ASCENDING' },
+                ],
+                density: 'SPARSE_ALL',
+            },
+        ]));
+        expect(config.fieldOverrides).toContainEqual({
+            collectionGroup: 'mutationReceipts',
+            fieldPath: 'expireAt',
+            ttl: true,
+            indexes: [],
+        });
+    });
 });

--- a/functions/src/firestore-indexes.spec.ts
+++ b/functions/src/firestore-indexes.spec.ts
@@ -782,7 +782,7 @@ describe('firestore indexes', () => {
         });
     });
 
-    it('supports dated plan overlays, deletion fencing queries, and expiring mutation receipts', () => {
+    it('supports dated plan overlays, bounded indexing, deletion fencing, and expiring mutation receipts', () => {
         const config = loadFirestoreIndexes();
 
         expect(config.indexes).toEqual(expect.arrayContaining([
@@ -814,5 +814,25 @@ describe('firestore indexes', () => {
             ttl: true,
             indexes: [],
         });
+        expect(config.fieldOverrides).toEqual(expect.arrayContaining([
+            {
+                collectionGroup: 'scheduledWorkouts',
+                fieldPath: 'structure',
+                ttl: false,
+                indexes: [],
+            },
+            {
+                collectionGroup: 'revisions',
+                fieldPath: 'snapshot',
+                ttl: false,
+                indexes: [],
+            },
+            {
+                collectionGroup: 'chunks',
+                fieldPath: 'payloadBase64',
+                ttl: false,
+                indexes: [],
+            },
+        ]));
     });
 });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -196,6 +196,13 @@ export {
   deleteManualHealthMeasurementCallable as deleteManualHealthMeasurement,
 } from './health/manual-callable';
 export { setTrainingBuildBenchmark } from './derived-metrics/set-training-build-benchmark';
+export { mutateTrainingSchedule } from './training-plans/mutate-training-schedule';
+export {
+  getTrainingScheduleHistory,
+  previewTrainingScheduleRestore,
+} from './training-plans/history-callables';
+export { restoreTrainingScheduleRevision } from './training-plans/restore-callable';
+export { deleteTrainingPlan } from './training-plans/delete-training-plan-callable';
 export {
   onDashboardDerivedMetricsActivityWrite,
   onDashboardDerivedMetricsEventWrite,

--- a/functions/src/training-plans/delete-training-plan-callable.spec.ts
+++ b/functions/src/training-plans/delete-training-plan-callable.spec.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+    enforceAppCheck: vi.fn(),
+    deletePlan: vi.fn(),
+    loggerError: vi.fn(),
+}));
+
+vi.mock('firebase-functions/v2/https', () => ({
+    HttpsError: class MockHttpsError extends Error {
+        constructor(public readonly code: string, message: string) { super(message); }
+    },
+    onCall: (_options: unknown, handler: unknown) => handler,
+}));
+vi.mock('firebase-functions/logger', () => ({ error: hoisted.loggerError }));
+vi.mock('../../../shared/functions-manifest', () => ({
+    FUNCTIONS_MANIFEST: { deleteTrainingPlan: { region: 'europe-west2' } },
+}));
+vi.mock('../utils', () => ({ enforceAppCheck: hoisted.enforceAppCheck }));
+vi.mock('./delete-training-plan', () => ({ deleteTrainingPlanForUser: hoisted.deletePlan }));
+
+import { TrainingScheduleMutationError } from './mutation';
+import { deleteTrainingPlan } from './delete-training-plan-callable';
+
+const DATA = {
+    mutationId: 'delete-plan-1',
+    planId: 'plan-1',
+    expectedRevisions: [
+        { scope: 'state', id: 'current', revision: 8 },
+        { scope: 'plan', id: 'plan-1', revision: 4 },
+    ],
+    workoutDisposition: 'convert-to-standalone',
+    confirmPlanDeletion: true,
+};
+
+describe('deleteTrainingPlan callable', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        hoisted.deletePlan.mockResolvedValue({ removedPlanId: 'plan-1' });
+    });
+
+    it('requires auth and App Check', async () => {
+        await expect((deleteTrainingPlan as never as (request: unknown) => Promise<unknown>)({ data: DATA }))
+            .rejects.toMatchObject({ code: 'unauthenticated' });
+        expect(hoisted.enforceAppCheck).not.toHaveBeenCalled();
+
+        hoisted.enforceAppCheck.mockImplementationOnce(() => { throw new Error('App Check failed.'); });
+        await expect((deleteTrainingPlan as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'owner' }, data: DATA,
+        })).rejects.toThrow('App Check failed');
+    });
+
+    it('derives the owner and passes an explicitly confirmed disposition', async () => {
+        await (deleteTrainingPlan as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'owner' }, app: {}, data: DATA,
+        });
+        expect(hoisted.deletePlan).toHaveBeenCalledWith('owner', DATA);
+    });
+
+    it('rejects deletion without exact confirmation', async () => {
+        await expect((deleteTrainingPlan as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'owner' }, app: {}, data: { ...DATA, confirmPlanDeletion: false },
+        })).rejects.toMatchObject({ code: 'invalid-argument' });
+        expect(hoisted.deletePlan).not.toHaveBeenCalled();
+    });
+
+    it('maps revision conflicts to aborted', async () => {
+        hoisted.deletePlan.mockRejectedValueOnce(new TrainingScheduleMutationError('revision-conflict', 'Changed.'));
+        await expect((deleteTrainingPlan as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'owner' }, app: {}, data: DATA,
+        })).rejects.toMatchObject({ code: 'aborted', message: 'Changed.' });
+    });
+
+    it('redacts unexpected failures while telling the client to retry identically', async () => {
+        hoisted.deletePlan.mockRejectedValueOnce(new Error('private Firestore path'));
+        await expect((deleteTrainingPlan as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'owner' }, app: {}, data: DATA,
+        })).rejects.toMatchObject({
+            code: 'internal', message: 'Unable to delete this training plan. Retry with the same request.',
+        });
+        expect(hoisted.loggerError).toHaveBeenCalledWith(
+            '[TrainingPlans] Plan deletion failed.', { errorName: 'Error' },
+        );
+    });
+});

--- a/functions/src/training-plans/delete-training-plan-callable.ts
+++ b/functions/src/training-plans/delete-training-plan-callable.ts
@@ -1,0 +1,49 @@
+import * as logger from 'firebase-functions/logger';
+import { HttpsError, onCall } from 'firebase-functions/v2/https';
+import { FUNCTIONS_MANIFEST } from '../../../shared/functions-manifest';
+import {
+    TrainingPlanContractError,
+    parseDeleteTrainingPlanRequestV1,
+} from '../../../shared/training-plans';
+import { enforceAppCheck } from '../utils';
+import { deleteTrainingPlanForUser } from './delete-training-plan';
+import { TrainingScheduleMutationError } from './mutation';
+
+function mapDeletionError(error: TrainingScheduleMutationError): HttpsError {
+    switch (error.code) {
+        case 'not-found':
+            return new HttpsError('not-found', error.message);
+        case 'revision-conflict':
+            return new HttpsError('aborted', error.message);
+        case 'limit-exceeded':
+            return new HttpsError('resource-exhausted', error.message);
+        case 'already-exists':
+            return new HttpsError('already-exists', error.message);
+        case 'range-extension-required':
+        case 'failed-precondition':
+            return new HttpsError('failed-precondition', error.message);
+    }
+}
+
+export const deleteTrainingPlan = onCall({
+    region: FUNCTIONS_MANIFEST.deleteTrainingPlan.region,
+    timeoutSeconds: 540,
+    memory: '1GiB',
+}, async (request) => {
+    if (!request.auth) throw new HttpsError('unauthenticated', 'The function must be called while authenticated.');
+    enforceAppCheck(request);
+    try {
+        return await deleteTrainingPlanForUser(
+            request.auth.uid,
+            parseDeleteTrainingPlanRequestV1(request.data),
+        );
+    } catch (error) {
+        if (error instanceof TrainingPlanContractError) throw new HttpsError('invalid-argument', error.message);
+        if (error instanceof TrainingScheduleMutationError) throw mapDeletionError(error);
+        if (error instanceof HttpsError) throw error;
+        logger.error('[TrainingPlans] Plan deletion failed.', {
+            errorName: error instanceof Error ? error.name : 'UnknownError',
+        });
+        throw new HttpsError('internal', 'Unable to delete this training plan. Retry with the same request.');
+    }
+});

--- a/functions/src/training-plans/delete-training-plan.persistence.spec.ts
+++ b/functions/src/training-plans/delete-training-plan.persistence.spec.ts
@@ -14,6 +14,7 @@ vi.mock('../shared/user-deletion-guard', () => ({
 
 import { deleteTrainingPlanForUser } from './delete-training-plan';
 import {
+    hashTrainingScheduleRequestPayload,
     mutateTrainingScheduleForUser,
     trainingScheduleDeletionTombstoneDocumentId,
 } from './persistence';
@@ -183,14 +184,15 @@ function request(workoutDisposition: DeleteTrainingPlanRequestV1['workoutDisposi
 }
 
 function seed(db: FakeFirestore, workouts: ScheduledWorkoutV1[]): void {
+    const currentWorkoutCount = workouts.filter(item => item.lifecycle !== 'deleted').length;
     db.seed('users/user-1/trainingPlanState/current', {
         schemaVersion: 1,
         activePlanId: 'plan-1',
         revision: 8,
-        currentWorkoutCount: workouts.length,
+        currentWorkoutCount,
         updatedAtMs: 8,
     });
-    db.seed('users/user-1/trainingPlans/plan-1', plan(workouts.length));
+    db.seed('users/user-1/trainingPlans/plan-1', plan(currentWorkoutCount));
     db.seed('users/user-1/trainingPlans/plan-1/revisions/0000000001', { privateHistory: true });
     workouts.forEach(item => db.seed(`users/user-1/scheduledWorkouts/${item.id}`, item));
 }
@@ -271,7 +273,51 @@ describe('deleteTrainingPlanForUser persistence', () => {
         });
     });
 
-    it('honors the declared 400-current-workout limit without exceeding one batch', async () => {
+    it('retires soft-deleted plan workout IDs before removing their residual roots', async () => {
+        const current = workout('workout-1');
+        const previouslyDeleted = {
+            ...workout('workout-deleted'),
+            lifecycle: 'deleted' as const,
+            revision: 3,
+            deletedAtMs: NOW_MS - 100,
+        };
+        seed(db, [current, previouslyDeleted]);
+        db.seed('users/user-1/scheduledWorkouts/workout-deleted/revisions/0000000003', { privateHistory: true });
+
+        await deleteTrainingPlanForUser(
+            'user-1', request('convert-to-standalone'), { db: db as never, nowMs: NOW_MS },
+        );
+
+        expect(db.read('users/user-1/scheduledWorkouts/workout-deleted')).toBeUndefined();
+        expect(db.read('users/user-1/scheduledWorkouts/workout-deleted/revisions/0000000003')).toBeUndefined();
+        const tombstoneId = trainingScheduleDeletionTombstoneDocumentId('workout', 'workout-deleted');
+        expect(db.read(`users/user-1/trainingPlanState/current/deletionTombstones/${tombstoneId}`)).toMatchObject({
+            entityKind: 'workout',
+            mutationId: request('convert-to-standalone').mutationId,
+        });
+
+        const recreate: MutateTrainingScheduleRequestV1 = {
+            mutationId: 'recreate-retired-workout',
+            expectedRevisions: [{ scope: 'state', id: 'current', revision: 9 }],
+            operation: {
+                kind: 'create-workout',
+                workoutId: 'workout-deleted',
+                planId: null,
+                localDate: '2026-09-04',
+                title: 'Must stay retired',
+                structure: STRUCTURE,
+                confirmPlanRangeExtension: false,
+            },
+        };
+        await expect(mutateTrainingScheduleForUser('user-1', recreate, {
+            db: db as never,
+            nowMs: NOW_MS + 1,
+        })).rejects.toMatchObject({ code: 'already-exists' });
+    });
+
+    it('preserves the declared 400-current-workout limit in the in-memory transaction model', async () => {
+        // Emulator request-size and resumable-operation coverage is tracked by
+        // https://github.com/jimmykane/quantified-self/issues/657.
         const workouts = Array.from({ length: 400 }, (_, index) => workout(`workout-${`${index}`.padStart(3, '0')}`));
         seed(db, workouts);
 
@@ -293,6 +339,84 @@ describe('deleteTrainingPlanForUser persistence', () => {
         expect(db.read('users/user-1/trainingPlanState/current/planDeletionLocks/plan-1')).toBeUndefined();
     });
 
+    it('resumes an interrupted deletion after a reload supplies a new mutation ID', async () => {
+        const current = workout('workout-1');
+        seed(db, [current]);
+        const original = request('convert-to-standalone');
+        db.seed('users/user-1/trainingPlanState/current/planDeletionLocks/plan-1', {
+            schemaVersion: 1,
+            mutationId: original.mutationId,
+            requestHash: hashTrainingScheduleRequestPayload(original),
+            planId: 'plan-1',
+            stateRevision: 8,
+            planRevision: 4,
+            workoutDisposition: 'convert-to-standalone',
+            workouts: [{ id: current.id, revision: current.revision }],
+            createdAtMs: NOW_MS - 1,
+        });
+        const retry = { ...original, mutationId: 'delete-after-reload' };
+
+        const response = await deleteTrainingPlanForUser(
+            'user-1', retry, { db: db as never, nowMs: NOW_MS },
+        );
+
+        expect(response.mutationId).toBe(original.mutationId);
+        expect(db.read('users/user-1/trainingPlans/plan-1')).toBeUndefined();
+        expect(db.read('users/user-1/scheduledWorkouts/workout-1')).toMatchObject({ planId: null, revision: 3 });
+        expect(db.read('users/user-1/scheduledWorkouts/workout-1/revisions/0000000003')).toMatchObject({
+            mutationId: original.mutationId,
+        });
+        expect(db.read('users/user-1/trainingPlanState/current/mutationReceipts/delete-after-reload'))
+            .toMatchObject({
+                requestHash: hashTrainingScheduleRequestPayload(retry),
+                response: { mutationId: original.mutationId },
+            });
+
+        await expect(deleteTrainingPlanForUser(
+            'user-1', retry, { db: db as never, nowMs: NOW_MS + 1 },
+        )).resolves.toEqual(response);
+    });
+
+    it('resumes cleanup with a new mutation ID after the deletion commit already succeeded', async () => {
+        seed(db, [workout('workout-1')]);
+        const original = request('convert-to-standalone');
+        db.recursiveDelete.mockRejectedValueOnce(new Error('cleanup interrupted'));
+
+        await expect(deleteTrainingPlanForUser(
+            'user-1', original, { db: db as never, nowMs: NOW_MS },
+        )).rejects.toThrow('cleanup interrupted');
+        expect(db.read('users/user-1/trainingPlans/plan-1')).toBeUndefined();
+        expect(db.read('users/user-1/scheduledWorkouts/workout-1')).toMatchObject({ planId: null, revision: 3 });
+        expect(db.read(`users/user-1/trainingPlanState/current/mutationReceipts/${original.mutationId}`))
+            .toMatchObject({ response: { mutationId: original.mutationId } });
+        expect(db.read('users/user-1/trainingPlanState/current/planDeletionLocks/plan-1')).toBeDefined();
+
+        const retry = { ...original, mutationId: 'delete-after-committed-reload' };
+        const response = await deleteTrainingPlanForUser(
+            'user-1', retry, { db: db as never, nowMs: NOW_MS + 1 },
+        );
+
+        expect(response.mutationId).toBe(original.mutationId);
+        expect(db.read('users/user-1/trainingPlanState/current/planDeletionLocks/plan-1')).toBeUndefined();
+        expect(db.read('users/user-1/trainingPlanState/current/mutationReceipts/delete-after-committed-reload'))
+            .toMatchObject({ response: { mutationId: original.mutationId } });
+    });
+
+    it('does not stage deletion records after account deletion starts', async () => {
+        seed(db, [workout('workout-1')]);
+        guard.getUserDeletionGuardStateInTransaction
+            .mockResolvedValueOnce({ shouldSkip: false })
+            .mockResolvedValueOnce({ shouldSkip: true });
+
+        await expect(deleteTrainingPlanForUser(
+            'user-1', request('convert-to-standalone'), { db: db as never, nowMs: NOW_MS },
+        )).rejects.toThrow('account is being deleted');
+
+        expect(db.read('users/user-1/trainingPlans/plan-1')).toBeDefined();
+        expect(db.read('users/user-1/scheduledWorkouts/workout-1')).toMatchObject({ planId: 'plan-1' });
+        expect(db.read('users/user-1/scheduledWorkouts/workout-1/revisions/0000000003')).toBeUndefined();
+    });
+
     it('serializes plan deletions for a user', async () => {
         seed(db, [workout('workout-1')]);
         db.seed('users/user-1/trainingPlanState/current/planDeletionLocks/plan-2', {
@@ -300,6 +424,7 @@ describe('deleteTrainingPlanForUser persistence', () => {
             mutationId: 'delete-plan-2',
             requestHash: 'different-request',
             planId: 'plan-2',
+            stateRevision: 8,
             planRevision: 1,
             workoutDisposition: 'delete-workouts',
             workouts: [],

--- a/functions/src/training-plans/delete-training-plan.persistence.spec.ts
+++ b/functions/src/training-plans/delete-training-plan.persistence.spec.ts
@@ -1,0 +1,314 @@
+import { ActivityTypes } from '@sports-alliance/sports-lib';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+    DeleteTrainingPlanRequestV1,
+    MutateTrainingScheduleRequestV1,
+    ScheduledWorkoutV1,
+    TrainingPlanV1,
+} from '../../../shared/training-plans';
+
+const guard = vi.hoisted(() => ({ getUserDeletionGuardStateInTransaction: vi.fn() }));
+vi.mock('../shared/user-deletion-guard', () => ({
+    getUserDeletionGuardStateInTransaction: guard.getUserDeletionGuardStateInTransaction,
+}));
+
+import { deleteTrainingPlanForUser } from './delete-training-plan';
+import {
+    mutateTrainingScheduleForUser,
+    trainingScheduleDeletionTombstoneDocumentId,
+} from './persistence';
+
+const NOW_MS = Date.UTC(2026, 8, 2, 14);
+const STRUCTURE = {
+    version: 1 as const,
+    sport: ActivityTypes.Running,
+    nodes: [{
+        kind: 'step' as const,
+        id: 'steady',
+        purpose: 'work' as const,
+        ending: { kind: 'time' as const, seconds: 1800 },
+        targets: [],
+    }],
+};
+
+type Stored = Record<string, unknown>;
+
+function clone<T>(value: T): T {
+    return JSON.parse(JSON.stringify(value)) as T;
+}
+
+class FakeSnapshot {
+    constructor(readonly ref: FakeDocumentReference, private readonly stored: Stored | undefined) {}
+    get id(): string { return this.ref.id; }
+    get exists(): boolean { return this.stored !== undefined; }
+    data(): Stored | undefined { return this.stored === undefined ? undefined : clone(this.stored); }
+}
+
+interface Filter {
+    field: string;
+    operator: string;
+    value: unknown;
+}
+
+class FakeQuery {
+    constructor(
+        readonly db: FakeFirestore,
+        readonly path: string,
+        readonly filters: Filter[] = [],
+    ) {}
+    where(field: string, operator: string, value: unknown): FakeQuery {
+        return new FakeQuery(this.db, this.path, [...this.filters, { field, operator, value }]);
+    }
+    async get(): Promise<{ docs: FakeSnapshot[]; empty: boolean }> {
+        const docs = this.db.query(this);
+        return { docs, empty: docs.length === 0 };
+    }
+}
+
+class FakeCollectionReference extends FakeQuery {
+    doc(id: string): FakeDocumentReference { return new FakeDocumentReference(this.db, `${this.path}/${id}`); }
+}
+
+class FakeDocumentReference {
+    constructor(readonly db: FakeFirestore, readonly path: string) {}
+    get id(): string { return this.path.split('/').at(-1) ?? ''; }
+    collection(id: string): FakeCollectionReference { return new FakeCollectionReference(this.db, `${this.path}/${id}`); }
+}
+
+class FakeTransaction {
+    constructor(private readonly db: FakeFirestore) {}
+    async get(ref: FakeDocumentReference | FakeQuery): Promise<FakeSnapshot | { docs: FakeSnapshot[]; empty: boolean }> {
+        if (ref instanceof FakeDocumentReference) return this.db.snapshot(ref);
+        const docs = this.db.query(ref);
+        return { docs, empty: docs.length === 0 };
+    }
+    set(ref: FakeDocumentReference, value: unknown): void { this.db.docs.set(ref.path, clone(value as Stored)); }
+    create(ref: FakeDocumentReference, value: unknown): void {
+        if (this.db.docs.has(ref.path)) throw new Error(`Document exists: ${ref.path}`);
+        this.set(ref, value);
+    }
+    delete(ref: FakeDocumentReference): void { this.db.docs.delete(ref.path); }
+}
+
+class FakeBatch {
+    private readonly creates: Array<{ ref: FakeDocumentReference; value: unknown }> = [];
+    constructor(private readonly db: FakeFirestore) {}
+    create(ref: FakeDocumentReference, value: unknown): FakeBatch {
+        this.creates.push({ ref, value });
+        return this;
+    }
+    async commit(): Promise<void> {
+        this.creates.forEach(({ ref }) => {
+            if (this.db.docs.has(ref.path)) throw new Error(`Document exists: ${ref.path}`);
+        });
+        this.creates.forEach(({ ref, value }) => this.db.docs.set(ref.path, clone(value as Stored)));
+    }
+}
+
+class FakeFirestore {
+    readonly docs = new Map<string, Stored>();
+    readonly recursiveDelete = vi.fn(async (ref: FakeDocumentReference) => {
+        [...this.docs.keys()].forEach((path) => {
+            if (path === ref.path || path.startsWith(`${ref.path}/`)) this.docs.delete(path);
+        });
+    });
+    collection(id: string): FakeCollectionReference { return new FakeCollectionReference(this, id); }
+    batch(): FakeBatch { return new FakeBatch(this); }
+    async runTransaction<T>(handler: (transaction: FakeTransaction) => Promise<T>): Promise<T> {
+        return handler(new FakeTransaction(this));
+    }
+    async getAll(...refs: FakeDocumentReference[]): Promise<FakeSnapshot[]> {
+        return refs.map(ref => this.snapshot(ref));
+    }
+    snapshot(ref: FakeDocumentReference): FakeSnapshot { return new FakeSnapshot(ref, this.docs.get(ref.path)); }
+    query(query: FakeQuery): FakeSnapshot[] {
+        const prefix = `${query.path}/`;
+        return [...this.docs.entries()]
+            .filter(([path]) => path.startsWith(prefix) && !path.slice(prefix.length).includes('/'))
+            .filter(([, value]) => query.filters.every((filter) => {
+                if (filter.operator === '==') return value[filter.field] === filter.value;
+                if (filter.operator === 'in' && Array.isArray(filter.value)) {
+                    return filter.value.includes(value[filter.field]);
+                }
+                throw new Error(`Unsupported operator ${filter.operator}`);
+            }))
+            .map(([path, value]) => new FakeSnapshot(new FakeDocumentReference(this, path), value));
+    }
+    seed(path: string, value: unknown): void { this.docs.set(path, clone(value as Stored)); }
+    read(path: string): Stored | undefined { return this.docs.get(path); }
+}
+
+function plan(workoutCount: number): TrainingPlanV1 {
+    return {
+        schemaVersion: 1,
+        id: 'plan-1',
+        name: 'Plan one',
+        lifecycle: 'active',
+        startLocalDate: '2026-09-01',
+        endLocalDate: '2026-09-30',
+        revision: 4,
+        lastCheckpointRevision: 1,
+        workoutCount,
+        createdAtMs: 1,
+        updatedAtMs: 4,
+    };
+}
+
+function workout(id: string): ScheduledWorkoutV1 {
+    return {
+        schemaVersion: 1,
+        id,
+        planId: 'plan-1',
+        localDate: '2026-09-03',
+        lifecycle: 'planned',
+        title: id,
+        structure: STRUCTURE,
+        revision: 2,
+        createdAtMs: 1,
+        updatedAtMs: 2,
+    };
+}
+
+function request(workoutDisposition: DeleteTrainingPlanRequestV1['workoutDisposition']): DeleteTrainingPlanRequestV1 {
+    return {
+        mutationId: `delete-${workoutDisposition}`,
+        planId: 'plan-1',
+        expectedRevisions: [
+            { scope: 'state', id: 'current', revision: 8 },
+            { scope: 'plan', id: 'plan-1', revision: 4 },
+        ],
+        workoutDisposition,
+        confirmPlanDeletion: true,
+    };
+}
+
+function seed(db: FakeFirestore, workouts: ScheduledWorkoutV1[]): void {
+    db.seed('users/user-1/trainingPlanState/current', {
+        schemaVersion: 1,
+        activePlanId: 'plan-1',
+        revision: 8,
+        currentWorkoutCount: workouts.length,
+        updatedAtMs: 8,
+    });
+    db.seed('users/user-1/trainingPlans/plan-1', plan(workouts.length));
+    db.seed('users/user-1/trainingPlans/plan-1/revisions/0000000001', { privateHistory: true });
+    workouts.forEach(item => db.seed(`users/user-1/scheduledWorkouts/${item.id}`, item));
+}
+
+describe('deleteTrainingPlanForUser persistence', () => {
+    let db: FakeFirestore;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        guard.getUserDeletionGuardStateInTransaction.mockResolvedValue({ shouldSkip: false });
+        db = new FakeFirestore();
+    });
+
+    it('prepares standalone history, atomically converts workouts, and cleans plan history', async () => {
+        seed(db, [workout('workout-1'), workout('workout-2')]);
+        const deletion = request('convert-to-standalone');
+
+        const response = await deleteTrainingPlanForUser('user-1', deletion, { db: db as never, nowMs: NOW_MS });
+
+        expect(response.convertedWorkoutIds).toEqual(['workout-1', 'workout-2']);
+        expect(db.read('users/user-1/trainingPlans/plan-1')).toBeUndefined();
+        expect(db.read('users/user-1/trainingPlans/plan-1/revisions/0000000001')).toBeUndefined();
+        expect(db.read('users/user-1/scheduledWorkouts/workout-1')).toMatchObject({ planId: null, revision: 3 });
+        expect(db.read('users/user-1/scheduledWorkouts/workout-1/revisions/0000000003')).toMatchObject({
+            mutationId: deletion.mutationId,
+            operationKind: 'delete-plan-convert-workouts',
+            snapshot: expect.objectContaining({ planId: null, revision: 3 }),
+        });
+        expect(db.read('users/user-1/trainingPlanState/current')).toMatchObject({
+            activePlanId: null, revision: 9, currentWorkoutCount: 2,
+        });
+        expect(db.read('users/user-1/trainingPlanState/current/planDeletionLocks/plan-1')).toBeUndefined();
+        const planTombstoneId = trainingScheduleDeletionTombstoneDocumentId('plan', 'plan-1');
+        expect(db.read(`users/user-1/trainingPlanState/current/deletionTombstones/${planTombstoneId}`)).toMatchObject({
+            entityKind: 'plan',
+            entityIdHash: planTombstoneId,
+            mutationId: deletion.mutationId,
+        });
+
+        await expect(deleteTrainingPlanForUser('user-1', deletion, { db: db as never, nowMs: NOW_MS + 100 }))
+            .resolves.toEqual(response);
+
+        const recreate: MutateTrainingScheduleRequestV1 = {
+            mutationId: 'recreate-retired-plan',
+            expectedRevisions: [{ scope: 'state', id: 'current', revision: 9 }],
+            operation: {
+                kind: 'create-plan',
+                planId: 'plan-1',
+                name: 'Reused plan ID',
+                startLocalDate: '2026-10-01',
+                endLocalDate: '2026-10-31',
+                activate: false,
+            },
+        };
+        await expect(mutateTrainingScheduleForUser('user-1', recreate, {
+            db: db as never,
+            nowMs: NOW_MS + 101,
+        })).rejects.toMatchObject({ code: 'already-exists' });
+    });
+
+    it('permanently deletes workouts and their nested history', async () => {
+        const current = workout('workout-1');
+        seed(db, [current]);
+        db.seed('users/user-1/scheduledWorkouts/workout-1/revisions/0000000002', { privateHistory: true });
+
+        const response = await deleteTrainingPlanForUser(
+            'user-1', request('delete-workouts'), { db: db as never, nowMs: NOW_MS },
+        );
+
+        expect(response.permanentlyDeletedWorkoutIds).toEqual(['workout-1']);
+        expect(db.read('users/user-1/scheduledWorkouts/workout-1')).toBeUndefined();
+        expect(db.read('users/user-1/scheduledWorkouts/workout-1/revisions/0000000002')).toBeUndefined();
+        expect(db.read('users/user-1/trainingPlanState/current')).toMatchObject({ currentWorkoutCount: 0 });
+        const workoutTombstoneId = trainingScheduleDeletionTombstoneDocumentId('workout', 'workout-1');
+        expect(db.read(`users/user-1/trainingPlanState/current/deletionTombstones/${workoutTombstoneId}`)).toMatchObject({
+            entityKind: 'workout',
+            entityIdHash: workoutTombstoneId,
+        });
+    });
+
+    it('honors the declared 400-current-workout limit without exceeding one batch', async () => {
+        const workouts = Array.from({ length: 400 }, (_, index) => workout(`workout-${`${index}`.padStart(3, '0')}`));
+        seed(db, workouts);
+
+        const response = await deleteTrainingPlanForUser(
+            'user-1', request('convert-to-standalone'), { db: db as never, nowMs: NOW_MS },
+        );
+
+        expect(response.convertedWorkoutIds).toHaveLength(400);
+        expect(db.read('users/user-1/scheduledWorkouts/workout-399')).toMatchObject({ planId: null, revision: 3 });
+    });
+
+    it('rechecks account deletion before acquiring or finalizing a lock', async () => {
+        seed(db, [workout('workout-1')]);
+        guard.getUserDeletionGuardStateInTransaction.mockResolvedValue({ shouldSkip: true });
+
+        await expect(deleteTrainingPlanForUser(
+            'user-1', request('delete-workouts'), { db: db as never, nowMs: NOW_MS },
+        )).rejects.toThrow('account is being deleted');
+        expect(db.read('users/user-1/trainingPlanState/current/planDeletionLocks/plan-1')).toBeUndefined();
+    });
+
+    it('serializes plan deletions for a user', async () => {
+        seed(db, [workout('workout-1')]);
+        db.seed('users/user-1/trainingPlanState/current/planDeletionLocks/plan-2', {
+            schemaVersion: 1,
+            mutationId: 'delete-plan-2',
+            requestHash: 'different-request',
+            planId: 'plan-2',
+            planRevision: 1,
+            workoutDisposition: 'delete-workouts',
+            workouts: [],
+            createdAtMs: NOW_MS - 1,
+        });
+
+        await expect(deleteTrainingPlanForUser(
+            'user-1', request('delete-workouts'), { db: db as never, nowMs: NOW_MS },
+        )).rejects.toThrow('Another training plan deletion is in progress');
+        expect(db.read('users/user-1/trainingPlanState/current/planDeletionLocks/plan-1')).toBeUndefined();
+    });
+});

--- a/functions/src/training-plans/delete-training-plan.spec.ts
+++ b/functions/src/training-plans/delete-training-plan.spec.ts
@@ -1,0 +1,148 @@
+import { ActivityTypes } from '@sports-alliance/sports-lib';
+import { describe, expect, it } from 'vitest';
+import type {
+    DeleteTrainingPlanRequestV1,
+    ScheduledWorkoutV1,
+    TrainingPlanV1,
+} from '../../../shared/training-plans';
+import { createEmptyTrainingPlanState, type TrainingScheduleSnapshotV1 } from './mutation';
+import { applyTrainingPlanDeletion } from './delete-training-plan';
+
+const NOW_MS = Date.UTC(2026, 8, 2, 13);
+const STRUCTURE = {
+    version: 1 as const,
+    sport: ActivityTypes.Cycling,
+    nodes: [{
+        kind: 'step' as const,
+        id: 'work',
+        purpose: 'work' as const,
+        ending: { kind: 'distance' as const, meters: 20_000 },
+        targets: [],
+    }],
+};
+
+function plan(overrides: Partial<TrainingPlanV1> = {}): TrainingPlanV1 {
+    return {
+        schemaVersion: 1,
+        id: 'plan-1',
+        name: 'Plan one',
+        lifecycle: 'active',
+        startLocalDate: '2026-09-01',
+        endLocalDate: '2026-09-30',
+        revision: 4,
+        lastCheckpointRevision: 1,
+        workoutCount: 2,
+        createdAtMs: 1,
+        updatedAtMs: 4,
+        ...overrides,
+    };
+}
+
+function workout(id: string, overrides: Partial<ScheduledWorkoutV1> = {}): ScheduledWorkoutV1 {
+    return {
+        schemaVersion: 1,
+        id,
+        planId: 'plan-1',
+        localDate: '2026-09-03',
+        lifecycle: 'planned',
+        title: `Workout ${id}`,
+        structure: STRUCTURE,
+        revision: 2,
+        createdAtMs: 1,
+        updatedAtMs: 2,
+        ...overrides,
+    };
+}
+
+function snapshot(): TrainingScheduleSnapshotV1 {
+    const workouts = [workout('workout-1'), workout('workout-2', { lifecycle: 'skipped' })];
+    return {
+        state: {
+            ...createEmptyTrainingPlanState(0),
+            activePlanId: 'plan-1',
+            revision: 8,
+            currentWorkoutCount: 3,
+        },
+        plans: new Map([
+            ['plan-1', plan()],
+            ['plan-2', plan({ id: 'plan-2', name: 'Other', lifecycle: 'paused', workoutCount: 0 })],
+        ]),
+        workouts: new Map([
+            ...workouts.map(item => [item.id, item] as const),
+            ['standalone', workout('standalone', { planId: null })],
+        ]),
+    };
+}
+
+function request(
+    workoutDisposition: DeleteTrainingPlanRequestV1['workoutDisposition'],
+): DeleteTrainingPlanRequestV1 {
+    return {
+        mutationId: `delete-plan-${workoutDisposition}`,
+        planId: 'plan-1',
+        expectedRevisions: [
+            { scope: 'state', id: 'current', revision: 8 },
+            { scope: 'plan', id: 'plan-1', revision: 4 },
+        ],
+        workoutDisposition,
+        confirmPlanDeletion: true,
+    };
+}
+
+describe('applyTrainingPlanDeletion', () => {
+    it('converts current workouts to standalone while preserving IDs and total count', () => {
+        const result = applyTrainingPlanDeletion(snapshot(), request('convert-to-standalone'), NOW_MS);
+
+        expect(result.after.plans.has('plan-1')).toBe(false);
+        expect(result.after.plans.has('plan-2')).toBe(true);
+        expect(result.after.state).toMatchObject({
+            activePlanId: null,
+            revision: 9,
+            currentWorkoutCount: 3,
+            updatedAtMs: NOW_MS,
+        });
+        expect(result.after.workouts.get('workout-1')).toMatchObject({
+            id: 'workout-1', planId: null, revision: 3, updatedAtMs: NOW_MS,
+        });
+        expect(result.after.workouts.get('workout-2')).toMatchObject({
+            id: 'workout-2', planId: null, lifecycle: 'skipped', revision: 3,
+        });
+        expect(result.response).toMatchObject({
+            removedPlanId: 'plan-1',
+            convertedWorkoutIds: ['workout-1', 'workout-2'],
+            permanentlyDeletedWorkoutIds: [],
+        });
+    });
+
+    it('permanently removes current plan workouts and decrements the total count', () => {
+        const result = applyTrainingPlanDeletion(snapshot(), request('delete-workouts'), NOW_MS);
+
+        expect(result.after.workouts.has('workout-1')).toBe(false);
+        expect(result.after.workouts.has('workout-2')).toBe(false);
+        expect(result.after.workouts.has('standalone')).toBe(true);
+        expect(result.after.state.currentWorkoutCount).toBe(1);
+        expect(result.response.permanentlyDeletedWorkoutIds).toEqual(['workout-1', 'workout-2']);
+        expect(result.response.convertedWorkoutIds).toEqual([]);
+    });
+
+    it('preserves a different active plan', () => {
+        const input = snapshot();
+        input.state.activePlanId = 'plan-2';
+        const result = applyTrainingPlanDeletion(input, request('convert-to-standalone'), NOW_MS);
+        expect(result.after.state.activePlanId).toBe('plan-2');
+    });
+
+    it('requires matching state and plan revisions', () => {
+        const bad = request('delete-workouts');
+        bad.expectedRevisions[0] = { scope: 'state', id: 'current', revision: 7 };
+        expect(() => applyTrainingPlanDeletion(snapshot(), bad, NOW_MS))
+            .toThrow(expect.objectContaining({ code: 'revision-conflict' }));
+    });
+
+    it('refuses deletion when the plan count proves the workout read was incomplete', () => {
+        const input = snapshot();
+        input.plans.set('plan-1', plan({ workoutCount: 3 }));
+        expect(() => applyTrainingPlanDeletion(input, request('delete-workouts'), NOW_MS))
+            .toThrow('workout count is inconsistent');
+    });
+});

--- a/functions/src/training-plans/delete-training-plan.ts
+++ b/functions/src/training-plans/delete-training-plan.ts
@@ -31,6 +31,7 @@ import {
 
 const DELETE_PLAN_RECEIPT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const RECURSIVE_DELETE_CONCURRENCY = 20;
+const TOMBSTONE_BATCH_SIZE = 400;
 
 interface PlanDeletionLockWorkoutV1 {
     id: string;
@@ -42,6 +43,7 @@ interface PlanDeletionLockV1 {
     mutationId: string;
     requestHash: string;
     planId: string;
+    stateRevision: number;
     planRevision: number;
     workoutDisposition: DeleteTrainingPlanRequestV1['workoutDisposition'];
     workouts: PlanDeletionLockWorkoutV1[];
@@ -183,6 +185,7 @@ function parsePlanDeletionLock(value: unknown): PlanDeletionLockV1 {
         || typeof record.mutationId !== 'string'
         || typeof record.requestHash !== 'string'
         || typeof record.planId !== 'string'
+        || !Number.isSafeInteger(record.stateRevision)
         || !Number.isSafeInteger(record.planRevision)
         || (record.workoutDisposition !== 'convert-to-standalone' && record.workoutDisposition !== 'delete-workouts')
         || !Array.isArray(record.workouts)
@@ -201,6 +204,7 @@ function parsePlanDeletionLock(value: unknown): PlanDeletionLockV1 {
         mutationId: record.mutationId,
         requestHash: record.requestHash,
         planId: record.planId,
+        stateRevision: record.stateRevision as number,
         planRevision: record.planRevision as number,
         workoutDisposition: record.workoutDisposition,
         workouts,
@@ -281,8 +285,29 @@ async function ensurePlanDeletionLock(
         }
         if (lockSnapshot?.exists) {
             const lock = parsePlanDeletionLock(documentData(lockSnapshot));
-            if (lock.requestHash !== requestHash || lock.mutationId !== request.mutationId) {
-                throw new TrainingScheduleMutationError('failed-precondition', 'This plan already has a deletion in progress.');
+            if (lock.workoutDisposition !== request.workoutDisposition) {
+                throw new TrainingScheduleMutationError(
+                    'failed-precondition',
+                    'This plan already has a deletion in progress with a different workout choice.',
+                );
+            }
+            requireExpectedRevision(request, 'state', 'current', lock.stateRevision);
+            requireExpectedRevision(request, 'plan', request.planId, lock.planRevision);
+            const canonicalReceiptSnapshot = await transaction.get(
+                stateRef.collection(TRAINING_PLAN_MUTATION_RECEIPTS_COLLECTION_ID).doc(lock.mutationId),
+            );
+            if (canonicalReceiptSnapshot.exists) {
+                const canonicalReceipt = documentData(canonicalReceiptSnapshot);
+                if (canonicalReceipt.requestHash !== lock.requestHash) {
+                    throw new TrainingScheduleMutationError(
+                        'failed-precondition',
+                        'The completed plan deletion does not match its cleanup lock.',
+                    );
+                }
+                return {
+                    kind: 'completed',
+                    response: parseStoredDeleteResponse(canonicalReceipt.response),
+                };
             }
             return { kind: 'pending', lock };
         }
@@ -294,6 +319,7 @@ async function ensurePlanDeletionLock(
             mutationId: request.mutationId,
             requestHash,
             planId: request.planId,
+            stateRevision: snapshot.state.revision,
             planRevision: plan.revision,
             workoutDisposition: request.workoutDisposition,
             workouts: [...applied.convertedWorkouts.size > 0
@@ -324,6 +350,7 @@ async function prepareStandaloneRevisionSnapshots(
     db: admin.firestore.Firestore,
     uid: string,
     lock: PlanDeletionLockV1,
+    nowMs: number,
 ): Promise<void> {
     if (lock.workoutDisposition !== 'convert-to-standalone' || lock.workouts.length === 0) return;
     const workoutsRef = db.collection('users').doc(uid).collection(SCHEDULED_WORKOUTS_COLLECTION_ID);
@@ -341,36 +368,44 @@ async function prepareStandaloneRevisionSnapshots(
     const revisionRefs = converted.map(workout => workoutsRef.doc(workout.id)
         .collection(TRAINING_PLAN_REVISIONS_COLLECTION_ID)
         .doc(trainingScheduleRevisionDocumentId(workout.revision)));
-    const revisionSnapshots = await db.getAll(...revisionRefs);
-    const missing: Array<{ ref: admin.firestore.DocumentReference; revision: StandaloneWorkoutRevisionDocumentV1 }> = [];
-    revisionSnapshots.forEach((snapshot, index) => {
-        const workout = converted[index];
-        const revision: StandaloneWorkoutRevisionDocumentV1 = {
-            schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
-            revision: workout.revision,
-            mutationId: lock.mutationId,
-            operationKind: 'delete-plan-convert-workouts',
-            createdAtMs: lock.createdAtMs,
-            snapshot: workout,
-        };
-        if (!snapshot.exists) {
-            missing.push({ ref: revisionRefs[index], revision });
-            return;
+    await db.runTransaction(async (transaction) => {
+        const deletionGuard = await getUserDeletionGuardStateInTransaction(db, transaction, uid, nowMs);
+        if (deletionGuard.shouldSkip) {
+            throw new TrainingScheduleMutationError(
+                'failed-precondition',
+                'This account is being deleted or is no longer available.',
+            );
         }
-        if (!valuesEqual(documentData(snapshot), revision)) {
-            throw new TrainingScheduleMutationError('failed-precondition', 'A workout revision conflicts with this plan deletion.');
-        }
+        const revisionSnapshots = await Promise.all(revisionRefs.map(ref => transaction.get(ref)));
+        revisionSnapshots.forEach((snapshot, index) => {
+            const workout = converted[index];
+            const revision: StandaloneWorkoutRevisionDocumentV1 = {
+                schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+                revision: workout.revision,
+                mutationId: lock.mutationId,
+                operationKind: 'delete-plan-convert-workouts',
+                createdAtMs: lock.createdAtMs,
+                snapshot: workout,
+            };
+            if (!snapshot.exists) {
+                transaction.create(revisionRefs[index], revision);
+                return;
+            }
+            if (!valuesEqual(documentData(snapshot), revision)) {
+                throw new TrainingScheduleMutationError(
+                    'failed-precondition',
+                    'A workout revision conflicts with this plan deletion.',
+                );
+            }
+        });
     });
-    if (missing.length === 0) return;
-    const batch = db.batch();
-    missing.forEach(item => batch.create(item.ref, item.revision));
-    await batch.commit();
 }
 
 async function preparePlanDeletionTombstones(
     db: admin.firestore.Firestore,
     uid: string,
     lock: PlanDeletionLockV1,
+    nowMs: number,
 ): Promise<void> {
     const stateRef = db.collection('users').doc(uid).collection('trainingPlanState').doc('current');
     const targets: Array<{ kind: 'plan' | 'workout'; id: string }> = [
@@ -390,21 +425,111 @@ async function preparePlanDeletionTombstones(
             lock.createdAtMs,
         ),
     }));
-    const existing = await db.getAll(...tombstones.map(tombstone => tombstone.ref));
-    const missing = tombstones.filter((tombstone, index) => {
-        if (!existing[index].exists) return true;
-        if (!valuesEqual(documentData(existing[index]), tombstone.value)) {
+    await db.runTransaction(async (transaction) => {
+        const deletionGuard = await getUserDeletionGuardStateInTransaction(db, transaction, uid, nowMs);
+        if (deletionGuard.shouldSkip) {
             throw new TrainingScheduleMutationError(
                 'failed-precondition',
-                'A deletion tombstone conflicts with this plan deletion.',
+                'This account is being deleted or is no longer available.',
             );
         }
-        return false;
+        const existing = await Promise.all(tombstones.map(tombstone => transaction.get(tombstone.ref)));
+        tombstones.forEach((tombstone, index) => {
+            if (!existing[index].exists) {
+                transaction.create(tombstone.ref, tombstone.value);
+                return;
+            }
+            if (!valuesEqual(documentData(existing[index]), tombstone.value)) {
+                throw new TrainingScheduleMutationError(
+                    'failed-precondition',
+                    'A deletion tombstone conflicts with this plan deletion.',
+                );
+            }
+        });
     });
-    if (missing.length === 0) return;
-    const batch = db.batch();
-    missing.forEach(tombstone => batch.create(tombstone.ref, tombstone.value));
-    await batch.commit();
+}
+
+async function prepareResidualWorkoutTombstones(
+    db: admin.firestore.Firestore,
+    uid: string,
+    workoutIds: string[],
+    mutationId: string,
+    createdAtMs: number,
+    nowMs: number,
+): Promise<void> {
+    const stateRef = db.collection('users').doc(uid).collection('trainingPlanState').doc('current');
+    const tombstonesRef = stateRef.collection(TRAINING_SCHEDULE_DELETION_TOMBSTONES_COLLECTION_ID);
+    for (let index = 0; index < workoutIds.length; index += TOMBSTONE_BATCH_SIZE) {
+        const values = workoutIds.slice(index, index + TOMBSTONE_BATCH_SIZE).map(workoutId => ({
+            ref: tombstonesRef.doc(trainingScheduleDeletionTombstoneDocumentId('workout', workoutId)),
+            value: buildTrainingScheduleDeletionTombstone('workout', workoutId, mutationId, createdAtMs),
+        }));
+        const shouldContinue = await db.runTransaction(async (transaction) => {
+            const deletionGuard = await getUserDeletionGuardStateInTransaction(
+                db,
+                transaction,
+                uid,
+                nowMs,
+            );
+            if (deletionGuard.shouldSkip) return false;
+            const existing = await Promise.all(values.map(value => transaction.get(value.ref)));
+            values.forEach((value, valueIndex) => {
+                if (existing[valueIndex].exists) {
+                    if (!valuesEqual(documentData(existing[valueIndex]), value.value)) {
+                        throw new TrainingScheduleMutationError(
+                            'failed-precondition',
+                            'A deletion tombstone conflicts with this plan cleanup.',
+                        );
+                    }
+                    return;
+                }
+                transaction.create(value.ref, value.value);
+            });
+            return true;
+        });
+        if (!shouldContinue) return;
+    }
+}
+
+async function persistPlanDeletionResumeReceipt(
+    db: admin.firestore.Firestore,
+    uid: string,
+    request: DeleteTrainingPlanRequestV1,
+    requestHash: string,
+    response: DeleteTrainingPlanResponseV1,
+    nowMs: number,
+): Promise<void> {
+    if (request.mutationId === response.mutationId) return;
+    const receiptRef = db.collection('users').doc(uid)
+        .collection('trainingPlanState').doc('current')
+        .collection(TRAINING_PLAN_MUTATION_RECEIPTS_COLLECTION_ID).doc(request.mutationId);
+    await db.runTransaction(async (transaction) => {
+        const deletionGuard = await getUserDeletionGuardStateInTransaction(db, transaction, uid, nowMs);
+        if (deletionGuard.shouldSkip) {
+            throw new TrainingScheduleMutationError(
+                'failed-precondition',
+                'This account is being deleted or is no longer available.',
+            );
+        }
+        const snapshot = await transaction.get(receiptRef);
+        if (snapshot.exists) {
+            const receipt = documentData(snapshot);
+            if (receipt.requestHash !== requestHash || !valuesEqual(receipt.response, response)) {
+                throw new TrainingScheduleMutationError(
+                    'failed-precondition',
+                    'This mutation ID was already used differently.',
+                );
+            }
+            return;
+        }
+        transaction.create(receiptRef, {
+            schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+            requestHash,
+            response,
+            createdAtMs: nowMs,
+            expireAt: Timestamp.fromMillis(nowMs + DELETE_PLAN_RECEIPT_RETENTION_MS),
+        });
+    });
 }
 
 function validateLockedWorkouts(snapshot: TrainingScheduleSnapshotV1, lock: PlanDeletionLockV1): void {
@@ -487,7 +612,6 @@ async function finalizePlanDeletion(
             createdAtMs: nowMs,
             expireAt: Timestamp.fromMillis(nowMs + DELETE_PLAN_RECEIPT_RETENTION_MS),
         });
-        transaction.delete(lockRef);
         return applied.response;
     });
 }
@@ -505,16 +629,42 @@ async function cleanupDeletedPlanData(
     db: admin.firestore.Firestore,
     uid: string,
     response: DeleteTrainingPlanResponseV1,
+    nowMs: number,
 ): Promise<void> {
     const userRef = db.collection('users').doc(uid);
     const workoutsRef = userRef.collection(SCHEDULED_WORKOUTS_COLLECTION_ID);
     await db.recursiveDelete(userRef.collection(TRAINING_PLANS_COLLECTION_ID).doc(response.removedPlanId));
-    await recursivelyDeleteInChunks(
-        db,
-        response.permanentlyDeletedWorkoutIds.map(id => workoutsRef.doc(id)),
-    );
     const residual = await workoutsRef.where('planId', '==', response.removedPlanId).get();
-    await recursivelyDeleteInChunks(db, residual.docs.map(snapshot => snapshot.ref));
+    const workoutRefs = new Map<string, admin.firestore.DocumentReference>();
+    response.permanentlyDeletedWorkoutIds.forEach(id => workoutRefs.set(id, workoutsRef.doc(id)));
+    residual.docs.forEach(snapshot => workoutRefs.set(snapshot.id, snapshot.ref));
+    const residualWorkoutIds = residual.docs.map(snapshot => snapshot.id).sort();
+    await prepareResidualWorkoutTombstones(
+        db,
+        uid,
+        residualWorkoutIds,
+        response.mutationId,
+        response.state.updatedAtMs,
+        nowMs,
+    );
+    await recursivelyDeleteInChunks(db, [...workoutRefs.values()]);
+
+    const stateRef = userRef.collection('trainingPlanState').doc('current');
+    const lockRef = stateRef.collection(TRAINING_PLAN_DELETION_LOCKS_COLLECTION_ID).doc(response.removedPlanId);
+    await db.runTransaction(async (transaction) => {
+        const deletionGuard = await getUserDeletionGuardStateInTransaction(db, transaction, uid, nowMs);
+        if (deletionGuard.shouldSkip) return;
+        const lockSnapshot = await transaction.get(lockRef);
+        if (!lockSnapshot.exists) return;
+        const lock = parsePlanDeletionLock(documentData(lockSnapshot));
+        if (lock.mutationId !== response.mutationId) {
+            throw new TrainingScheduleMutationError(
+                'failed-precondition',
+                'A different plan deletion owns the cleanup lock.',
+            );
+        }
+        transaction.delete(lockRef);
+    });
 }
 
 export async function deleteTrainingPlanForUser(
@@ -529,10 +679,23 @@ export async function deleteTrainingPlanForUser(
     const response = lockResult.kind === 'completed'
         ? lockResult.response
         : await (async () => {
-            await preparePlanDeletionTombstones(db, uid, lockResult.lock);
-            await prepareStandaloneRevisionSnapshots(db, uid, lockResult.lock);
-            return finalizePlanDeletion(db, uid, request, requestHash, lockResult.lock, nowMs);
+            await preparePlanDeletionTombstones(db, uid, lockResult.lock, nowMs);
+            await prepareStandaloneRevisionSnapshots(db, uid, lockResult.lock, nowMs);
+            const lockedRequest: DeleteTrainingPlanRequestV1 = {
+                ...request,
+                mutationId: lockResult.lock.mutationId,
+                workoutDisposition: lockResult.lock.workoutDisposition,
+            };
+            return finalizePlanDeletion(
+                db,
+                uid,
+                lockedRequest,
+                lockResult.lock.requestHash,
+                lockResult.lock,
+                nowMs,
+            );
         })();
-    await cleanupDeletedPlanData(db, uid, response);
+    await persistPlanDeletionResumeReceipt(db, uid, request, requestHash, response, nowMs);
+    await cleanupDeletedPlanData(db, uid, response, nowMs);
     return response;
 }

--- a/functions/src/training-plans/delete-training-plan.ts
+++ b/functions/src/training-plans/delete-training-plan.ts
@@ -1,0 +1,538 @@
+import * as admin from 'firebase-admin';
+import { Timestamp } from 'firebase-admin/firestore';
+import {
+    SCHEDULED_WORKOUTS_COLLECTION_ID,
+    TRAINING_PLAN_DELETION_LOCKS_COLLECTION_ID,
+    TRAINING_PLAN_MUTATION_RECEIPTS_COLLECTION_ID,
+    TRAINING_PLAN_REVISIONS_COLLECTION_ID,
+    TRAINING_PLAN_SCHEMA_VERSION,
+    TRAINING_PLANS_COLLECTION_ID,
+    TRAINING_SCHEDULE_DELETION_TOMBSTONES_COLLECTION_ID,
+    parseScheduledWorkoutV1,
+    parseTrainingPlanStateV1,
+    parseTrainingPlanV1,
+    type DeleteTrainingPlanRequestV1,
+    type DeleteTrainingPlanResponseV1,
+    type ScheduledWorkoutV1,
+} from '../../../shared/training-plans';
+import { getUserDeletionGuardStateInTransaction } from '../shared/user-deletion-guard';
+import {
+    TrainingScheduleMutationError,
+    cloneTrainingScheduleSnapshot,
+    type TrainingScheduleSnapshotV1,
+} from './mutation';
+import {
+    buildTrainingScheduleDeletionTombstone,
+    hashTrainingScheduleRequestPayload,
+    trainingScheduleDeletionTombstoneDocumentId,
+    trainingScheduleRevisionDocumentId,
+    type StandaloneWorkoutRevisionDocumentV1,
+} from './persistence';
+
+const DELETE_PLAN_RECEIPT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+const RECURSIVE_DELETE_CONCURRENCY = 20;
+
+interface PlanDeletionLockWorkoutV1 {
+    id: string;
+    revision: number;
+}
+
+interface PlanDeletionLockV1 {
+    schemaVersion: typeof TRAINING_PLAN_SCHEMA_VERSION;
+    mutationId: string;
+    requestHash: string;
+    planId: string;
+    planRevision: number;
+    workoutDisposition: DeleteTrainingPlanRequestV1['workoutDisposition'];
+    workouts: PlanDeletionLockWorkoutV1[];
+    createdAtMs: number;
+}
+
+export interface AppliedTrainingPlanDeletionV1 {
+    before: TrainingScheduleSnapshotV1;
+    after: TrainingScheduleSnapshotV1;
+    convertedWorkouts: Map<string, ScheduledWorkoutV1>;
+    response: DeleteTrainingPlanResponseV1;
+}
+
+function documentData(snapshot: admin.firestore.DocumentSnapshot): Record<string, unknown> {
+    return (snapshot.data() ?? {}) as Record<string, unknown>;
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+    return hashTrainingScheduleRequestPayload(left) === hashTrainingScheduleRequestPayload(right);
+}
+
+function requireExpectedRevision(
+    request: DeleteTrainingPlanRequestV1,
+    scope: 'state' | 'plan',
+    id: string,
+    actual: number,
+): void {
+    const expected = request.expectedRevisions.find(item => item.scope === scope && item.id === id);
+    if (!expected || expected.revision !== actual) {
+        throw new TrainingScheduleMutationError(
+            'revision-conflict',
+            `${scope} ${id} changed before the plan could be deleted.`,
+        );
+    }
+}
+
+function currentPlanWorkouts(snapshot: TrainingScheduleSnapshotV1, planId: string): ScheduledWorkoutV1[] {
+    return [...snapshot.workouts.values()]
+        .filter(workout => workout.planId === planId && workout.lifecycle !== 'deleted')
+        .sort((left, right) => left.id.localeCompare(right.id));
+}
+
+export function applyTrainingPlanDeletion(
+    snapshotInput: TrainingScheduleSnapshotV1,
+    request: DeleteTrainingPlanRequestV1,
+    nowMs: number,
+): AppliedTrainingPlanDeletionV1 {
+    const before = cloneTrainingScheduleSnapshot(snapshotInput);
+    const after = cloneTrainingScheduleSnapshot(snapshotInput);
+    const plan = before.plans.get(request.planId);
+    if (!plan) throw new TrainingScheduleMutationError('not-found', 'The training plan was not found.');
+    requireExpectedRevision(request, 'state', 'current', before.state.revision);
+    requireExpectedRevision(request, 'plan', request.planId, plan.revision);
+
+    const planWorkouts = currentPlanWorkouts(before, request.planId);
+    if (plan.workoutCount !== planWorkouts.length) {
+        throw new TrainingScheduleMutationError(
+            'failed-precondition',
+            'The plan workout count is inconsistent. Reload the schedule before deleting this plan.',
+        );
+    }
+
+    const convertedWorkouts = new Map<string, ScheduledWorkoutV1>();
+    const permanentlyDeletedWorkoutIds: string[] = [];
+    for (const current of planWorkouts) {
+        if (request.workoutDisposition === 'convert-to-standalone') {
+            const converted = parseScheduledWorkoutV1({
+                ...current,
+                planId: null,
+                revision: current.revision + 1,
+                updatedAtMs: nowMs,
+            });
+            after.workouts.set(current.id, converted);
+            convertedWorkouts.set(current.id, converted);
+        } else {
+            after.workouts.delete(current.id);
+            permanentlyDeletedWorkoutIds.push(current.id);
+        }
+    }
+    after.plans.delete(request.planId);
+    after.state = parseTrainingPlanStateV1({
+        ...after.state,
+        activePlanId: after.state.activePlanId === request.planId ? null : after.state.activePlanId,
+        revision: before.state.revision + 1,
+        currentWorkoutCount: request.workoutDisposition === 'delete-workouts'
+            ? before.state.currentWorkoutCount - planWorkouts.length
+            : before.state.currentWorkoutCount,
+        updatedAtMs: nowMs,
+    });
+
+    const convertedWorkoutIds = [...convertedWorkouts.keys()].sort();
+    permanentlyDeletedWorkoutIds.sort();
+    return {
+        before,
+        after,
+        convertedWorkouts,
+        response: {
+            mutationId: request.mutationId,
+            state: after.state,
+            removedPlanId: request.planId,
+            workoutDisposition: request.workoutDisposition,
+            convertedWorkoutIds,
+            permanentlyDeletedWorkoutIds,
+        },
+    };
+}
+
+function parseStoredDeleteResponse(value: unknown): DeleteTrainingPlanResponseV1 {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('Invalid plan-deletion receipt.');
+    const record = value as Record<string, unknown>;
+    if (
+        typeof record.mutationId !== 'string'
+        || typeof record.removedPlanId !== 'string'
+        || (record.workoutDisposition !== 'convert-to-standalone' && record.workoutDisposition !== 'delete-workouts')
+        || !Array.isArray(record.convertedWorkoutIds)
+        || !Array.isArray(record.permanentlyDeletedWorkoutIds)
+    ) throw new Error('Invalid plan-deletion receipt.');
+    const convertedWorkoutIds = record.convertedWorkoutIds;
+    const permanentlyDeletedWorkoutIds = record.permanentlyDeletedWorkoutIds;
+    if (
+        convertedWorkoutIds.some(id => typeof id !== 'string')
+        || permanentlyDeletedWorkoutIds.some(id => typeof id !== 'string')
+    ) throw new Error('Invalid plan-deletion receipt.');
+    return {
+        mutationId: record.mutationId,
+        state: parseTrainingPlanStateV1(record.state),
+        removedPlanId: record.removedPlanId,
+        workoutDisposition: record.workoutDisposition,
+        convertedWorkoutIds: convertedWorkoutIds as string[],
+        permanentlyDeletedWorkoutIds: permanentlyDeletedWorkoutIds as string[],
+    };
+}
+
+function parsePlanDeletionLock(value: unknown): PlanDeletionLockV1 {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('Invalid plan-deletion lock.');
+    const record = value as Record<string, unknown>;
+    if (
+        record.schemaVersion !== TRAINING_PLAN_SCHEMA_VERSION
+        || typeof record.mutationId !== 'string'
+        || typeof record.requestHash !== 'string'
+        || typeof record.planId !== 'string'
+        || !Number.isSafeInteger(record.planRevision)
+        || (record.workoutDisposition !== 'convert-to-standalone' && record.workoutDisposition !== 'delete-workouts')
+        || !Array.isArray(record.workouts)
+        || !Number.isSafeInteger(record.createdAtMs)
+    ) throw new Error('Invalid plan-deletion lock.');
+    const workouts = record.workouts.map((value) => {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('Invalid plan-deletion lock workout.');
+        const workout = value as Record<string, unknown>;
+        if (typeof workout.id !== 'string' || !Number.isSafeInteger(workout.revision)) {
+            throw new Error('Invalid plan-deletion lock workout.');
+        }
+        return { id: workout.id, revision: workout.revision as number };
+    });
+    return {
+        schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+        mutationId: record.mutationId,
+        requestHash: record.requestHash,
+        planId: record.planId,
+        planRevision: record.planRevision as number,
+        workoutDisposition: record.workoutDisposition,
+        workouts,
+        createdAtMs: record.createdAtMs as number,
+    };
+}
+
+function snapshotFromDocuments(
+    stateSnapshot: admin.firestore.DocumentSnapshot,
+    planSnapshot: admin.firestore.DocumentSnapshot,
+    workoutSnapshots: admin.firestore.QueryDocumentSnapshot[],
+): TrainingScheduleSnapshotV1 {
+    if (!stateSnapshot.exists) {
+        throw new TrainingScheduleMutationError('failed-precondition', 'Training schedule state is unavailable.');
+    }
+    if (!planSnapshot.exists) throw new TrainingScheduleMutationError('not-found', 'The training plan was not found.');
+    const plan = parseTrainingPlanV1(documentData(planSnapshot));
+    if (plan.id !== planSnapshot.id) throw new Error('Training plan document ID mismatch.');
+    const workouts = workoutSnapshots.map((snapshot) => {
+        const parsed = parseScheduledWorkoutV1(documentData(snapshot));
+        if (parsed.id !== snapshot.id) throw new Error('Scheduled workout document ID mismatch.');
+        return parsed;
+    });
+    return {
+        state: parseTrainingPlanStateV1(documentData(stateSnapshot)),
+        plans: new Map([[plan.id, plan]]),
+        workouts: new Map(workouts.map(workout => [workout.id, workout])),
+    };
+}
+
+type LockResult =
+    | { kind: 'completed'; response: DeleteTrainingPlanResponseV1 }
+    | { kind: 'pending'; lock: PlanDeletionLockV1 };
+
+async function ensurePlanDeletionLock(
+    db: admin.firestore.Firestore,
+    uid: string,
+    request: DeleteTrainingPlanRequestV1,
+    requestHash: string,
+    nowMs: number,
+): Promise<LockResult> {
+    const userRef = db.collection('users').doc(uid);
+    const stateRef = userRef.collection('trainingPlanState').doc('current');
+    const planRef = userRef.collection(TRAINING_PLANS_COLLECTION_ID).doc(request.planId);
+    const workoutsQuery = userRef.collection(SCHEDULED_WORKOUTS_COLLECTION_ID)
+        .where('planId', '==', request.planId)
+        .where('lifecycle', 'in', ['planned', 'skipped']);
+    const receiptRef = stateRef.collection(TRAINING_PLAN_MUTATION_RECEIPTS_COLLECTION_ID).doc(request.mutationId);
+    const locksRef = stateRef.collection(TRAINING_PLAN_DELETION_LOCKS_COLLECTION_ID);
+    const lockRef = locksRef.doc(request.planId);
+
+    return db.runTransaction(async (transaction) => {
+        const deletionGuard = await getUserDeletionGuardStateInTransaction(db, transaction, uid, nowMs);
+        if (deletionGuard.shouldSkip) {
+            throw new TrainingScheduleMutationError('failed-precondition', 'This account is being deleted or is no longer available.');
+        }
+        const [receiptSnapshot, lockSnapshots, stateSnapshot, planSnapshot, workoutSnapshots] = await Promise.all([
+            transaction.get(receiptRef),
+            transaction.get(locksRef),
+            transaction.get(stateRef),
+            transaction.get(planRef),
+            transaction.get(workoutsQuery),
+        ]);
+        if (receiptSnapshot.exists) {
+            const receipt = documentData(receiptSnapshot);
+            if (receipt.requestHash !== requestHash) {
+                throw new TrainingScheduleMutationError('failed-precondition', 'This mutation ID was already used differently.');
+            }
+            return { kind: 'completed', response: parseStoredDeleteResponse(receipt.response) };
+        }
+        const lockSnapshot = lockSnapshots.docs.find(snapshot => snapshot.id === request.planId);
+        const otherLockExists = lockSnapshots.docs.some(snapshot => snapshot.id !== request.planId);
+        if (otherLockExists) {
+            throw new TrainingScheduleMutationError(
+                'failed-precondition',
+                'Another training plan deletion is in progress. Retry this deletion after it finishes.',
+            );
+        }
+        if (lockSnapshot?.exists) {
+            const lock = parsePlanDeletionLock(documentData(lockSnapshot));
+            if (lock.requestHash !== requestHash || lock.mutationId !== request.mutationId) {
+                throw new TrainingScheduleMutationError('failed-precondition', 'This plan already has a deletion in progress.');
+            }
+            return { kind: 'pending', lock };
+        }
+        const snapshot = snapshotFromDocuments(stateSnapshot, planSnapshot, workoutSnapshots.docs);
+        const applied = applyTrainingPlanDeletion(snapshot, request, nowMs);
+        const plan = snapshot.plans.get(request.planId)!;
+        const lock: PlanDeletionLockV1 = {
+            schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+            mutationId: request.mutationId,
+            requestHash,
+            planId: request.planId,
+            planRevision: plan.revision,
+            workoutDisposition: request.workoutDisposition,
+            workouts: [...applied.convertedWorkouts.size > 0
+                ? applied.convertedWorkouts.values()
+                : currentPlanWorkouts(snapshot, request.planId)]
+                .map(workout => ({
+                    id: workout.id,
+                    revision: snapshot.workouts.get(workout.id)!.revision,
+                }))
+                .sort((left, right) => left.id.localeCompare(right.id)),
+            createdAtMs: nowMs,
+        };
+        transaction.create(lockRef, lock);
+        return { kind: 'pending', lock };
+    });
+}
+
+function convertedWorkoutForLock(current: ScheduledWorkoutV1, lock: PlanDeletionLockV1): ScheduledWorkoutV1 {
+    return parseScheduledWorkoutV1({
+        ...current,
+        planId: null,
+        revision: current.revision + 1,
+        updatedAtMs: lock.createdAtMs,
+    });
+}
+
+async function prepareStandaloneRevisionSnapshots(
+    db: admin.firestore.Firestore,
+    uid: string,
+    lock: PlanDeletionLockV1,
+): Promise<void> {
+    if (lock.workoutDisposition !== 'convert-to-standalone' || lock.workouts.length === 0) return;
+    const workoutsRef = db.collection('users').doc(uid).collection(SCHEDULED_WORKOUTS_COLLECTION_ID);
+    const currentRefs = lock.workouts.map(workout => workoutsRef.doc(workout.id));
+    const currentSnapshots = await db.getAll(...currentRefs);
+    const converted = currentSnapshots.map((snapshot, index) => {
+        if (!snapshot.exists) throw new TrainingScheduleMutationError('failed-precondition', 'A locked plan workout is missing.');
+        const current = parseScheduledWorkoutV1(documentData(snapshot));
+        const expected = lock.workouts[index];
+        if (current.planId !== lock.planId || current.revision !== expected.revision || current.lifecycle === 'deleted') {
+            throw new TrainingScheduleMutationError('revision-conflict', 'A locked plan workout changed during deletion.');
+        }
+        return convertedWorkoutForLock(current, lock);
+    });
+    const revisionRefs = converted.map(workout => workoutsRef.doc(workout.id)
+        .collection(TRAINING_PLAN_REVISIONS_COLLECTION_ID)
+        .doc(trainingScheduleRevisionDocumentId(workout.revision)));
+    const revisionSnapshots = await db.getAll(...revisionRefs);
+    const missing: Array<{ ref: admin.firestore.DocumentReference; revision: StandaloneWorkoutRevisionDocumentV1 }> = [];
+    revisionSnapshots.forEach((snapshot, index) => {
+        const workout = converted[index];
+        const revision: StandaloneWorkoutRevisionDocumentV1 = {
+            schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+            revision: workout.revision,
+            mutationId: lock.mutationId,
+            operationKind: 'delete-plan-convert-workouts',
+            createdAtMs: lock.createdAtMs,
+            snapshot: workout,
+        };
+        if (!snapshot.exists) {
+            missing.push({ ref: revisionRefs[index], revision });
+            return;
+        }
+        if (!valuesEqual(documentData(snapshot), revision)) {
+            throw new TrainingScheduleMutationError('failed-precondition', 'A workout revision conflicts with this plan deletion.');
+        }
+    });
+    if (missing.length === 0) return;
+    const batch = db.batch();
+    missing.forEach(item => batch.create(item.ref, item.revision));
+    await batch.commit();
+}
+
+async function preparePlanDeletionTombstones(
+    db: admin.firestore.Firestore,
+    uid: string,
+    lock: PlanDeletionLockV1,
+): Promise<void> {
+    const stateRef = db.collection('users').doc(uid).collection('trainingPlanState').doc('current');
+    const targets: Array<{ kind: 'plan' | 'workout'; id: string }> = [
+        { kind: 'plan', id: lock.planId },
+        ...(lock.workoutDisposition === 'delete-workouts'
+            ? lock.workouts.map(workout => ({ kind: 'workout' as const, id: workout.id }))
+            : []),
+    ];
+    const tombstones = targets.map(target => ({
+        ref: stateRef.collection(TRAINING_SCHEDULE_DELETION_TOMBSTONES_COLLECTION_ID).doc(
+            trainingScheduleDeletionTombstoneDocumentId(target.kind, target.id),
+        ),
+        value: buildTrainingScheduleDeletionTombstone(
+            target.kind,
+            target.id,
+            lock.mutationId,
+            lock.createdAtMs,
+        ),
+    }));
+    const existing = await db.getAll(...tombstones.map(tombstone => tombstone.ref));
+    const missing = tombstones.filter((tombstone, index) => {
+        if (!existing[index].exists) return true;
+        if (!valuesEqual(documentData(existing[index]), tombstone.value)) {
+            throw new TrainingScheduleMutationError(
+                'failed-precondition',
+                'A deletion tombstone conflicts with this plan deletion.',
+            );
+        }
+        return false;
+    });
+    if (missing.length === 0) return;
+    const batch = db.batch();
+    missing.forEach(tombstone => batch.create(tombstone.ref, tombstone.value));
+    await batch.commit();
+}
+
+function validateLockedWorkouts(snapshot: TrainingScheduleSnapshotV1, lock: PlanDeletionLockV1): void {
+    const current = currentPlanWorkouts(snapshot, lock.planId);
+    if (current.length !== lock.workouts.length) {
+        throw new TrainingScheduleMutationError('revision-conflict', 'The locked plan workout set changed during deletion.');
+    }
+    current.forEach((workout, index) => {
+        const expected = lock.workouts[index];
+        if (workout.id !== expected.id || workout.revision !== expected.revision) {
+            throw new TrainingScheduleMutationError('revision-conflict', 'A locked plan workout changed during deletion.');
+        }
+    });
+}
+
+async function finalizePlanDeletion(
+    db: admin.firestore.Firestore,
+    uid: string,
+    request: DeleteTrainingPlanRequestV1,
+    requestHash: string,
+    lock: PlanDeletionLockV1,
+    nowMs: number,
+): Promise<DeleteTrainingPlanResponseV1> {
+    const userRef = db.collection('users').doc(uid);
+    const stateRef = userRef.collection('trainingPlanState').doc('current');
+    const planRef = userRef.collection(TRAINING_PLANS_COLLECTION_ID).doc(request.planId);
+    const workoutsRef = userRef.collection(SCHEDULED_WORKOUTS_COLLECTION_ID);
+    const workoutsQuery = workoutsRef.where('planId', '==', request.planId)
+        .where('lifecycle', 'in', ['planned', 'skipped']);
+    const receiptRef = stateRef.collection(TRAINING_PLAN_MUTATION_RECEIPTS_COLLECTION_ID).doc(request.mutationId);
+    const lockRef = stateRef.collection(TRAINING_PLAN_DELETION_LOCKS_COLLECTION_ID).doc(request.planId);
+
+    return db.runTransaction(async (transaction) => {
+        const deletionGuard = await getUserDeletionGuardStateInTransaction(db, transaction, uid, nowMs);
+        if (deletionGuard.shouldSkip) {
+            throw new TrainingScheduleMutationError('failed-precondition', 'This account is being deleted or is no longer available.');
+        }
+        const [receiptSnapshot, lockSnapshot, stateSnapshot, planSnapshot, workoutSnapshots] = await Promise.all([
+            transaction.get(receiptRef),
+            transaction.get(lockRef),
+            transaction.get(stateRef),
+            transaction.get(planRef),
+            transaction.get(workoutsQuery),
+        ]);
+        if (receiptSnapshot.exists) {
+            const receipt = documentData(receiptSnapshot);
+            if (receipt.requestHash !== requestHash) {
+                throw new TrainingScheduleMutationError('failed-precondition', 'This mutation ID was already used differently.');
+            }
+            return parseStoredDeleteResponse(receipt.response);
+        }
+        if (!lockSnapshot.exists || !valuesEqual(parsePlanDeletionLock(documentData(lockSnapshot)), lock)) {
+            throw new TrainingScheduleMutationError('failed-precondition', 'The plan-deletion lock is unavailable.');
+        }
+        const snapshot = snapshotFromDocuments(stateSnapshot, planSnapshot, workoutSnapshots.docs);
+        const currentPlan = snapshot.plans.get(request.planId)!;
+        if (currentPlan.revision !== lock.planRevision) {
+            throw new TrainingScheduleMutationError('revision-conflict', 'The locked plan changed during deletion.');
+        }
+        validateLockedWorkouts(snapshot, lock);
+        const finalRequest: DeleteTrainingPlanRequestV1 = {
+            ...request,
+            expectedRevisions: [
+                { scope: 'state', id: 'current', revision: snapshot.state.revision },
+                { scope: 'plan', id: request.planId, revision: currentPlan.revision },
+            ],
+        };
+        const applied = applyTrainingPlanDeletion(snapshot, finalRequest, lock.createdAtMs);
+        transaction.set(stateRef, applied.after.state);
+        if (request.workoutDisposition === 'convert-to-standalone') {
+            applied.convertedWorkouts.forEach((workout) => transaction.set(workoutsRef.doc(workout.id), workout));
+        } else {
+            applied.response.permanentlyDeletedWorkoutIds.forEach(id => transaction.delete(workoutsRef.doc(id)));
+        }
+        transaction.delete(planRef);
+        transaction.create(receiptRef, {
+            schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+            requestHash,
+            response: applied.response,
+            createdAtMs: nowMs,
+            expireAt: Timestamp.fromMillis(nowMs + DELETE_PLAN_RECEIPT_RETENTION_MS),
+        });
+        transaction.delete(lockRef);
+        return applied.response;
+    });
+}
+
+async function recursivelyDeleteInChunks(
+    db: admin.firestore.Firestore,
+    refs: admin.firestore.DocumentReference[],
+): Promise<void> {
+    for (let index = 0; index < refs.length; index += RECURSIVE_DELETE_CONCURRENCY) {
+        await Promise.all(refs.slice(index, index + RECURSIVE_DELETE_CONCURRENCY).map(ref => db.recursiveDelete(ref)));
+    }
+}
+
+async function cleanupDeletedPlanData(
+    db: admin.firestore.Firestore,
+    uid: string,
+    response: DeleteTrainingPlanResponseV1,
+): Promise<void> {
+    const userRef = db.collection('users').doc(uid);
+    const workoutsRef = userRef.collection(SCHEDULED_WORKOUTS_COLLECTION_ID);
+    await db.recursiveDelete(userRef.collection(TRAINING_PLANS_COLLECTION_ID).doc(response.removedPlanId));
+    await recursivelyDeleteInChunks(
+        db,
+        response.permanentlyDeletedWorkoutIds.map(id => workoutsRef.doc(id)),
+    );
+    const residual = await workoutsRef.where('planId', '==', response.removedPlanId).get();
+    await recursivelyDeleteInChunks(db, residual.docs.map(snapshot => snapshot.ref));
+}
+
+export async function deleteTrainingPlanForUser(
+    uid: string,
+    request: DeleteTrainingPlanRequestV1,
+    options: { db?: admin.firestore.Firestore; nowMs?: number } = {},
+): Promise<DeleteTrainingPlanResponseV1> {
+    const db = options.db ?? admin.firestore();
+    const nowMs = options.nowMs ?? Date.now();
+    const requestHash = hashTrainingScheduleRequestPayload(request);
+    const lockResult = await ensurePlanDeletionLock(db, uid, request, requestHash, nowMs);
+    const response = lockResult.kind === 'completed'
+        ? lockResult.response
+        : await (async () => {
+            await preparePlanDeletionTombstones(db, uid, lockResult.lock);
+            await prepareStandaloneRevisionSnapshots(db, uid, lockResult.lock);
+            return finalizePlanDeletion(db, uid, request, requestHash, lockResult.lock, nowMs);
+        })();
+    await cleanupDeletedPlanData(db, uid, response);
+    return response;
+}

--- a/functions/src/training-plans/deletion-lock.ts
+++ b/functions/src/training-plans/deletion-lock.ts
@@ -1,0 +1,16 @@
+import * as admin from 'firebase-admin';
+import { TRAINING_PLAN_DELETION_LOCKS_COLLECTION_ID } from '../../../shared/training-plans';
+import { TrainingScheduleMutationError } from './mutation';
+
+export async function assertNoTrainingPlanDeletionInProgress(
+    transaction: admin.firestore.Transaction,
+    stateRef: admin.firestore.DocumentReference,
+): Promise<void> {
+    const snapshot = await transaction.get(stateRef.collection(TRAINING_PLAN_DELETION_LOCKS_COLLECTION_ID));
+    if (snapshot.docs.length > 0) {
+        throw new TrainingScheduleMutationError(
+            'failed-precondition',
+            'A training plan deletion is in progress. Retry this change after deletion finishes.',
+        );
+    }
+}

--- a/functions/src/training-plans/history-callables.spec.ts
+++ b/functions/src/training-plans/history-callables.spec.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+    enforceAppCheck: vi.fn(),
+    getHistory: vi.fn(),
+    previewRestore: vi.fn(),
+    loggerError: vi.fn(),
+}));
+
+vi.mock('firebase-functions/v2/https', () => ({
+    HttpsError: class MockHttpsError extends Error {
+        constructor(public readonly code: string, message: string) { super(message); }
+    },
+    onCall: (_options: unknown, handler: unknown) => handler,
+}));
+vi.mock('firebase-functions/logger', () => ({ error: hoisted.loggerError }));
+vi.mock('../../../shared/functions-manifest', () => ({
+    FUNCTIONS_MANIFEST: {
+        getTrainingScheduleHistory: { region: 'europe-west2' },
+        previewTrainingScheduleRestore: { region: 'europe-west2' },
+    },
+}));
+vi.mock('../utils', () => ({ enforceAppCheck: hoisted.enforceAppCheck }));
+vi.mock('./history', async () => {
+    const actual = await vi.importActual<typeof import('./history')>('./history');
+    return {
+        ...actual,
+        getTrainingScheduleHistoryForUser: hoisted.getHistory,
+        previewTrainingScheduleRestoreForUser: hoisted.previewRestore,
+    };
+});
+
+import { getTrainingScheduleHistory, previewTrainingScheduleRestore } from './history-callables';
+
+describe('training schedule history callables', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        hoisted.getHistory.mockResolvedValue({ entries: [] });
+        hoisted.previewRestore.mockResolvedValue({ changedWorkoutIds: [] });
+    });
+
+    it.each([
+        ['history', getTrainingScheduleHistory],
+        ['preview', previewTrainingScheduleRestore],
+    ] as const)('requires auth and App Check for %s', async (_label, callable) => {
+        await expect((callable as never as (request: unknown) => Promise<unknown>)({ data: {} }))
+            .rejects.toMatchObject({ code: 'unauthenticated' });
+        expect(hoisted.enforceAppCheck).not.toHaveBeenCalled();
+
+        hoisted.enforceAppCheck.mockImplementationOnce(() => { throw new Error('App Check verification failed.'); });
+        await expect((callable as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'user-1' }, data: {},
+        })).rejects.toThrow('App Check verification failed');
+    });
+
+    it('bounds history input and derives the owner from auth', async () => {
+        await (getTrainingScheduleHistory as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'owner' }, app: {},
+            data: { scope: { kind: 'plan', id: 'plan-1' }, limit: 10 },
+        });
+        expect(hoisted.getHistory).toHaveBeenCalledWith('owner', {
+            scope: { kind: 'plan', id: 'plan-1' }, limit: 10,
+        });
+
+        await expect((getTrainingScheduleHistory as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'owner' }, app: {},
+            data: { scope: { kind: 'plan', id: 'plan-1' }, limit: 1000 },
+        })).rejects.toMatchObject({ code: 'invalid-argument' });
+    });
+
+    it('passes only a validated restore target to preview', async () => {
+        await (previewTrainingScheduleRestore as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'owner' }, app: {},
+            data: { scope: { kind: 'workout', id: 'workout-1' }, targetRevision: 2 },
+        });
+        expect(hoisted.previewRestore).toHaveBeenCalledWith('owner', {
+            scope: { kind: 'workout', id: 'workout-1' }, targetRevision: 2,
+        });
+    });
+
+    it('redacts unexpected history failures', async () => {
+        hoisted.getHistory.mockRejectedValueOnce(new Error('private history payload'));
+        await expect((getTrainingScheduleHistory as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'owner' }, app: {},
+            data: { scope: { kind: 'plan', id: 'plan-1' } },
+        })).rejects.toMatchObject({
+            code: 'internal', message: 'Unable to load training schedule history.',
+        });
+        expect(hoisted.loggerError).toHaveBeenCalledWith(
+            '[TrainingPlans] History query failed.', { errorName: 'Error' },
+        );
+    });
+});

--- a/functions/src/training-plans/history-callables.ts
+++ b/functions/src/training-plans/history-callables.ts
@@ -1,0 +1,60 @@
+import * as logger from 'firebase-functions/logger';
+import { HttpsError, onCall } from 'firebase-functions/v2/https';
+import { FUNCTIONS_MANIFEST } from '../../../shared/functions-manifest';
+import { TrainingPlanContractError } from '../../../shared/training-plans';
+import { enforceAppCheck } from '../utils';
+import { TrainingScheduleMutationError } from './mutation';
+import {
+    getTrainingScheduleHistoryForUser,
+    parsePreviewTrainingScheduleRestoreRequest,
+    parseTrainingScheduleHistoryRequest,
+    previewTrainingScheduleRestoreForUser,
+} from './history';
+
+function mapKnownError(error: unknown): HttpsError | null {
+    if (error instanceof TrainingPlanContractError) return new HttpsError('invalid-argument', error.message);
+    if (error instanceof TrainingScheduleMutationError) {
+        return new HttpsError(error.code === 'not-found' ? 'not-found' : 'failed-precondition', error.message);
+    }
+    return null;
+}
+
+export const getTrainingScheduleHistory = onCall({
+    region: FUNCTIONS_MANIFEST.getTrainingScheduleHistory.region,
+}, async (request) => {
+    if (!request.auth) throw new HttpsError('unauthenticated', 'The function must be called while authenticated.');
+    enforceAppCheck(request);
+    try {
+        return await getTrainingScheduleHistoryForUser(
+            request.auth.uid,
+            parseTrainingScheduleHistoryRequest(request.data),
+        );
+    } catch (error) {
+        const known = mapKnownError(error);
+        if (known) throw known;
+        logger.error('[TrainingPlans] History query failed.', {
+            errorName: error instanceof Error ? error.name : 'UnknownError',
+        });
+        throw new HttpsError('internal', 'Unable to load training schedule history.');
+    }
+});
+
+export const previewTrainingScheduleRestore = onCall({
+    region: FUNCTIONS_MANIFEST.previewTrainingScheduleRestore.region,
+}, async (request) => {
+    if (!request.auth) throw new HttpsError('unauthenticated', 'The function must be called while authenticated.');
+    enforceAppCheck(request);
+    try {
+        return await previewTrainingScheduleRestoreForUser(
+            request.auth.uid,
+            parsePreviewTrainingScheduleRestoreRequest(request.data),
+        );
+    } catch (error) {
+        const known = mapKnownError(error);
+        if (known) throw known;
+        logger.error('[TrainingPlans] Restore preview failed.', {
+            errorName: error instanceof Error ? error.name : 'UnknownError',
+        });
+        throw new HttpsError('internal', 'Unable to preview this training schedule revision.');
+    }
+});

--- a/functions/src/training-plans/history.spec.ts
+++ b/functions/src/training-plans/history.spec.ts
@@ -1,0 +1,374 @@
+import { ActivityTypes } from '@sports-alliance/sports-lib';
+import { gzipSync } from 'node:zlib';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ScheduledWorkoutV1, TrainingPlanV1 } from '../../../shared/training-plans';
+
+const guard = vi.hoisted(() => ({ getUserDeletionGuardState: vi.fn() }));
+vi.mock('../shared/user-deletion-guard', () => ({
+    getUserDeletionGuardState: guard.getUserDeletionGuardState,
+}));
+
+import {
+    getTrainingScheduleHistoryForUser,
+    parsePreviewTrainingScheduleRestoreRequest,
+    parseTrainingScheduleHistoryRequest,
+    previewTrainingScheduleRestoreForUser,
+    readPlanSnapshotAtRevision,
+    readStandaloneWorkoutAtRevision,
+} from './history';
+
+const STRUCTURE = {
+    version: 1 as const,
+    sport: ActivityTypes.Running,
+    nodes: [{
+        kind: 'step' as const,
+        id: 'steady',
+        purpose: 'work' as const,
+        ending: { kind: 'time' as const, seconds: 1800 },
+        targets: [],
+    }],
+};
+
+function plan(overrides: Partial<TrainingPlanV1> = {}): TrainingPlanV1 {
+    return {
+        schemaVersion: 1,
+        id: 'plan-1',
+        name: 'Plan one',
+        lifecycle: 'paused',
+        startLocalDate: '2026-09-01',
+        endLocalDate: '2026-09-30',
+        revision: 1,
+        lastCheckpointRevision: 1,
+        workoutCount: 1,
+        createdAtMs: 1,
+        updatedAtMs: 1,
+        ...overrides,
+    };
+}
+
+function workout(overrides: Partial<ScheduledWorkoutV1> = {}): ScheduledWorkoutV1 {
+    return {
+        schemaVersion: 1,
+        id: 'workout-1',
+        planId: 'plan-1',
+        localDate: '2026-09-02',
+        lifecycle: 'planned',
+        title: 'Steady run',
+        structure: STRUCTURE,
+        revision: 1,
+        createdAtMs: 1,
+        updatedAtMs: 1,
+        ...overrides,
+    };
+}
+
+class Snapshot {
+    constructor(readonly ref: DocRef, private readonly value: unknown) {}
+    get id(): string { return this.ref.id; }
+    get exists(): boolean { return this.value !== undefined; }
+    data(): unknown { return this.value; }
+}
+
+class QueryRef {
+    constructor(
+        readonly db: FakeDb,
+        readonly path: string,
+        readonly filters: Array<{ field: string; operator: string; value: unknown }> = [],
+        readonly direction: 'asc' | 'desc' | null = null,
+        readonly max: number | null = null,
+    ) {}
+    doc(id: string): DocRef { return new DocRef(this.db, `${this.path}/${id}`); }
+    orderBy(_field: string, direction: 'asc' | 'desc'): QueryRef {
+        return new QueryRef(this.db, this.path, this.filters, direction, this.max);
+    }
+    where(field: string, operator: string, value: unknown): QueryRef {
+        return new QueryRef(this.db, this.path, [...this.filters, { field, operator, value }], this.direction, this.max);
+    }
+    limit(max: number): QueryRef {
+        return new QueryRef(this.db, this.path, this.filters, this.direction, max);
+    }
+    async get(): Promise<{ docs: Snapshot[] }> { return { docs: this.db.query(this) }; }
+}
+
+class DocRef {
+    constructor(readonly db: FakeDb, readonly path: string) {}
+    get id(): string { return this.path.split('/').at(-1) ?? ''; }
+    collection(id: string): QueryRef { return new QueryRef(this.db, `${this.path}/${id}`); }
+    async get(): Promise<Snapshot> { return new Snapshot(this, this.db.docs.get(this.path)); }
+}
+
+class FakeDb {
+    readonly docs = new Map<string, unknown>();
+    collection(id: string): QueryRef { return new QueryRef(this, id); }
+    async getAll(...refs: DocRef[]): Promise<Snapshot[]> {
+        return refs.map(ref => new Snapshot(ref, this.docs.get(ref.path)));
+    }
+    seed(path: string, value: unknown): void { this.docs.set(path, value); }
+    query(ref: QueryRef): Snapshot[] {
+        const prefix = `${ref.path}/`;
+        let rows = [...this.docs.entries()]
+            .filter(([path]) => path.startsWith(prefix) && !path.slice(prefix.length).includes('/'))
+            .filter(([, value]) => ref.filters.every((filter) => {
+                const fieldValue = (value as Record<string, unknown>)[filter.field];
+                if (filter.operator === '==') return fieldValue === filter.value;
+                if (filter.operator === '<') return Number(fieldValue) < Number(filter.value);
+                return false;
+            }))
+            .map(([path, value]) => new Snapshot(new DocRef(this, path), value));
+        if (ref.direction) {
+            rows = rows.sort((left, right) => {
+                const delta = Number((left.data() as Record<string, unknown>).revision)
+                    - Number((right.data() as Record<string, unknown>).revision);
+                return ref.direction === 'asc' ? delta : -delta;
+            });
+        }
+        return ref.max === null ? rows : rows.slice(0, ref.max);
+    }
+}
+
+function planRevision(
+    revision: number,
+    planAfter: TrainingPlanV1,
+    options: {
+        checkpointRevision?: number;
+        checkpointWorkouts?: ScheduledWorkoutV1[];
+        workoutDeltas?: Array<{ workoutId: string; before: ScheduledWorkoutV1 | null; after: ScheduledWorkoutV1 | null }>;
+    } = {},
+): Record<string, unknown> {
+    const workoutDeltas = options.workoutDeltas ?? [];
+    const value: Record<string, unknown> = {
+        schemaVersion: 1,
+        revision,
+        mutationId: `mutation-${revision}`,
+        operationKind: revision === 1 ? 'create-plan' : 'rename-plan',
+        createdAtMs: revision,
+        checkpointRevision: options.checkpointRevision ?? 1,
+        delta: {
+            planBefore: revision === 1 ? null : plan({ revision: revision - 1 }),
+            planAfter,
+            workoutCount: workoutDeltas.length,
+            workoutChunkCount: workoutDeltas.length > 0 ? 1 : 0,
+            workoutEncoding: 'gzip-json-base64-v1',
+        },
+    };
+    if (options.checkpointWorkouts) {
+        value.checkpoint = {
+            plan: planAfter,
+            workoutCount: options.checkpointWorkouts.length,
+            workoutChunkCount: options.checkpointWorkouts.length > 0 ? 1 : 0,
+            workoutEncoding: 'gzip-json-base64-v1',
+        };
+    }
+    return value;
+}
+
+function seedPlanRevision(
+    db: FakeDb,
+    revision: number,
+    planAfter: TrainingPlanV1,
+    options: {
+        checkpointRevision?: number;
+        checkpointWorkouts?: ScheduledWorkoutV1[];
+        workoutDeltas?: Array<{ workoutId: string; before: ScheduledWorkoutV1 | null; after: ScheduledWorkoutV1 | null }>;
+    } = {},
+): void {
+    const revisionId = `${revision}`.padStart(10, '0');
+    const revisionPath = `users/user-1/trainingPlans/plan-1/revisions/${revisionId}`;
+    db.seed(revisionPath, planRevision(revision, planAfter, options));
+    const seedChunk = (kind: 'delta-workouts' | 'checkpoint-workouts', value: unknown[]): void => {
+        if (value.length === 0) return;
+        db.seed(`${revisionPath}/chunks/${kind}-0000`, {
+            schemaVersion: 1,
+            revision,
+            kind,
+            chunkIndex: 0,
+            chunkCount: 1,
+            encoding: 'gzip-json-base64-v1',
+            payloadBase64: gzipSync(Buffer.from(JSON.stringify(value), 'utf8')).toString('base64'),
+        });
+    };
+    seedChunk('delta-workouts', options.workoutDeltas ?? []);
+    seedChunk('checkpoint-workouts', options.checkpointWorkouts ?? []);
+}
+
+describe('training schedule history request parsing', () => {
+    it('normalizes bounded history and restore requests', () => {
+        expect(parseTrainingScheduleHistoryRequest({ scope: { kind: 'plan', id: 'plan-1' } })).toEqual({
+            scope: { kind: 'plan', id: 'plan-1' },
+            limit: 20,
+        });
+        expect(parsePreviewTrainingScheduleRestoreRequest({
+            scope: { kind: 'workout', id: 'workout-1' }, targetRevision: 2,
+        })).toEqual({ scope: { kind: 'workout', id: 'workout-1' }, targetRevision: 2 });
+    });
+
+    it('rejects unknown scope fields and unbounded pages', () => {
+        expect(() => parseTrainingScheduleHistoryRequest({
+            scope: { kind: 'plan', id: 'plan-1', userID: 'other' },
+        })).toThrow('Unknown field');
+        expect(() => parseTrainingScheduleHistoryRequest({
+            scope: { kind: 'plan', id: 'plan-1' }, limit: 51,
+        })).toThrow('at most 50');
+    });
+});
+
+describe('training schedule history reads', () => {
+    let db: FakeDb;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        guard.getUserDeletionGuardState.mockResolvedValue({ shouldSkip: false });
+        db = new FakeDb();
+    });
+
+    it('returns only safe revision envelopes with pagination', async () => {
+        const initialPlan = plan();
+        for (let revision = 1; revision <= 3; revision += 1) {
+            seedPlanRevision(db, revision, plan({ revision, name: `Plan ${revision}` }), {
+                ...(revision === 1 ? { checkpointWorkouts: [workout()] } : {}),
+            });
+        }
+        const response = await getTrainingScheduleHistoryForUser('user-1', {
+            scope: { kind: 'plan', id: 'plan-1' }, limit: 2,
+        }, db as never);
+
+        expect(response.entries.map(entry => entry.revision)).toEqual([3, 2]);
+        expect(response.nextBeforeRevision).toBe(2);
+        expect(response.entries[0]).not.toHaveProperty('delta');
+        expect(response.entries[0]).not.toHaveProperty('checkpoint');
+        expect(initialPlan.id).toBe('plan-1');
+    });
+
+    it('reconstructs a plan from its nearest checkpoint and immutable deltas', async () => {
+        const initialWorkout = workout();
+        const updatedWorkout = workout({ revision: 2, title: 'Updated workout', updatedAtMs: 2 });
+        const renamedPlan = plan({ revision: 2, name: 'Renamed', updatedAtMs: 2 });
+        seedPlanRevision(db, 1, plan(), { checkpointWorkouts: [initialWorkout] });
+        seedPlanRevision(db, 2, renamedPlan, {
+            workoutDeltas: [{
+                workoutId: initialWorkout.id,
+                before: initialWorkout,
+                after: updatedWorkout,
+            }],
+        });
+
+        const reconstructed = await readPlanSnapshotAtRevision(db as never, 'user-1', 'plan-1', 2);
+
+        expect(reconstructed.plan.name).toBe('Renamed');
+        expect(reconstructed.workouts.get(initialWorkout.id)).toEqual(updatedWorkout);
+    });
+
+    it('reads complete standalone snapshots', async () => {
+        const standalone = workout({ planId: null, revision: 2 });
+        db.seed('users/user-1/scheduledWorkouts/workout-1/revisions/0000000002', {
+            schemaVersion: 1,
+            revision: 2,
+            mutationId: 'mutation-2',
+            operationKind: 'update-workout',
+            createdAtMs: 2,
+            snapshot: standalone,
+        });
+        await expect(readStandaloneWorkoutAtRevision(db as never, 'user-1', 'workout-1', 2))
+            .resolves.toEqual(standalone);
+    });
+
+    it('previews moved plan workouts as conflicts instead of reclaiming them', async () => {
+        const desiredWorkout = workout();
+        seedPlanRevision(db, 1, plan(), { checkpointWorkouts: [desiredWorkout] });
+        db.seed('users/user-1/trainingPlans/plan-1', plan({ revision: 2, name: 'Current' }));
+        db.seed('users/user-1/scheduledWorkouts/workout-1', workout({
+            planId: 'plan-2', revision: 4,
+        }));
+
+        const preview = await previewTrainingScheduleRestoreForUser('user-1', {
+            scope: { kind: 'plan', id: 'plan-1' }, targetRevision: 1,
+        }, db as never);
+
+        expect(preview.skippedWorkoutIds).toEqual(['workout-1']);
+        expect(preview.changedWorkoutIds).toEqual([]);
+        expect(preview.warnings[0]).toContain('will not be reclaimed');
+    });
+
+    it('does not report metadata-only workout revision differences as plan restore changes', async () => {
+        const desiredWorkout = workout();
+        seedPlanRevision(db, 1, plan(), { checkpointWorkouts: [desiredWorkout] });
+        db.seed('users/user-1/trainingPlans/plan-1', plan({ revision: 2, name: 'Current' }));
+        db.seed('users/user-1/scheduledWorkouts/workout-1', workout({ revision: 4, updatedAtMs: 4 }));
+
+        const preview = await previewTrainingScheduleRestoreForUser('user-1', {
+            scope: { kind: 'plan', id: 'plan-1' }, targetRevision: 1,
+        }, db as never);
+
+        expect(preview.changedWorkoutIds).toEqual([]);
+        expect(preview.changedPlanIds).toEqual(['plan-1']);
+    });
+
+    it('previews permanently deleted plan workouts as skipped instead of recreating them', async () => {
+        const desiredWorkout = workout();
+        seedPlanRevision(db, 1, plan(), { checkpointWorkouts: [desiredWorkout] });
+        db.seed('users/user-1/trainingPlans/plan-1', plan({ revision: 2, name: 'Current', workoutCount: 0 }));
+        db.seed('users/user-1/scheduledWorkouts/already-deleted', workout({
+            id: 'already-deleted',
+            lifecycle: 'deleted',
+            deletedAtMs: 2,
+        }));
+
+        const preview = await previewTrainingScheduleRestoreForUser('user-1', {
+            scope: { kind: 'plan', id: 'plan-1' }, targetRevision: 1,
+        }, db as never);
+
+        expect(preview.skippedWorkoutIds).toEqual(['workout-1']);
+        expect(preview.changedWorkoutIds).toEqual([]);
+        expect(preview.warnings[0]).toContain('permanently deleted');
+    });
+
+    it('previews standalone workouts moved into a plan as conflicts', async () => {
+        const standalone = workout({ planId: null });
+        db.seed('users/user-1/scheduledWorkouts/workout-1/revisions/0000000001', {
+            schemaVersion: 1,
+            revision: 1,
+            mutationId: 'create',
+            operationKind: 'create-workout',
+            createdAtMs: 1,
+            snapshot: standalone,
+        });
+        db.seed('users/user-1/scheduledWorkouts/workout-1', workout({ planId: 'plan-2', revision: 3 }));
+
+        const preview = await previewTrainingScheduleRestoreForUser('user-1', {
+            scope: { kind: 'workout', id: 'workout-1' }, targetRevision: 1,
+        }, db as never);
+        expect(preview).toMatchObject({
+            changedWorkoutIds: [],
+            skippedWorkoutIds: ['workout-1'],
+        });
+    });
+
+    it('does not offer a plan-bound snapshot from the standalone revision stream for restore', async () => {
+        const planBound = workout({ planId: 'plan-2', revision: 2 });
+        db.seed('users/user-1/scheduledWorkouts/workout-1/revisions/0000000002', {
+            schemaVersion: 1,
+            revision: 2,
+            mutationId: 'attach',
+            operationKind: 'move-workout',
+            createdAtMs: 2,
+            snapshot: planBound,
+        });
+        db.seed('users/user-1/scheduledWorkouts/workout-1', workout({ planId: null, revision: 3 }));
+
+        const preview = await previewTrainingScheduleRestoreForUser('user-1', {
+            scope: { kind: 'workout', id: 'workout-1' }, targetRevision: 2,
+        }, db as never);
+        expect(preview).toMatchObject({
+            changedWorkoutIds: [],
+            skippedWorkoutIds: ['workout-1'],
+        });
+        expect(preview.warnings[0]).toContain('belongs to a plan');
+    });
+
+    it('stops history reads when account deletion has begun', async () => {
+        guard.getUserDeletionGuardState.mockResolvedValueOnce({ shouldSkip: true });
+        await expect(getTrainingScheduleHistoryForUser('user-1', {
+            scope: { kind: 'plan', id: 'plan-1' }, limit: 20,
+        }, db as never)).rejects.toMatchObject({ code: 'failed-precondition' });
+    });
+});

--- a/functions/src/training-plans/history.ts
+++ b/functions/src/training-plans/history.ts
@@ -1,0 +1,535 @@
+import * as admin from 'firebase-admin';
+import { gunzipSync } from 'node:zlib';
+import {
+    SCHEDULED_WORKOUTS_COLLECTION_ID,
+    TRAINING_PLAN_REVISIONS_COLLECTION_ID,
+    TRAINING_PLAN_SCHEMA_VERSION,
+    TRAINING_PLAN_MAX_CURRENT_WORKOUTS,
+    TRAINING_PLANS_COLLECTION_ID,
+    TrainingPlanContractError,
+    parseScheduledWorkoutV1,
+    parseTrainingPlanV1,
+    type PreviewTrainingScheduleRestoreRequestV1,
+    type ScheduledWorkoutV1,
+    type TrainingPlanV1,
+    type TrainingScheduleHistoryRequestV1,
+    type TrainingScheduleHistoryResponseV1,
+    type TrainingScheduleRestorePreviewV1,
+} from '../../../shared/training-plans';
+import { getUserDeletionGuardState } from '../shared/user-deletion-guard';
+import { TrainingScheduleMutationError } from './mutation';
+import {
+    TRAINING_PLAN_REVISION_CHUNKS_COLLECTION_ID,
+    TRAINING_PLAN_REVISION_CHUNK_ENCODING,
+    TRAINING_PLAN_REVISION_CHUNK_MAX_BASE64_CHARACTERS,
+    TRAINING_PLAN_REVISION_MAX_CHUNKS,
+    type StandaloneWorkoutRevisionDocumentV1,
+    type TrainingPlanRevisionChunkKindV1,
+    type TrainingPlanRevisionDocumentV1,
+    type TrainingPlanWorkoutDeltaV1,
+    trainingPlanRevisionChunkDocumentId,
+    trainingScheduleRevisionDocumentId,
+} from './persistence';
+
+const DEFAULT_HISTORY_LIMIT = 20;
+const MAX_HISTORY_LIMIT = 50;
+
+export interface ReconstructedTrainingPlanRevisionV1 {
+    plan: TrainingPlanV1;
+    workouts: Map<string, ScheduledWorkoutV1>;
+}
+
+function asRecord(value: unknown, path: string): Record<string, unknown> {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new TrainingPlanContractError(path, 'Expected an object.');
+    }
+    return value as Record<string, unknown>;
+}
+
+function rejectUnknownFields(record: Record<string, unknown>, allowed: readonly string[], path: string): void {
+    const unknown = Object.keys(record).find(field => !allowed.includes(field));
+    if (unknown) throw new TrainingPlanContractError(`${path}.${unknown}`, 'Unknown field.');
+}
+
+function readPositiveInteger(value: unknown, path: string): number {
+    if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+        throw new TrainingPlanContractError(path, 'Expected a positive integer.');
+    }
+    return value as number;
+}
+
+function readNonNegativeInteger(value: unknown, path: string): number {
+    if (!Number.isSafeInteger(value) || (value as number) < 0) {
+        throw new TrainingPlanContractError(path, 'Expected a non-negative integer.');
+    }
+    return value as number;
+}
+
+function readScope(value: unknown, path: string): TrainingScheduleHistoryRequestV1['scope'] {
+    const record = asRecord(value, path);
+    rejectUnknownFields(record, ['kind', 'id'], path);
+    if (record.kind !== 'plan' && record.kind !== 'workout') {
+        throw new TrainingPlanContractError(`${path}.kind`, 'Expected plan or workout.');
+    }
+    if (typeof record.id !== 'string' || !/^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/.test(record.id)) {
+        throw new TrainingPlanContractError(`${path}.id`, 'Expected a Firestore-safe ID.');
+    }
+    return { kind: record.kind, id: record.id };
+}
+
+export function parseTrainingScheduleHistoryRequest(value: unknown): TrainingScheduleHistoryRequestV1 {
+    const record = asRecord(value, '$');
+    rejectUnknownFields(record, ['scope', 'beforeRevision', 'limit'], '$');
+    const beforeRevision = record.beforeRevision === undefined
+        ? undefined
+        : readPositiveInteger(record.beforeRevision, '$.beforeRevision');
+    const limit = record.limit === undefined ? DEFAULT_HISTORY_LIMIT : readPositiveInteger(record.limit, '$.limit');
+    if (limit > MAX_HISTORY_LIMIT) {
+        throw new TrainingPlanContractError('$.limit', `History pages may contain at most ${MAX_HISTORY_LIMIT} entries.`);
+    }
+    return {
+        scope: readScope(record.scope, '$.scope'),
+        ...(beforeRevision === undefined ? {} : { beforeRevision }),
+        limit,
+    };
+}
+
+export function parsePreviewTrainingScheduleRestoreRequest(value: unknown): PreviewTrainingScheduleRestoreRequestV1 {
+    const record = asRecord(value, '$');
+    rejectUnknownFields(record, ['scope', 'targetRevision'], '$');
+    return {
+        scope: readScope(record.scope, '$.scope'),
+        targetRevision: readPositiveInteger(record.targetRevision, '$.targetRevision'),
+    };
+}
+
+function documentData(snapshot: admin.firestore.DocumentSnapshot): Record<string, unknown> {
+    return (snapshot.data() ?? {}) as Record<string, unknown>;
+}
+
+function parsePlanRevision(value: unknown): TrainingPlanRevisionDocumentV1 {
+    const record = asRecord(value, '$revision');
+    rejectUnknownFields(record, [
+        'schemaVersion', 'revision', 'mutationId', 'operationKind', 'createdAtMs',
+        'checkpointRevision', 'delta', 'checkpoint',
+    ], '$revision');
+    if (record.schemaVersion !== TRAINING_PLAN_SCHEMA_VERSION) throw new Error('Unsupported plan revision schema.');
+    const revision = readPositiveInteger(record.revision, '$revision.revision');
+    const checkpointRevision = readPositiveInteger(record.checkpointRevision, '$revision.checkpointRevision');
+    if (checkpointRevision > revision) throw new Error('Invalid checkpoint revision.');
+    if (typeof record.mutationId !== 'string' || typeof record.operationKind !== 'string') {
+        throw new Error('Invalid plan revision identity.');
+    }
+    if (!Number.isSafeInteger(record.createdAtMs) || (record.createdAtMs as number) < 0) {
+        throw new Error('Invalid plan revision timestamp.');
+    }
+    const delta = asRecord(record.delta, '$revision.delta');
+    rejectUnknownFields(delta, [
+        'planBefore', 'planAfter', 'workoutCount', 'workoutChunkCount', 'workoutEncoding',
+    ], '$revision.delta');
+    const workoutCount = readNonNegativeInteger(delta.workoutCount, '$revision.delta.workoutCount');
+    const workoutChunkCount = readNonNegativeInteger(
+        delta.workoutChunkCount,
+        '$revision.delta.workoutChunkCount',
+    );
+    if (delta.workoutEncoding !== TRAINING_PLAN_REVISION_CHUNK_ENCODING) {
+        throw new Error('Unsupported plan workout-delta encoding.');
+    }
+    if ((workoutCount === 0) !== (workoutChunkCount === 0)) {
+        throw new Error('Invalid plan workout-delta chunk counts.');
+    }
+    if (
+        workoutCount > TRAINING_PLAN_MAX_CURRENT_WORKOUTS * 2
+        || workoutChunkCount > TRAINING_PLAN_REVISION_MAX_CHUNKS
+    ) {
+        throw new Error('Plan workout-delta limits were exceeded.');
+    }
+    const parsed: TrainingPlanRevisionDocumentV1 = {
+        schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+        revision,
+        mutationId: record.mutationId,
+        operationKind: record.operationKind,
+        createdAtMs: record.createdAtMs as number,
+        checkpointRevision,
+        delta: {
+            planBefore: delta.planBefore === null ? null : parseTrainingPlanV1(delta.planBefore),
+            planAfter: parseTrainingPlanV1(delta.planAfter),
+            workoutCount,
+            workoutChunkCount,
+            workoutEncoding: TRAINING_PLAN_REVISION_CHUNK_ENCODING,
+        },
+    };
+    if (record.checkpoint !== undefined) {
+        const checkpoint = asRecord(record.checkpoint, '$revision.checkpoint');
+        rejectUnknownFields(checkpoint, [
+            'plan', 'workoutCount', 'workoutChunkCount', 'workoutEncoding',
+        ], '$revision.checkpoint');
+        const checkpointWorkoutCount = readNonNegativeInteger(
+            checkpoint.workoutCount,
+            '$revision.checkpoint.workoutCount',
+        );
+        const checkpointWorkoutChunkCount = readNonNegativeInteger(
+            checkpoint.workoutChunkCount,
+            '$revision.checkpoint.workoutChunkCount',
+        );
+        if (checkpoint.workoutEncoding !== TRAINING_PLAN_REVISION_CHUNK_ENCODING) {
+            throw new Error('Unsupported plan checkpoint encoding.');
+        }
+        if ((checkpointWorkoutCount === 0) !== (checkpointWorkoutChunkCount === 0)) {
+            throw new Error('Invalid plan checkpoint chunk counts.');
+        }
+        if (
+            checkpointWorkoutCount > TRAINING_PLAN_MAX_CURRENT_WORKOUTS
+            || checkpointWorkoutChunkCount > TRAINING_PLAN_REVISION_MAX_CHUNKS
+        ) {
+            throw new Error('Plan checkpoint limits were exceeded.');
+        }
+        parsed.checkpoint = {
+            plan: parseTrainingPlanV1(checkpoint.plan),
+            workoutCount: checkpointWorkoutCount,
+            workoutChunkCount: checkpointWorkoutChunkCount,
+            workoutEncoding: TRAINING_PLAN_REVISION_CHUNK_ENCODING,
+        };
+    }
+    return parsed;
+}
+
+function parseWorkoutDelta(value: unknown, path: string): TrainingPlanWorkoutDeltaV1 {
+    const record = asRecord(value, path);
+    rejectUnknownFields(record, ['workoutId', 'before', 'after'], path);
+    if (typeof record.workoutId !== 'string') throw new Error('Invalid workout delta ID.');
+    const before = record.before === null ? null : parseScheduledWorkoutV1(record.before);
+    const after = record.after === null ? null : parseScheduledWorkoutV1(record.after);
+    if (before?.id !== undefined && before.id !== record.workoutId) throw new Error('Workout delta before ID mismatch.');
+    if (after?.id !== undefined && after.id !== record.workoutId) throw new Error('Workout delta after ID mismatch.');
+    return { workoutId: record.workoutId, before, after };
+}
+
+async function readRevisionChunkPayload<T>(params: {
+    db: admin.firestore.Firestore;
+    revisionRef: admin.firestore.DocumentReference;
+    revision: number;
+    kind: TrainingPlanRevisionChunkKindV1;
+    itemCount: number;
+    chunkCount: number;
+    parseItem: (value: unknown, path: string) => T;
+}): Promise<T[]> {
+    if (params.itemCount === 0) {
+        if (params.chunkCount !== 0) throw new Error('Empty revision payload has unexpected chunks.');
+        return [];
+    }
+    if (params.chunkCount <= 0) throw new Error('Revision payload chunks are missing.');
+    const chunkRefs = Array.from({ length: params.chunkCount }, (_, chunkIndex) => (
+        params.revisionRef.collection(TRAINING_PLAN_REVISION_CHUNKS_COLLECTION_ID)
+            .doc(trainingPlanRevisionChunkDocumentId(params.kind, chunkIndex))
+    ));
+    const chunkSnapshots = await params.db.getAll(...chunkRefs);
+    const payloadBase64 = chunkSnapshots.map((snapshot, chunkIndex) => {
+        if (!snapshot.exists) throw new Error('A training-plan revision chunk is missing.');
+        const record = asRecord(documentData(snapshot), `$revision.chunks[${chunkIndex}]`);
+        rejectUnknownFields(record, [
+            'schemaVersion', 'revision', 'kind', 'chunkIndex', 'chunkCount', 'encoding', 'payloadBase64',
+        ], `$revision.chunks[${chunkIndex}]`);
+        if (
+            record.schemaVersion !== TRAINING_PLAN_SCHEMA_VERSION
+            || record.revision !== params.revision
+            || record.kind !== params.kind
+            || record.chunkIndex !== chunkIndex
+            || record.chunkCount !== params.chunkCount
+            || record.encoding !== TRAINING_PLAN_REVISION_CHUNK_ENCODING
+            || typeof record.payloadBase64 !== 'string'
+            || record.payloadBase64.length === 0
+            || record.payloadBase64.length > TRAINING_PLAN_REVISION_CHUNK_MAX_BASE64_CHARACTERS
+        ) {
+            throw new Error('A training-plan revision chunk is invalid.');
+        }
+        return record.payloadBase64;
+    }).join('');
+
+    let decoded: unknown;
+    try {
+        decoded = JSON.parse(gunzipSync(Buffer.from(payloadBase64, 'base64')).toString('utf8')) as unknown;
+    } catch {
+        throw new Error('A training-plan revision payload could not be decoded.');
+    }
+    if (!Array.isArray(decoded) || decoded.length !== params.itemCount) {
+        throw new Error('A training-plan revision payload has the wrong item count.');
+    }
+    return decoded.map((item, index) => params.parseItem(item, `$revision.items[${index}]`));
+}
+
+function parseStandaloneRevision(value: unknown): StandaloneWorkoutRevisionDocumentV1 {
+    const record = asRecord(value, '$revision');
+    rejectUnknownFields(record, [
+        'schemaVersion', 'revision', 'mutationId', 'operationKind', 'createdAtMs', 'snapshot',
+    ], '$revision');
+    if (record.schemaVersion !== TRAINING_PLAN_SCHEMA_VERSION) throw new Error('Unsupported workout revision schema.');
+    if (typeof record.mutationId !== 'string' || typeof record.operationKind !== 'string') {
+        throw new Error('Invalid workout revision identity.');
+    }
+    const createdAtMs = Number(record.createdAtMs);
+    if (!Number.isSafeInteger(createdAtMs) || createdAtMs < 0) {
+        throw new Error('Invalid workout revision timestamp.');
+    }
+    return {
+        schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+        revision: readPositiveInteger(record.revision, '$revision.revision'),
+        mutationId: record.mutationId,
+        operationKind: record.operationKind,
+        createdAtMs,
+        snapshot: parseScheduledWorkoutV1(record.snapshot),
+    };
+}
+
+async function requireAvailableUser(db: admin.firestore.Firestore, uid: string): Promise<void> {
+    const deletionGuard = await getUserDeletionGuardState(db, uid);
+    if (deletionGuard.shouldSkip) {
+        throw new TrainingScheduleMutationError(
+            'failed-precondition',
+            'This account is being deleted or is no longer available.',
+        );
+    }
+}
+
+export async function getTrainingScheduleHistoryForUser(
+    uid: string,
+    request: TrainingScheduleHistoryRequestV1,
+    db: admin.firestore.Firestore = admin.firestore(),
+): Promise<TrainingScheduleHistoryResponseV1> {
+    await requireAvailableUser(db, uid);
+    const userRef = db.collection('users').doc(uid);
+    const ownerRef = request.scope.kind === 'plan'
+        ? userRef.collection(TRAINING_PLANS_COLLECTION_ID).doc(request.scope.id)
+        : userRef.collection(SCHEDULED_WORKOUTS_COLLECTION_ID).doc(request.scope.id);
+    let query: admin.firestore.Query = ownerRef.collection(TRAINING_PLAN_REVISIONS_COLLECTION_ID)
+        .orderBy('revision', 'desc');
+    if (request.beforeRevision !== undefined) query = query.where('revision', '<', request.beforeRevision);
+    const limit = request.limit ?? DEFAULT_HISTORY_LIMIT;
+    const snapshot = await query.limit(limit + 1).get();
+    const visible = snapshot.docs.slice(0, limit).map((revisionSnapshot) => {
+        const record = documentData(revisionSnapshot);
+        const revision = readPositiveInteger(record.revision, '$revision.revision');
+        if (typeof record.operationKind !== 'string' || typeof record.mutationId !== 'string') {
+            throw new Error('Invalid schedule revision envelope.');
+        }
+        const createdAtMs = Number(record.createdAtMs);
+        if (!Number.isSafeInteger(createdAtMs) || createdAtMs < 0) throw new Error('Invalid revision timestamp.');
+        return {
+            revision,
+            operationKind: record.operationKind,
+            createdAtMs,
+            mutationId: record.mutationId,
+            isCheckpoint: record.checkpoint !== undefined || request.scope.kind === 'workout',
+        };
+    });
+    return {
+        scope: request.scope,
+        entries: visible,
+        nextBeforeRevision: snapshot.docs.length > limit && visible.length > 0
+            ? visible[visible.length - 1].revision
+            : null,
+    };
+}
+
+export async function readPlanSnapshotAtRevision(
+    db: admin.firestore.Firestore,
+    uid: string,
+    planId: string,
+    targetRevision: number,
+): Promise<ReconstructedTrainingPlanRevisionV1> {
+    const revisionsRef = db.collection('users').doc(uid)
+        .collection(TRAINING_PLANS_COLLECTION_ID).doc(planId)
+        .collection(TRAINING_PLAN_REVISIONS_COLLECTION_ID);
+    const targetSnapshot = await revisionsRef.doc(trainingScheduleRevisionDocumentId(targetRevision)).get();
+    if (!targetSnapshot.exists) throw new TrainingScheduleMutationError('not-found', 'The requested plan revision was not found.');
+    const target = parsePlanRevision(documentData(targetSnapshot));
+    if (target.revision !== targetRevision) throw new Error('Plan revision document ID mismatch.');
+    const checkpointSnapshot = target.checkpointRevision === targetRevision
+        ? targetSnapshot
+        : await revisionsRef.doc(trainingScheduleRevisionDocumentId(target.checkpointRevision)).get();
+    if (!checkpointSnapshot.exists) throw new Error('The plan checkpoint is missing.');
+    const checkpointRevision = parsePlanRevision(documentData(checkpointSnapshot));
+    if (!checkpointRevision.checkpoint || checkpointRevision.revision !== target.checkpointRevision) {
+        throw new Error('The plan checkpoint is invalid.');
+    }
+    let plan = checkpointRevision.checkpoint.plan;
+    const checkpointRef = revisionsRef.doc(trainingScheduleRevisionDocumentId(checkpointRevision.revision));
+    const checkpointWorkouts = await readRevisionChunkPayload({
+        db,
+        revisionRef: checkpointRef,
+        revision: checkpointRevision.revision,
+        kind: 'checkpoint-workouts',
+        itemCount: checkpointRevision.checkpoint.workoutCount,
+        chunkCount: checkpointRevision.checkpoint.workoutChunkCount,
+        parseItem: value => parseScheduledWorkoutV1(value),
+    });
+    const workouts = new Map(checkpointWorkouts.map((workout) => {
+        if (workout.planId !== planId || workout.lifecycle === 'deleted') {
+            throw new Error('The plan checkpoint contains an invalid workout.');
+        }
+        return [workout.id, workout];
+    }));
+
+    const followingRevisionNumbers = Array.from(
+        { length: targetRevision - target.checkpointRevision },
+        (_, index) => target.checkpointRevision + index + 1,
+    );
+    if (followingRevisionNumbers.length > 0) {
+        const followingSnapshots = await db.getAll(...followingRevisionNumbers.map(revision => (
+            revisionsRef.doc(trainingScheduleRevisionDocumentId(revision))
+        )));
+        for (let index = 0; index < followingSnapshots.length; index += 1) {
+            const snapshot = followingSnapshots[index];
+            if (!snapshot.exists) throw new Error('The plan revision stream contains a gap.');
+            const revision = parsePlanRevision(documentData(snapshot));
+            if (revision.revision !== followingRevisionNumbers[index]) throw new Error('Plan revisions are out of order.');
+            plan = revision.delta.planAfter;
+            const workoutDeltas = await readRevisionChunkPayload({
+                db,
+                revisionRef: revisionsRef.doc(trainingScheduleRevisionDocumentId(revision.revision)),
+                revision: revision.revision,
+                kind: 'delta-workouts',
+                itemCount: revision.delta.workoutCount,
+                chunkCount: revision.delta.workoutChunkCount,
+                parseItem: parseWorkoutDelta,
+            });
+            workoutDeltas.forEach((delta) => {
+                if (delta.after?.planId === planId && delta.after.lifecycle !== 'deleted') {
+                    workouts.set(delta.workoutId, delta.after);
+                } else {
+                    workouts.delete(delta.workoutId);
+                }
+            });
+        }
+    }
+    return { plan, workouts };
+}
+
+export async function readStandaloneWorkoutAtRevision(
+    db: admin.firestore.Firestore,
+    uid: string,
+    workoutId: string,
+    targetRevision: number,
+): Promise<ScheduledWorkoutV1> {
+    const revisionRef = db.collection('users').doc(uid)
+        .collection(SCHEDULED_WORKOUTS_COLLECTION_ID).doc(workoutId)
+        .collection(TRAINING_PLAN_REVISIONS_COLLECTION_ID)
+        .doc(trainingScheduleRevisionDocumentId(targetRevision));
+    const snapshot = await revisionRef.get();
+    if (!snapshot.exists) throw new TrainingScheduleMutationError('not-found', 'The requested workout revision was not found.');
+    const revision = parseStandaloneRevision(documentData(snapshot));
+    if (revision.revision !== targetRevision) throw new Error('Workout revision document ID mismatch.');
+    return revision.snapshot;
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+    return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function logicalWorkoutValuesEqual(
+    left: ScheduledWorkoutV1 | null | undefined,
+    right: ScheduledWorkoutV1 | null | undefined,
+): boolean {
+    const logicalValue = (workout: ScheduledWorkoutV1 | null | undefined): unknown => workout ? {
+        planId: workout.planId,
+        localDate: workout.localDate,
+        lifecycle: workout.lifecycle,
+        title: workout.title,
+        structure: workout.structure,
+    } : null;
+    return valuesEqual(logicalValue(left), logicalValue(right));
+}
+
+export async function previewTrainingScheduleRestoreForUser(
+    uid: string,
+    request: PreviewTrainingScheduleRestoreRequestV1,
+    db: admin.firestore.Firestore = admin.firestore(),
+): Promise<TrainingScheduleRestorePreviewV1> {
+    await requireAvailableUser(db, uid);
+    const userRef = db.collection('users').doc(uid);
+    if (request.scope.kind === 'workout') {
+        const desired = await readStandaloneWorkoutAtRevision(db, uid, request.scope.id, request.targetRevision);
+        const currentSnapshot = await userRef.collection(SCHEDULED_WORKOUTS_COLLECTION_ID).doc(request.scope.id).get();
+        const current = currentSnapshot.exists ? parseScheduledWorkoutV1(documentData(currentSnapshot)) : null;
+        const selectedRevisionIsPlanBound = desired.planId !== null;
+        const moved = current?.planId !== null && current?.planId !== undefined;
+        const blocked = selectedRevisionIsPlanBound || moved;
+        return {
+            scope: request.scope,
+            targetRevision: request.targetRevision,
+            changedPlanIds: [],
+            changedWorkoutIds: blocked || valuesEqual(current, desired) ? [] : [request.scope.id],
+            skippedWorkoutIds: blocked ? [request.scope.id] : [],
+            warnings: selectedRevisionIsPlanBound
+                ? ['The selected revision belongs to a plan and cannot be restored from standalone history.']
+                : moved
+                    ? ['The workout now belongs to a plan and will not be reclaimed automatically.']
+                    : [],
+        };
+    }
+
+    const desired = await readPlanSnapshotAtRevision(db, uid, request.scope.id, request.targetRevision);
+    const planRef = userRef.collection(TRAINING_PLANS_COLLECTION_ID).doc(request.scope.id);
+    const [currentPlanSnapshot, currentPlanWorkoutsSnapshot] = await Promise.all([
+        planRef.get(),
+        userRef.collection(SCHEDULED_WORKOUTS_COLLECTION_ID).where('planId', '==', request.scope.id).get(),
+    ]);
+    if (!currentPlanSnapshot.exists) throw new TrainingScheduleMutationError('not-found', 'The current training plan was not found.');
+    const currentPlan = parseTrainingPlanV1(documentData(currentPlanSnapshot));
+    const currentWorkouts = new Map(currentPlanWorkoutsSnapshot.docs.map((snapshot) => {
+        const parsed = parseScheduledWorkoutV1(documentData(snapshot));
+        return [parsed.id, parsed] as const;
+    }));
+    const desiredWorkoutIds = [...desired.workouts.keys()];
+    const desiredSnapshots = desiredWorkoutIds.length === 0
+        ? []
+        : await db.getAll(...desiredWorkoutIds.map(workoutId => (
+            userRef.collection(SCHEDULED_WORKOUTS_COLLECTION_ID).doc(workoutId)
+        )));
+    const movedIds = new Set<string>();
+    const permanentlyDeletedIds = new Set<string>();
+    desiredSnapshots.forEach((snapshot, index) => {
+        if (!snapshot.exists) {
+            permanentlyDeletedIds.add(desiredWorkoutIds[index]);
+            return;
+        }
+        const current = parseScheduledWorkoutV1(documentData(snapshot));
+        currentWorkouts.set(current.id, current);
+        if (current.planId !== request.scope.id) movedIds.add(current.id);
+    });
+    const changedWorkoutIds = new Set<string>();
+    desired.workouts.forEach((workout, workoutId) => {
+        if (
+            !movedIds.has(workoutId)
+            && !permanentlyDeletedIds.has(workoutId)
+            && !logicalWorkoutValuesEqual(currentWorkouts.get(workoutId), workout)
+        ) {
+            changedWorkoutIds.add(workoutId);
+        }
+    });
+    currentWorkouts.forEach((workout, workoutId) => {
+        if (
+            workout.planId === request.scope.id
+            && workout.lifecycle !== 'deleted'
+            && !desired.workouts.has(workoutId)
+        ) {
+            changedWorkoutIds.add(workoutId);
+        }
+    });
+    const skippedWorkoutIds = [...new Set([...movedIds, ...permanentlyDeletedIds])].sort();
+    const warnings: string[] = [];
+    if (movedIds.size > 0) {
+        warnings.push(`${movedIds.size} workout${movedIds.size === 1 ? '' : 's'} moved to another scope and will not be reclaimed.`);
+    }
+    if (permanentlyDeletedIds.size > 0) {
+        warnings.push(`${permanentlyDeletedIds.size} permanently deleted workout${permanentlyDeletedIds.size === 1 ? '' : 's'} will remain deleted.`);
+    }
+    return {
+        scope: request.scope,
+        targetRevision: request.targetRevision,
+        changedPlanIds: valuesEqual(currentPlan, desired.plan) ? [] : [request.scope.id],
+        changedWorkoutIds: [...changedWorkoutIds].sort(),
+        skippedWorkoutIds,
+        warnings,
+    };
+}

--- a/functions/src/training-plans/mutate-training-schedule.spec.ts
+++ b/functions/src/training-plans/mutate-training-schedule.spec.ts
@@ -1,0 +1,151 @@
+import { ActivityTypes } from '@sports-alliance/sports-lib';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+    enforceAppCheck: vi.fn(),
+    mutateTrainingScheduleForUser: vi.fn(),
+    loggerError: vi.fn(),
+}));
+
+vi.mock('firebase-functions/v2/https', () => ({
+    HttpsError: class MockHttpsError extends Error {
+        constructor(public readonly code: string, message: string) {
+            super(message);
+        }
+    },
+    onCall: (_options: unknown, handler: unknown) => handler,
+}));
+vi.mock('firebase-functions/logger', () => ({ error: hoisted.loggerError }));
+vi.mock('../../../shared/functions-manifest', () => ({
+    FUNCTIONS_MANIFEST: { mutateTrainingSchedule: { region: 'europe-west2' } },
+}));
+vi.mock('../utils', () => ({ enforceAppCheck: hoisted.enforceAppCheck }));
+vi.mock('./persistence', () => ({ mutateTrainingScheduleForUser: hoisted.mutateTrainingScheduleForUser }));
+
+import { TrainingScheduleMutationError } from './mutation';
+import { mutateTrainingSchedule } from './mutate-training-schedule';
+
+const VALID_DATA = {
+    mutationId: 'create-1',
+    expectedRevisions: [{ scope: 'state', id: 'current', revision: 0 }],
+    operation: {
+        kind: 'create-workout',
+        workoutId: 'workout-1',
+        planId: null,
+        localDate: '2026-09-02',
+        title: 'Easy run',
+        structure: {
+            version: 1,
+            sport: ActivityTypes.Running,
+            nodes: [{
+                kind: 'step',
+                id: 'steady',
+                purpose: 'work',
+                ending: { kind: 'time', seconds: 1800 },
+                targets: [],
+            }],
+        },
+        confirmPlanRangeExtension: false,
+    },
+};
+
+describe('mutateTrainingSchedule callable', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        hoisted.mutateTrainingScheduleForUser.mockResolvedValue({
+            mutationId: 'create-1',
+            state: {
+                schemaVersion: 1,
+                activePlanId: null,
+                revision: 1,
+                currentWorkoutCount: 1,
+                updatedAtMs: 1,
+            },
+            plans: [],
+            workouts: [],
+            removedPlanIds: [],
+            permanentlyDeletedWorkoutIds: [],
+        });
+    });
+
+    it('requires authentication before App Check or persistence', async () => {
+        await expect((mutateTrainingSchedule as never as (request: unknown) => Promise<unknown>)({ data: VALID_DATA }))
+            .rejects.toMatchObject({ code: 'unauthenticated' });
+        expect(hoisted.enforceAppCheck).not.toHaveBeenCalled();
+        expect(hoisted.mutateTrainingScheduleForUser).not.toHaveBeenCalled();
+    });
+
+    it('enforces App Check before validating or persisting', async () => {
+        hoisted.enforceAppCheck.mockImplementationOnce(() => {
+            throw new Error('App Check verification failed.');
+        });
+        await expect((mutateTrainingSchedule as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'user-1' }, data: VALID_DATA,
+        })).rejects.toThrow('App Check verification failed');
+        expect(hoisted.mutateTrainingScheduleForUser).not.toHaveBeenCalled();
+    });
+
+    it('normalizes the request and derives ownership only from auth', async () => {
+        await (mutateTrainingSchedule as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'owner-user' },
+            app: { appId: 'app-check' },
+            data: { ...VALID_DATA, userID: undefined },
+        }).catch(() => undefined);
+
+        expect(hoisted.mutateTrainingScheduleForUser).not.toHaveBeenCalled();
+
+        await (mutateTrainingSchedule as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'owner-user' },
+            app: { appId: 'app-check' },
+            data: VALID_DATA,
+        });
+        expect(hoisted.mutateTrainingScheduleForUser).toHaveBeenCalledWith(
+            'owner-user',
+            expect.objectContaining({ mutationId: 'create-1' }),
+        );
+    });
+
+    it('rejects malformed and provider-contaminated structures before persistence', async () => {
+        await expect((mutateTrainingSchedule as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'user-1' },
+            app: {},
+            data: {
+                ...VALID_DATA,
+                operation: {
+                    ...VALID_DATA.operation,
+                    structure: { ...VALID_DATA.operation.structure, providerId: 'garmin' },
+                },
+            },
+        })).rejects.toMatchObject({ code: 'invalid-argument' });
+        expect(hoisted.mutateTrainingScheduleForUser).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['revision-conflict', 'aborted'],
+        ['range-extension-required', 'failed-precondition'],
+        ['limit-exceeded', 'resource-exhausted'],
+        ['not-found', 'not-found'],
+        ['already-exists', 'already-exists'],
+    ] as const)('maps %s without exposing storage internals', async (serviceCode, callableCode) => {
+        hoisted.mutateTrainingScheduleForUser.mockRejectedValueOnce(
+            new TrainingScheduleMutationError(serviceCode, 'Safe message.'),
+        );
+        await expect((mutateTrainingSchedule as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'user-1' }, app: {}, data: VALID_DATA,
+        })).rejects.toMatchObject({ code: callableCode, message: 'Safe message.' });
+    });
+
+    it('redacts unexpected persistence failures', async () => {
+        hoisted.mutateTrainingScheduleForUser.mockRejectedValueOnce(new Error('private Firestore path'));
+        await expect((mutateTrainingSchedule as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'user-1' }, app: {}, data: VALID_DATA,
+        })).rejects.toMatchObject({
+            code: 'internal',
+            message: 'Unable to update the training schedule.',
+        });
+        expect(hoisted.loggerError).toHaveBeenCalledWith(
+            '[TrainingPlans] Schedule mutation failed.',
+            { errorName: 'Error' },
+        );
+    });
+});

--- a/functions/src/training-plans/mutate-training-schedule.ts
+++ b/functions/src/training-plans/mutate-training-schedule.ts
@@ -1,0 +1,54 @@
+import * as logger from 'firebase-functions/logger';
+import { HttpsError, onCall } from 'firebase-functions/v2/https';
+import { WorkoutStructureValidationError } from '../../../shared/planned-workout';
+import {
+    TrainingPlanContractError,
+    parseMutateTrainingScheduleRequestV1,
+    type MutateTrainingScheduleResponseV1,
+} from '../../../shared/training-plans';
+import { FUNCTIONS_MANIFEST } from '../../../shared/functions-manifest';
+import { enforceAppCheck } from '../utils';
+import { TrainingScheduleMutationError } from './mutation';
+import { mutateTrainingScheduleForUser } from './persistence';
+
+function mapMutationError(error: TrainingScheduleMutationError): HttpsError {
+    switch (error.code) {
+        case 'not-found':
+            return new HttpsError('not-found', error.message);
+        case 'already-exists':
+            return new HttpsError('already-exists', error.message);
+        case 'revision-conflict':
+            return new HttpsError('aborted', error.message);
+        case 'limit-exceeded':
+            return new HttpsError('resource-exhausted', error.message);
+        case 'range-extension-required':
+        case 'failed-precondition':
+            return new HttpsError('failed-precondition', error.message);
+    }
+}
+
+export const mutateTrainingSchedule = onCall({
+    region: FUNCTIONS_MANIFEST.mutateTrainingSchedule.region,
+}, async (request): Promise<MutateTrainingScheduleResponseV1> => {
+    if (!request.auth) {
+        throw new HttpsError('unauthenticated', 'The function must be called while authenticated.');
+    }
+    enforceAppCheck(request);
+
+    try {
+        const parsed = parseMutateTrainingScheduleRequestV1(request.data);
+        return await mutateTrainingScheduleForUser(request.auth.uid, parsed);
+    } catch (error) {
+        if (error instanceof TrainingPlanContractError || error instanceof WorkoutStructureValidationError) {
+            throw new HttpsError('invalid-argument', error.message);
+        }
+        if (error instanceof TrainingScheduleMutationError) {
+            throw mapMutationError(error);
+        }
+        if (error instanceof HttpsError) throw error;
+        logger.error('[TrainingPlans] Schedule mutation failed.', {
+            errorName: error instanceof Error ? error.name : 'UnknownError',
+        });
+        throw new HttpsError('internal', 'Unable to update the training schedule.');
+    }
+});

--- a/functions/src/training-plans/mutation.spec.ts
+++ b/functions/src/training-plans/mutation.spec.ts
@@ -1,0 +1,353 @@
+import { ActivityTypes } from '@sports-alliance/sports-lib';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+    TRAINING_PLAN_MAX_CURRENT_WORKOUTS,
+    type MutateTrainingScheduleRequestV1,
+    type ScheduledWorkoutV1,
+    type TrainingPlanV1,
+} from '../../../shared/training-plans';
+import {
+    TrainingScheduleMutationError,
+    applyTrainingScheduleMutation,
+    createEmptyTrainingPlanState,
+    type TrainingScheduleSnapshotV1,
+} from './mutation';
+
+const NOW_MS = Date.UTC(2026, 8, 2, 10);
+const STRUCTURE = {
+    version: 1 as const,
+    sport: ActivityTypes.Running,
+    nodes: [{
+        kind: 'step' as const,
+        id: 'steady',
+        purpose: 'work' as const,
+        ending: { kind: 'time' as const, seconds: 1800 },
+        targets: [],
+    }],
+};
+
+function plan(overrides: Partial<TrainingPlanV1> = {}): TrainingPlanV1 {
+    return {
+        schemaVersion: 1,
+        id: 'plan-1',
+        name: 'Plan one',
+        lifecycle: 'active',
+        startLocalDate: '2026-09-01',
+        endLocalDate: '2026-09-30',
+        revision: 3,
+        lastCheckpointRevision: 1,
+        workoutCount: 0,
+        createdAtMs: 1,
+        updatedAtMs: 2,
+        ...overrides,
+    };
+}
+
+function workout(overrides: Partial<ScheduledWorkoutV1> = {}): ScheduledWorkoutV1 {
+    return {
+        schemaVersion: 1,
+        id: 'workout-1',
+        planId: null,
+        localDate: '2026-09-02',
+        lifecycle: 'planned',
+        title: 'Steady run',
+        structure: STRUCTURE,
+        revision: 2,
+        createdAtMs: 1,
+        updatedAtMs: 2,
+        ...overrides,
+    };
+}
+
+function snapshot(
+    plans: TrainingPlanV1[] = [],
+    workouts: ScheduledWorkoutV1[] = [],
+    activePlanId: string | null = null,
+): TrainingScheduleSnapshotV1 {
+    return {
+        state: {
+            ...createEmptyTrainingPlanState(0),
+            activePlanId,
+            revision: 7,
+            currentWorkoutCount: workouts.filter(item => item.lifecycle !== 'deleted').length,
+        },
+        plans: new Map(plans.map(item => [item.id, item])),
+        workouts: new Map(workouts.map(item => [item.id, item])),
+    };
+}
+
+function request(
+    operation: MutateTrainingScheduleRequestV1['operation'],
+    expectedRevisions: MutateTrainingScheduleRequestV1['expectedRevisions'] = [],
+): MutateTrainingScheduleRequestV1 {
+    return {
+        mutationId: `mutation-${operation.kind}`,
+        expectedRevisions: [
+            { scope: 'state', id: 'current', revision: 7 },
+            ...expectedRevisions,
+        ],
+        operation,
+    };
+}
+
+describe('applyTrainingScheduleMutation', () => {
+    let initial: TrainingScheduleSnapshotV1;
+
+    beforeEach(() => {
+        initial = snapshot();
+    });
+
+    it('creates a standalone workout without a plan', () => {
+        const result = applyTrainingScheduleMutation(initial, request({
+            kind: 'create-workout',
+            workoutId: 'standalone-1',
+            planId: null,
+            localDate: '2026-09-03',
+            title: 'Standalone run',
+            structure: STRUCTURE,
+            confirmPlanRangeExtension: false,
+        }), NOW_MS);
+
+        expect(result.after.workouts.get('standalone-1')).toMatchObject({
+            id: 'standalone-1',
+            planId: null,
+            revision: 1,
+            lifecycle: 'planned',
+        });
+        expect(result.after.state.currentWorkoutCount).toBe(1);
+        expect(result.affectedPlanIds).toEqual([]);
+    });
+
+    it('activates a new plan and atomically pauses the previous active plan', () => {
+        const oldPlan = plan();
+        initial = snapshot([oldPlan], [], oldPlan.id);
+
+        const result = applyTrainingScheduleMutation(initial, request({
+            kind: 'create-plan',
+            planId: 'plan-2',
+            name: 'Plan two',
+            startLocalDate: '2026-10-01',
+            endLocalDate: '2026-10-31',
+            activate: true,
+        }, [{ scope: 'plan', id: oldPlan.id, revision: oldPlan.revision }]), NOW_MS);
+
+        expect(result.after.state.activePlanId).toBe('plan-2');
+        expect(result.after.plans.get('plan-1')).toMatchObject({ lifecycle: 'paused', revision: 4 });
+        expect(result.after.plans.get('plan-2')).toMatchObject({ lifecycle: 'active', revision: 1 });
+        expect(result.affectedPlanIds).toEqual(['plan-1', 'plan-2']);
+    });
+
+    it('requires confirmation before atomically extending a plan range', () => {
+        const targetPlan = plan();
+        initial = snapshot([targetPlan]);
+        const operation = {
+            kind: 'create-workout' as const,
+            workoutId: 'outside',
+            planId: targetPlan.id,
+            localDate: '2026-10-02',
+            title: 'Outside range',
+            structure: STRUCTURE,
+            confirmPlanRangeExtension: false,
+        };
+        const expected = [{ scope: 'plan' as const, id: targetPlan.id, revision: targetPlan.revision }];
+
+        expect(() => applyTrainingScheduleMutation(initial, request(operation, expected), NOW_MS))
+            .toThrow(expect.objectContaining({ code: 'range-extension-required' }));
+
+        const result = applyTrainingScheduleMutation(initial, request({
+            ...operation,
+            confirmPlanRangeExtension: true,
+        }, expected), NOW_MS);
+        expect(result.after.plans.get(targetPlan.id)).toMatchObject({
+            endLocalDate: '2026-10-02',
+            workoutCount: 1,
+            revision: 4,
+        });
+    });
+
+    it('moves standalone workouts into plans and plan workouts back to standalone without changing IDs', () => {
+        const targetPlan = plan();
+        const standalone = workout();
+        initial = snapshot([targetPlan], [standalone]);
+        const attached = applyTrainingScheduleMutation(initial, request({
+            kind: 'move-workout',
+            workoutId: standalone.id,
+            planId: targetPlan.id,
+            localDate: '2026-09-05',
+            confirmPlanRangeExtension: false,
+        }, [
+            { scope: 'workout', id: standalone.id, revision: standalone.revision },
+            { scope: 'plan', id: targetPlan.id, revision: targetPlan.revision },
+        ]), NOW_MS);
+
+        expect(attached.after.workouts.get(standalone.id)).toMatchObject({
+            id: standalone.id,
+            planId: targetPlan.id,
+            revision: 3,
+        });
+        expect(attached.after.plans.get(targetPlan.id)?.workoutCount).toBe(1);
+
+        const detached = applyTrainingScheduleMutation(attached.after, {
+            mutationId: 'detach',
+            expectedRevisions: [
+                { scope: 'state', id: 'current', revision: 8 },
+                { scope: 'workout', id: standalone.id, revision: 3 },
+                { scope: 'plan', id: targetPlan.id, revision: 4 },
+            ],
+            operation: {
+                kind: 'move-workout',
+                workoutId: standalone.id,
+                planId: null,
+                localDate: '2026-09-06',
+                confirmPlanRangeExtension: false,
+            },
+        }, NOW_MS + 1);
+
+        expect(detached.after.workouts.get(standalone.id)).toMatchObject({ id: standalone.id, planId: null });
+        expect(detached.after.plans.get(targetPlan.id)?.workoutCount).toBe(0);
+    });
+
+    it('moves a workout between plans while revising both plan streams once', () => {
+        const sourcePlan = plan({ workoutCount: 1 });
+        const destinationPlan = plan({ id: 'plan-2', name: 'Plan two', lifecycle: 'paused', revision: 6 });
+        const scheduled = workout({ planId: sourcePlan.id });
+        initial = snapshot([sourcePlan, destinationPlan], [scheduled], sourcePlan.id);
+
+        const result = applyTrainingScheduleMutation(initial, request({
+            kind: 'move-workout',
+            workoutId: scheduled.id,
+            planId: destinationPlan.id,
+            localDate: '2026-09-10',
+            confirmPlanRangeExtension: false,
+        }, [
+            { scope: 'workout', id: scheduled.id, revision: scheduled.revision },
+            { scope: 'plan', id: sourcePlan.id, revision: sourcePlan.revision },
+            { scope: 'plan', id: destinationPlan.id, revision: destinationPlan.revision },
+        ]), NOW_MS);
+
+        expect(result.after.plans.get(sourcePlan.id)).toMatchObject({ revision: 4, workoutCount: 0 });
+        expect(result.after.plans.get(destinationPlan.id)).toMatchObject({ revision: 7, workoutCount: 1 });
+        expect(result.after.workouts.get(scheduled.id)?.id).toBe(scheduled.id);
+    });
+
+    it('shifts only the selected plan range and its associated current workouts', () => {
+        const selectedPlan = plan({ workoutCount: 1 });
+        const otherPlan = plan({ id: 'plan-2', name: 'Other', revision: 2, workoutCount: 1 });
+        const selectedWorkout = workout({ planId: selectedPlan.id });
+        const otherWorkout = workout({ id: 'workout-2', planId: otherPlan.id, localDate: '2026-09-03' });
+        const standalone = workout({ id: 'standalone', localDate: '2026-09-04' });
+        initial = snapshot([selectedPlan, otherPlan], [selectedWorkout, otherWorkout, standalone], selectedPlan.id);
+
+        const result = applyTrainingScheduleMutation(initial, request({
+            kind: 'shift-plan',
+            planId: selectedPlan.id,
+            days: 7,
+        }, [{ scope: 'plan', id: selectedPlan.id, revision: selectedPlan.revision }]), NOW_MS);
+
+        expect(result.after.plans.get(selectedPlan.id)).toMatchObject({
+            startLocalDate: '2026-09-08',
+            endLocalDate: '2026-10-07',
+        });
+        expect(result.after.workouts.get(selectedWorkout.id)?.localDate).toBe('2026-09-09');
+        expect(result.after.workouts.get(otherWorkout.id)?.localDate).toBe('2026-09-03');
+        expect(result.after.workouts.get(standalone.id)?.localDate).toBe('2026-09-04');
+        expect(result.bulkOperation).toBe(true);
+    });
+
+    it('keeps skipped workouts current and makes deletion history-recoverable before permanent deletion', () => {
+        const scheduled = workout();
+        initial = snapshot([], [scheduled]);
+        const skipped = applyTrainingScheduleMutation(initial, request({
+            kind: 'set-workout-lifecycle', workoutId: scheduled.id, lifecycle: 'skipped',
+        }, [{ scope: 'workout', id: scheduled.id, revision: scheduled.revision }]), NOW_MS);
+        expect(skipped.after.workouts.get(scheduled.id)?.lifecycle).toBe('skipped');
+        expect(skipped.after.state.currentWorkoutCount).toBe(1);
+
+        const deleted = applyTrainingScheduleMutation(skipped.after, {
+            mutationId: 'soft-delete',
+            expectedRevisions: [
+                { scope: 'state', id: 'current', revision: 8 },
+                { scope: 'workout', id: scheduled.id, revision: 3 },
+            ],
+            operation: { kind: 'delete-workout', workoutId: scheduled.id },
+        }, NOW_MS + 1);
+        expect(deleted.after.workouts.get(scheduled.id)).toMatchObject({
+            lifecycle: 'deleted',
+            deletedAtMs: NOW_MS + 1,
+        });
+        expect(deleted.after.state.currentWorkoutCount).toBe(0);
+
+        const permanentlyDeleted = applyTrainingScheduleMutation(deleted.after, {
+            mutationId: 'permanent-delete',
+            expectedRevisions: [
+                { scope: 'state', id: 'current', revision: 9 },
+                { scope: 'workout', id: scheduled.id, revision: 4 },
+            ],
+            operation: {
+                kind: 'permanently-delete-workout',
+                workoutId: scheduled.id,
+                confirmPermanentDeletion: true,
+            },
+        }, NOW_MS + 2);
+        expect(permanentlyDeleted.after.workouts.has(scheduled.id)).toBe(false);
+        expect(permanentlyDeleted.permanentlyDeletedWorkoutIds).toEqual([scheduled.id]);
+    });
+
+    it('rejects missing or stale expected revisions', () => {
+        const scheduled = workout();
+        initial = snapshot([], [scheduled]);
+
+        expect(() => applyTrainingScheduleMutation(initial, request({
+            kind: 'update-workout',
+            workoutId: scheduled.id,
+            title: 'Changed',
+            structure: STRUCTURE,
+        }), NOW_MS)).toThrow(expect.objectContaining({ code: 'revision-conflict' }));
+
+        expect(() => applyTrainingScheduleMutation(initial, request({
+            kind: 'update-workout',
+            workoutId: scheduled.id,
+            title: 'Changed',
+            structure: STRUCTURE,
+        }, [{ scope: 'workout', id: scheduled.id, revision: 1 }]), NOW_MS))
+            .toThrow(expect.objectContaining({ code: 'revision-conflict' }));
+    });
+
+    it('enforces the current workout cap without counting soft-deleted workouts', () => {
+        const workouts = Array.from({ length: TRAINING_PLAN_MAX_CURRENT_WORKOUTS }, (_, index) => workout({
+            id: `workout-${index}`,
+        }));
+        initial = snapshot([], workouts);
+
+        expect(() => applyTrainingScheduleMutation(initial, request({
+            kind: 'create-workout',
+            workoutId: 'one-too-many',
+            planId: null,
+            localDate: '2026-09-03',
+            title: 'Too many',
+            structure: STRUCTURE,
+            confirmPlanRangeExtension: false,
+        }), NOW_MS)).toThrow(expect.objectContaining({ code: 'limit-exceeded' }));
+    });
+
+    it('checkpoints bulk shifts even when the next revision is not divisible by twenty', () => {
+        const selectedPlan = plan({ revision: 8, lastCheckpointRevision: 1 });
+        initial = snapshot([selectedPlan]);
+        const result = applyTrainingScheduleMutation(initial, request({
+            kind: 'shift-plan', planId: selectedPlan.id, days: 1,
+        }, [{ scope: 'plan', id: selectedPlan.id, revision: selectedPlan.revision }]), NOW_MS);
+
+        expect(result.after.plans.get(selectedPlan.id)).toMatchObject({
+            revision: 9,
+            lastCheckpointRevision: 9,
+        });
+    });
+
+    it('exposes typed mutation errors for callers without leaking storage details', () => {
+        expect(new TrainingScheduleMutationError('not-found', 'Missing')).toMatchObject({
+            name: 'TrainingScheduleMutationError',
+            code: 'not-found',
+            message: 'Missing',
+        });
+    });
+});

--- a/functions/src/training-plans/mutation.spec.ts
+++ b/functions/src/training-plans/mutation.spec.ts
@@ -254,6 +254,56 @@ describe('applyTrainingScheduleMutation', () => {
         expect(result.bulkOperation).toBe(true);
     });
 
+    it('updates content, date, association, and plan range in one revisioned mutation', () => {
+        const sourcePlan = plan({ workoutCount: 1 });
+        const destinationPlan = plan({
+            id: 'plan-2',
+            name: 'Destination',
+            lifecycle: 'paused',
+            revision: 5,
+            startLocalDate: '2026-09-01',
+            endLocalDate: '2026-09-30',
+        });
+        const scheduled = workout({ planId: sourcePlan.id });
+        initial = snapshot([sourcePlan, destinationPlan], [scheduled], sourcePlan.id);
+
+        const operation = {
+            kind: 'update-workout' as const,
+            workoutId: scheduled.id,
+            planId: destinationPlan.id,
+            localDate: '2026-10-02',
+            title: 'Moved and edited',
+            structure: STRUCTURE,
+            confirmPlanRangeExtension: false,
+        };
+        const expected = [
+            { scope: 'workout' as const, id: scheduled.id, revision: scheduled.revision },
+            { scope: 'plan' as const, id: sourcePlan.id, revision: sourcePlan.revision },
+            { scope: 'plan' as const, id: destinationPlan.id, revision: destinationPlan.revision },
+        ];
+
+        expect(() => applyTrainingScheduleMutation(initial, request(operation, expected), NOW_MS))
+            .toThrow(expect.objectContaining({ code: 'range-extension-required' }));
+
+        const result = applyTrainingScheduleMutation(initial, request({
+            ...operation,
+            confirmPlanRangeExtension: true,
+        }, expected), NOW_MS);
+
+        expect(result.after.workouts.get(scheduled.id)).toMatchObject({
+            planId: destinationPlan.id,
+            localDate: '2026-10-02',
+            title: 'Moved and edited',
+            revision: scheduled.revision + 1,
+        });
+        expect(result.after.plans.get(sourcePlan.id)).toMatchObject({ workoutCount: 0, revision: 4 });
+        expect(result.after.plans.get(destinationPlan.id)).toMatchObject({
+            workoutCount: 1,
+            revision: 6,
+            endLocalDate: '2026-10-02',
+        });
+    });
+
     it('keeps skipped workouts current and makes deletion history-recoverable before permanent deletion', () => {
         const scheduled = workout();
         initial = snapshot([], [scheduled]);
@@ -293,6 +343,33 @@ describe('applyTrainingScheduleMutation', () => {
         expect(permanentlyDeleted.permanentlyDeletedWorkoutIds).toEqual([scheduled.id]);
     });
 
+    it('records permanent deletion of a plan-bound workout in the plan revision stream', () => {
+        const selectedPlan = plan({ workoutCount: 0 });
+        const deletedWorkout = workout({
+            planId: selectedPlan.id,
+            lifecycle: 'deleted',
+            deletedAtMs: NOW_MS - 1,
+        });
+        initial = snapshot([selectedPlan], [deletedWorkout], selectedPlan.id);
+
+        const permanentlyDeleted = applyTrainingScheduleMutation(initial, request({
+            kind: 'permanently-delete-workout',
+            workoutId: deletedWorkout.id,
+            confirmPermanentDeletion: true,
+        }, [
+            { scope: 'plan', id: selectedPlan.id, revision: selectedPlan.revision },
+            { scope: 'workout', id: deletedWorkout.id, revision: deletedWorkout.revision },
+        ]), NOW_MS);
+
+        expect(permanentlyDeleted.after.workouts.has(deletedWorkout.id)).toBe(false);
+        expect(permanentlyDeleted.affectedPlanIds).toEqual([selectedPlan.id]);
+        expect(permanentlyDeleted.changedWorkoutIds).toEqual([deletedWorkout.id]);
+        expect(permanentlyDeleted.after.plans.get(selectedPlan.id)).toMatchObject({
+            revision: selectedPlan.revision + 1,
+            workoutCount: 0,
+        });
+    });
+
     it('rejects missing or stale expected revisions', () => {
         const scheduled = workout();
         initial = snapshot([], [scheduled]);
@@ -300,15 +377,21 @@ describe('applyTrainingScheduleMutation', () => {
         expect(() => applyTrainingScheduleMutation(initial, request({
             kind: 'update-workout',
             workoutId: scheduled.id,
+            planId: scheduled.planId,
+            localDate: scheduled.localDate,
             title: 'Changed',
             structure: STRUCTURE,
+            confirmPlanRangeExtension: false,
         }), NOW_MS)).toThrow(expect.objectContaining({ code: 'revision-conflict' }));
 
         expect(() => applyTrainingScheduleMutation(initial, request({
             kind: 'update-workout',
             workoutId: scheduled.id,
+            planId: scheduled.planId,
+            localDate: scheduled.localDate,
             title: 'Changed',
             structure: STRUCTURE,
+            confirmPlanRangeExtension: false,
         }, [{ scope: 'workout', id: scheduled.id, revision: 1 }]), NOW_MS))
             .toThrow(expect.objectContaining({ code: 'revision-conflict' }));
     });

--- a/functions/src/training-plans/mutation.ts
+++ b/functions/src/training-plans/mutation.ts
@@ -298,10 +298,18 @@ export function applyTrainingScheduleMutation(
         }
         case 'update-workout': {
             const workout = expectWorkout(operation.workoutId);
+            const sourcePlanId = workout.planId;
+            if (sourcePlanId) expectPlan(sourcePlanId);
+            if (operation.planId) {
+                const destination = expectPlan(operation.planId);
+                enforceDestinationRange(destination, operation.localDate, operation.confirmPlanRangeExtension);
+            }
+            workout.planId = operation.planId;
+            workout.localDate = operation.localDate;
             workout.title = operation.title;
             workout.structure = cloneValue(operation.structure);
-            affectPlan(workout.planId);
-            if (workout.planId) expectPlan(workout.planId);
+            affectPlan(sourcePlanId);
+            affectPlan(operation.planId);
             changeWorkout(workout.id);
             break;
         }
@@ -377,6 +385,13 @@ export function applyTrainingScheduleMutation(
                     'Delete the workout before permanently deleting its history.',
                 );
             }
+            if (workout.planId) expectPlan(workout.planId);
+            affectPlan(workout.planId);
+            // Plan history must record that this retained root became
+            // unavailable. The persisted plan delta keeps the before snapshot
+            // and an explicit null after value, while the root and its nested
+            // standalone history are removed below.
+            changeWorkout(workout.id);
             after.workouts.delete(workout.id);
             permanentlyDeletedWorkoutIds.add(workout.id);
             break;

--- a/functions/src/training-plans/mutation.ts
+++ b/functions/src/training-plans/mutation.ts
@@ -1,0 +1,451 @@
+import {
+    TRAINING_PLAN_MAX_CURRENT_WORKOUTS,
+    TRAINING_PLAN_SCHEMA_VERSION,
+    addDaysToTrainingLocalDate,
+    extendTrainingPlanRangeToDate,
+    isTrainingLocalDateWithinPlan,
+    parseScheduledWorkoutV1,
+    parseTrainingPlanStateV1,
+    parseTrainingPlanV1,
+    shouldCheckpointTrainingPlanRevision,
+    type ExpectedTrainingScheduleRevision,
+    type MutateTrainingScheduleRequestV1,
+    type MutateTrainingScheduleResponseV1,
+    type ScheduledWorkoutV1,
+    type TrainingPlanStateV1,
+    type TrainingPlanV1,
+} from '../../../shared/training-plans';
+
+export type TrainingScheduleMutationErrorCode =
+    | 'not-found'
+    | 'already-exists'
+    | 'revision-conflict'
+    | 'failed-precondition'
+    | 'range-extension-required'
+    | 'limit-exceeded';
+
+export class TrainingScheduleMutationError extends Error {
+    constructor(
+        public readonly code: TrainingScheduleMutationErrorCode,
+        message: string,
+    ) {
+        super(message);
+        this.name = 'TrainingScheduleMutationError';
+    }
+}
+
+export interface TrainingScheduleSnapshotV1 {
+    state: TrainingPlanStateV1;
+    plans: Map<string, TrainingPlanV1>;
+    workouts: Map<string, ScheduledWorkoutV1>;
+}
+
+export interface AppliedTrainingScheduleMutationV1 {
+    response: MutateTrainingScheduleResponseV1;
+    before: TrainingScheduleSnapshotV1;
+    after: TrainingScheduleSnapshotV1;
+    affectedPlanIds: string[];
+    changedWorkoutIds: string[];
+    permanentlyDeletedWorkoutIds: string[];
+    bulkOperation: boolean;
+}
+
+export function createEmptyTrainingPlanState(nowMs = 0): TrainingPlanStateV1 {
+    return {
+        schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+        activePlanId: null,
+        revision: 0,
+        currentWorkoutCount: 0,
+        updatedAtMs: nowMs,
+    };
+}
+
+function cloneValue<T>(value: T): T {
+    return JSON.parse(JSON.stringify(value)) as T;
+}
+
+export function cloneTrainingScheduleSnapshot(snapshot: TrainingScheduleSnapshotV1): TrainingScheduleSnapshotV1 {
+    return {
+        state: cloneValue(snapshot.state),
+        plans: new Map([...snapshot.plans].map(([id, plan]) => [id, cloneValue(plan)])),
+        workouts: new Map([...snapshot.workouts].map(([id, workout]) => [id, cloneValue(workout)])),
+    };
+}
+
+function expectedRevisionMap(expected: readonly ExpectedTrainingScheduleRevision[]): Map<string, number> {
+    return new Map(expected.map(item => [`${item.scope}:${item.id}`, item.revision]));
+}
+
+function requireExpectedRevision(
+    expected: Map<string, number>,
+    scope: ExpectedTrainingScheduleRevision['scope'],
+    id: string,
+    actualRevision: number,
+): void {
+    const key = `${scope}:${id}`;
+    if (!expected.has(key)) {
+        throw new TrainingScheduleMutationError(
+            'revision-conflict',
+            `The current ${scope} revision is required before changing ${id}.`,
+        );
+    }
+    if (expected.get(key) !== actualRevision) {
+        throw new TrainingScheduleMutationError(
+            'revision-conflict',
+            `${scope} ${id} changed from revision ${expected.get(key)} to ${actualRevision}.`,
+        );
+    }
+}
+
+function currentWorkoutCount(workouts: Map<string, ScheduledWorkoutV1>): number {
+    return [...workouts.values()].filter(workout => workout.lifecycle !== 'deleted').length;
+}
+
+function planWorkoutCount(workouts: Map<string, ScheduledWorkoutV1>, planId: string): number {
+    return [...workouts.values()].filter(workout => (
+        workout.planId === planId && workout.lifecycle !== 'deleted'
+    )).length;
+}
+
+function getPlan(plans: Map<string, TrainingPlanV1>, planId: string): TrainingPlanV1 {
+    const plan = plans.get(planId);
+    if (!plan) throw new TrainingScheduleMutationError('not-found', `Training plan ${planId} was not found.`);
+    return plan;
+}
+
+function getWorkout(workouts: Map<string, ScheduledWorkoutV1>, workoutId: string): ScheduledWorkoutV1 {
+    const workout = workouts.get(workoutId);
+    if (!workout) throw new TrainingScheduleMutationError('not-found', `Scheduled workout ${workoutId} was not found.`);
+    return workout;
+}
+
+function requireCurrentWorkout(workouts: Map<string, ScheduledWorkoutV1>, workoutId: string): ScheduledWorkoutV1 {
+    const workout = getWorkout(workouts, workoutId);
+    if (workout.lifecycle === 'deleted') {
+        throw new TrainingScheduleMutationError('failed-precondition', 'Restore the workout before changing it.');
+    }
+    return workout;
+}
+
+function enforceDestinationRange(
+    plan: TrainingPlanV1,
+    localDate: string,
+    confirmed: boolean,
+): void {
+    if (isTrainingLocalDateWithinPlan(localDate, plan)) return;
+    if (!confirmed) {
+        throw new TrainingScheduleMutationError(
+            'range-extension-required',
+            `Moving this workout requires extending ${plan.name} to include ${localDate}.`,
+        );
+    }
+    Object.assign(plan, extendTrainingPlanRangeToDate(plan, localDate));
+}
+
+function sortPlans(plans: TrainingPlanV1[]): TrainingPlanV1[] {
+    return [...plans].sort((left, right) => (
+        left.startLocalDate.localeCompare(right.startLocalDate)
+        || left.name.localeCompare(right.name)
+        || left.id.localeCompare(right.id)
+    ));
+}
+
+function sortWorkouts(workouts: ScheduledWorkoutV1[]): ScheduledWorkoutV1[] {
+    return [...workouts].sort((left, right) => (
+        left.localDate.localeCompare(right.localDate)
+        || left.title.localeCompare(right.title)
+        || left.id.localeCompare(right.id)
+    ));
+}
+
+export function applyTrainingScheduleMutation(
+    snapshotInput: TrainingScheduleSnapshotV1,
+    request: MutateTrainingScheduleRequestV1,
+    nowMs: number,
+): AppliedTrainingScheduleMutationV1 {
+    if (!Number.isSafeInteger(nowMs) || nowMs < 0) {
+        throw new TypeError('nowMs must be a non-negative safe integer.');
+    }
+
+    const before = cloneTrainingScheduleSnapshot(snapshotInput);
+    const after = cloneTrainingScheduleSnapshot(snapshotInput);
+    const expected = expectedRevisionMap(request.expectedRevisions);
+    const affectedPlanIds = new Set<string>();
+    const changedWorkoutIds = new Set<string>();
+    const permanentlyDeletedWorkoutIds = new Set<string>();
+    let bulkOperation = false;
+
+    requireExpectedRevision(expected, 'state', 'current', before.state.revision);
+
+    const expectPlan = (planId: string): TrainingPlanV1 => {
+        const plan = getPlan(after.plans, planId);
+        requireExpectedRevision(expected, 'plan', planId, before.plans.get(planId)!.revision);
+        return plan;
+    };
+    const expectWorkout = (workoutId: string, allowDeleted = false): ScheduledWorkoutV1 => {
+        const workout = allowDeleted
+            ? getWorkout(after.workouts, workoutId)
+            : requireCurrentWorkout(after.workouts, workoutId);
+        requireExpectedRevision(expected, 'workout', workoutId, before.workouts.get(workoutId)!.revision);
+        return workout;
+    };
+    const affectPlan = (planId: string | null): void => {
+        if (planId) affectedPlanIds.add(planId);
+    };
+    const changeWorkout = (workoutId: string): void => {
+        changedWorkoutIds.add(workoutId);
+    };
+    const activatePlan = (planId: string): void => {
+        const target = expectPlan(planId);
+        if (after.state.activePlanId && after.state.activePlanId !== planId) {
+            const previous = expectPlan(after.state.activePlanId);
+            previous.lifecycle = 'paused';
+            affectedPlanIds.add(previous.id);
+        }
+        target.lifecycle = 'active';
+        after.state.activePlanId = planId;
+        affectedPlanIds.add(planId);
+    };
+
+    const operation = request.operation;
+    switch (operation.kind) {
+        case 'create-plan': {
+            if (after.plans.has(operation.planId)) {
+                throw new TrainingScheduleMutationError('already-exists', `Training plan ${operation.planId} already exists.`);
+            }
+            if (operation.activate && after.state.activePlanId) {
+                const previous = expectPlan(after.state.activePlanId);
+                previous.lifecycle = 'paused';
+                affectedPlanIds.add(previous.id);
+            }
+            const plan: TrainingPlanV1 = {
+                schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+                id: operation.planId,
+                name: operation.name,
+                lifecycle: operation.activate ? 'active' : 'paused',
+                startLocalDate: operation.startLocalDate,
+                endLocalDate: operation.endLocalDate,
+                revision: 1,
+                lastCheckpointRevision: 1,
+                workoutCount: 0,
+                createdAtMs: nowMs,
+                updatedAtMs: nowMs,
+            };
+            after.plans.set(plan.id, plan);
+            affectedPlanIds.add(plan.id);
+            if (operation.activate) after.state.activePlanId = plan.id;
+            break;
+        }
+        case 'rename-plan': {
+            const plan = expectPlan(operation.planId);
+            plan.name = operation.name;
+            affectedPlanIds.add(plan.id);
+            break;
+        }
+        case 'set-plan-lifecycle': {
+            if (operation.lifecycle === 'active') {
+                activatePlan(operation.planId);
+                break;
+            }
+            const plan = expectPlan(operation.planId);
+            plan.lifecycle = operation.lifecycle;
+            affectedPlanIds.add(plan.id);
+            if (after.state.activePlanId === plan.id) after.state.activePlanId = null;
+            break;
+        }
+        case 'shift-plan': {
+            const plan = expectPlan(operation.planId);
+            plan.startLocalDate = addDaysToTrainingLocalDate(plan.startLocalDate, operation.days);
+            plan.endLocalDate = addDaysToTrainingLocalDate(plan.endLocalDate, operation.days);
+            affectedPlanIds.add(plan.id);
+            for (const workout of after.workouts.values()) {
+                if (workout.planId !== plan.id || workout.lifecycle === 'deleted') continue;
+                workout.localDate = addDaysToTrainingLocalDate(workout.localDate, operation.days);
+                changeWorkout(workout.id);
+            }
+            bulkOperation = true;
+            break;
+        }
+        case 'create-workout': {
+            if (after.workouts.has(operation.workoutId)) {
+                throw new TrainingScheduleMutationError('already-exists', `Scheduled workout ${operation.workoutId} already exists.`);
+            }
+            if (currentWorkoutCount(after.workouts) >= TRAINING_PLAN_MAX_CURRENT_WORKOUTS) {
+                throw new TrainingScheduleMutationError(
+                    'limit-exceeded',
+                    `An account may contain at most ${TRAINING_PLAN_MAX_CURRENT_WORKOUTS} current workouts.`,
+                );
+            }
+            if (operation.planId) {
+                const plan = expectPlan(operation.planId);
+                enforceDestinationRange(plan, operation.localDate, operation.confirmPlanRangeExtension);
+                affectedPlanIds.add(plan.id);
+            }
+            after.workouts.set(operation.workoutId, {
+                schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+                id: operation.workoutId,
+                planId: operation.planId,
+                localDate: operation.localDate,
+                lifecycle: 'planned',
+                title: operation.title,
+                structure: cloneValue(operation.structure),
+                revision: 1,
+                createdAtMs: nowMs,
+                updatedAtMs: nowMs,
+            });
+            changeWorkout(operation.workoutId);
+            break;
+        }
+        case 'update-workout': {
+            const workout = expectWorkout(operation.workoutId);
+            workout.title = operation.title;
+            workout.structure = cloneValue(operation.structure);
+            affectPlan(workout.planId);
+            if (workout.planId) expectPlan(workout.planId);
+            changeWorkout(workout.id);
+            break;
+        }
+        case 'move-workout': {
+            const workout = expectWorkout(operation.workoutId);
+            const sourcePlanId = workout.planId;
+            if (sourcePlanId) expectPlan(sourcePlanId);
+            if (operation.planId && operation.planId !== sourcePlanId) {
+                const destination = expectPlan(operation.planId);
+                enforceDestinationRange(destination, operation.localDate, operation.confirmPlanRangeExtension);
+            } else if (operation.planId) {
+                const destination = getPlan(after.plans, operation.planId);
+                enforceDestinationRange(destination, operation.localDate, operation.confirmPlanRangeExtension);
+            }
+            workout.planId = operation.planId;
+            workout.localDate = operation.localDate;
+            affectPlan(sourcePlanId);
+            affectPlan(operation.planId);
+            changeWorkout(workout.id);
+            break;
+        }
+        case 'copy-workout': {
+            const source = expectWorkout(operation.sourceWorkoutId);
+            if (after.workouts.has(operation.workoutId)) {
+                throw new TrainingScheduleMutationError('already-exists', `Scheduled workout ${operation.workoutId} already exists.`);
+            }
+            if (currentWorkoutCount(after.workouts) >= TRAINING_PLAN_MAX_CURRENT_WORKOUTS) {
+                throw new TrainingScheduleMutationError(
+                    'limit-exceeded',
+                    `An account may contain at most ${TRAINING_PLAN_MAX_CURRENT_WORKOUTS} current workouts.`,
+                );
+            }
+            if (operation.planId) {
+                const plan = expectPlan(operation.planId);
+                enforceDestinationRange(plan, operation.localDate, operation.confirmPlanRangeExtension);
+                affectPlan(plan.id);
+            }
+            after.workouts.set(operation.workoutId, {
+                ...cloneValue(source),
+                id: operation.workoutId,
+                planId: operation.planId,
+                localDate: operation.localDate,
+                lifecycle: 'planned',
+                revision: 1,
+                createdAtMs: nowMs,
+                updatedAtMs: nowMs,
+            });
+            changeWorkout(operation.workoutId);
+            break;
+        }
+        case 'set-workout-lifecycle': {
+            const workout = expectWorkout(operation.workoutId);
+            workout.lifecycle = operation.lifecycle;
+            if (workout.planId) expectPlan(workout.planId);
+            affectPlan(workout.planId);
+            changeWorkout(workout.id);
+            break;
+        }
+        case 'delete-workout': {
+            const workout = expectWorkout(operation.workoutId);
+            workout.lifecycle = 'deleted';
+            workout.deletedAtMs = nowMs;
+            if (workout.planId) expectPlan(workout.planId);
+            affectPlan(workout.planId);
+            changeWorkout(workout.id);
+            break;
+        }
+        case 'permanently-delete-workout': {
+            const workout = expectWorkout(operation.workoutId, true);
+            if (workout.lifecycle !== 'deleted') {
+                throw new TrainingScheduleMutationError(
+                    'failed-precondition',
+                    'Delete the workout before permanently deleting its history.',
+                );
+            }
+            after.workouts.delete(workout.id);
+            permanentlyDeletedWorkoutIds.add(workout.id);
+            break;
+        }
+    }
+
+    for (const workoutId of changedWorkoutIds) {
+        const workout = after.workouts.get(workoutId);
+        const previous = before.workouts.get(workoutId);
+        if (!workout) continue;
+        if (previous) {
+            workout.revision = previous.revision + 1;
+            workout.createdAtMs = previous.createdAtMs;
+        }
+        workout.updatedAtMs = nowMs;
+        after.workouts.set(workout.id, parseScheduledWorkoutV1(workout));
+    }
+
+    for (const planId of affectedPlanIds) {
+        const plan = getPlan(after.plans, planId);
+        const previous = before.plans.get(planId);
+        if (previous) {
+            plan.revision = previous.revision + 1;
+            plan.createdAtMs = previous.createdAtMs;
+        }
+        plan.workoutCount = planWorkoutCount(after.workouts, planId);
+        plan.updatedAtMs = nowMs;
+        if (shouldCheckpointTrainingPlanRevision(plan.revision, bulkOperation)) {
+            plan.lastCheckpointRevision = plan.revision;
+        } else if (previous) {
+            plan.lastCheckpointRevision = previous.lastCheckpointRevision;
+        }
+        after.plans.set(plan.id, parseTrainingPlanV1(plan));
+    }
+
+    after.state = parseTrainingPlanStateV1({
+        ...after.state,
+        schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+        revision: before.state.revision + 1,
+        currentWorkoutCount: currentWorkoutCount(after.workouts),
+        updatedAtMs: nowMs,
+    });
+
+    const changedPlans = [...affectedPlanIds].map(planId => cloneValue(getPlan(after.plans, planId)));
+    // Bulk operations are observed through the current-data listeners. Keeping
+    // hundreds of full workout structures out of the callable response also
+    // keeps the idempotency receipt safely below Firestore's document limit.
+    const changedWorkouts = bulkOperation
+        ? []
+        : [...changedWorkoutIds]
+            .map(workoutId => after.workouts.get(workoutId))
+            .filter((workout): workout is ScheduledWorkoutV1 => Boolean(workout))
+            .map(cloneValue);
+    const permanentlyDeleted = [...permanentlyDeletedWorkoutIds];
+
+    return {
+        response: {
+            mutationId: request.mutationId,
+            state: cloneValue(after.state),
+            plans: sortPlans(changedPlans),
+            workouts: sortWorkouts(changedWorkouts),
+            removedPlanIds: [],
+            permanentlyDeletedWorkoutIds: permanentlyDeleted,
+        },
+        before,
+        after,
+        affectedPlanIds: [...affectedPlanIds],
+        changedWorkoutIds: [...changedWorkoutIds],
+        permanentlyDeletedWorkoutIds: permanentlyDeleted,
+        bulkOperation,
+    };
+}

--- a/functions/src/training-plans/persistence.spec.ts
+++ b/functions/src/training-plans/persistence.spec.ts
@@ -1,0 +1,516 @@
+import { ActivityTypes } from '@sports-alliance/sports-lib';
+import { gunzipSync } from 'node:zlib';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+    MutateTrainingScheduleRequestV1,
+    ScheduledWorkoutV1,
+    TrainingPlanV1,
+} from '../../../shared/training-plans';
+import {
+    applyTrainingScheduleMutation,
+    createEmptyTrainingPlanState,
+    type TrainingScheduleSnapshotV1,
+} from './mutation';
+
+const guard = vi.hoisted(() => ({
+    result: { shouldSkip: false },
+    getUserDeletionGuardStateInTransaction: vi.fn(),
+}));
+
+vi.mock('../shared/user-deletion-guard', () => ({
+    getUserDeletionGuardStateInTransaction: guard.getUserDeletionGuardStateInTransaction,
+}));
+
+import {
+    buildTrainingScheduleRevisionWrites,
+    hashTrainingScheduleMutationRequest,
+    mutateTrainingScheduleForUser,
+    trainingScheduleDeletionTombstoneDocumentId,
+} from './persistence';
+
+const NOW_MS = Date.UTC(2026, 8, 2, 10);
+const STRUCTURE = {
+    version: 1 as const,
+    sport: ActivityTypes.Running,
+    nodes: [{
+        kind: 'step' as const,
+        id: 'steady',
+        purpose: 'work' as const,
+        ending: { kind: 'time' as const, seconds: 1800 },
+        targets: [],
+    }],
+};
+
+interface FakeDocumentData {
+    [key: string]: unknown;
+}
+
+class FakeDocumentSnapshot {
+    constructor(
+        readonly ref: FakeDocumentReference,
+        private readonly stored: FakeDocumentData | undefined,
+    ) {}
+
+    get id(): string { return this.ref.id; }
+    get exists(): boolean { return this.stored !== undefined; }
+    data(): FakeDocumentData | undefined {
+        return this.stored === undefined
+            ? undefined
+            : JSON.parse(JSON.stringify(this.stored)) as FakeDocumentData;
+    }
+}
+
+class FakeQuery {
+    constructor(
+        readonly collectionRef: FakeCollectionReference,
+        readonly filter?: { field: string; operator: string; value: unknown },
+    ) {}
+}
+
+class FakeDocumentReference {
+    readonly kind = 'document';
+
+    constructor(
+        readonly db: FakeFirestore,
+        readonly path: string,
+    ) {}
+
+    get id(): string { return this.path.split('/').at(-1) ?? ''; }
+    collection(id: string): FakeCollectionReference {
+        return new FakeCollectionReference(this.db, `${this.path}/${id}`);
+    }
+}
+
+class FakeCollectionReference extends FakeQuery {
+    readonly kind = 'collection';
+
+    constructor(
+        readonly db: FakeFirestore,
+        readonly path: string,
+    ) {
+        super(undefined as never);
+        this.collectionRef = this;
+    }
+
+    override collectionRef: FakeCollectionReference;
+    get id(): string { return this.path.split('/').at(-1) ?? ''; }
+    doc(id: string): FakeDocumentReference {
+        return new FakeDocumentReference(this.db, `${this.path}/${id}`);
+    }
+    where(field: string, operator: string, value: unknown): FakeQuery {
+        return new FakeQuery(this, { field, operator, value });
+    }
+}
+
+class FakeTransaction {
+    constructor(private readonly db: FakeFirestore) {}
+
+    async get(ref: FakeDocumentReference | FakeQuery): Promise<FakeDocumentSnapshot | { docs: FakeDocumentSnapshot[] }> {
+        if (ref instanceof FakeDocumentReference) return this.db.documentSnapshot(ref);
+        return { docs: this.db.querySnapshots(ref) };
+    }
+
+    set(ref: FakeDocumentReference, value: unknown): void {
+        this.db.documents.set(ref.path, JSON.parse(JSON.stringify(value)) as FakeDocumentData);
+    }
+
+    create(ref: FakeDocumentReference, value: unknown): void {
+        if (this.db.documents.has(ref.path)) throw new Error(`Document already exists: ${ref.path}`);
+        this.set(ref, value);
+    }
+
+    delete(ref: FakeDocumentReference): void {
+        this.db.documents.delete(ref.path);
+    }
+}
+
+class FakeFirestore {
+    readonly documents = new Map<string, FakeDocumentData>();
+    readonly recursiveDelete = vi.fn(async (ref: FakeDocumentReference) => {
+        for (const path of [...this.documents.keys()]) {
+            if (path === ref.path || path.startsWith(`${ref.path}/`)) this.documents.delete(path);
+        }
+    });
+
+    collection(id: string): FakeCollectionReference {
+        return new FakeCollectionReference(this, id);
+    }
+
+    async runTransaction<T>(handler: (transaction: FakeTransaction) => Promise<T>): Promise<T> {
+        return handler(new FakeTransaction(this));
+    }
+
+    documentSnapshot(ref: FakeDocumentReference): FakeDocumentSnapshot {
+        return new FakeDocumentSnapshot(ref, this.documents.get(ref.path));
+    }
+
+    querySnapshots(query: FakeQuery): FakeDocumentSnapshot[] {
+        const prefix = `${query.collectionRef.path}/`;
+        return [...this.documents.entries()]
+            .filter(([path]) => path.startsWith(prefix) && !path.slice(prefix.length).includes('/'))
+            .filter(([, value]) => {
+                if (!query.filter) return true;
+                if (query.filter.operator === 'in' && Array.isArray(query.filter.value)) {
+                    return query.filter.value.includes(value[query.filter.field]);
+                }
+                return false;
+            })
+            .map(([path, value]) => new FakeDocumentSnapshot(new FakeDocumentReference(this, path), value));
+    }
+
+    seed(path: string, value: unknown): void {
+        this.documents.set(path, JSON.parse(JSON.stringify(value)) as FakeDocumentData);
+    }
+
+    read(path: string): FakeDocumentData | undefined {
+        return this.documents.get(path);
+    }
+}
+
+function plan(overrides: Partial<TrainingPlanV1> = {}): TrainingPlanV1 {
+    return {
+        schemaVersion: 1,
+        id: 'plan-1',
+        name: 'Plan one',
+        lifecycle: 'active',
+        startLocalDate: '2026-09-01',
+        endLocalDate: '2026-09-30',
+        revision: 3,
+        lastCheckpointRevision: 1,
+        workoutCount: 1,
+        createdAtMs: 1,
+        updatedAtMs: 2,
+        ...overrides,
+    };
+}
+
+function workout(overrides: Partial<ScheduledWorkoutV1> = {}): ScheduledWorkoutV1 {
+    return {
+        schemaVersion: 1,
+        id: 'workout-1',
+        planId: null,
+        localDate: '2026-09-02',
+        lifecycle: 'planned',
+        title: 'Steady run',
+        structure: STRUCTURE,
+        revision: 2,
+        createdAtMs: 1,
+        updatedAtMs: 2,
+        ...overrides,
+    };
+}
+
+function request(
+    operation: MutateTrainingScheduleRequestV1['operation'],
+    expectedRevisions: MutateTrainingScheduleRequestV1['expectedRevisions'] = [],
+    mutationId = `mutation-${operation.kind}`,
+): MutateTrainingScheduleRequestV1 {
+    return {
+        mutationId,
+        expectedRevisions: [
+            { scope: 'state', id: 'current', revision: 0 },
+            ...expectedRevisions,
+        ],
+        operation,
+    };
+}
+
+describe('training schedule revision writes', () => {
+    it('creates complete standalone snapshots for both sides of a scope transfer', () => {
+        const sourcePlan = plan();
+        const scheduled = workout({ planId: sourcePlan.id });
+        const snapshot: TrainingScheduleSnapshotV1 = {
+            state: {
+                ...createEmptyTrainingPlanState(),
+                activePlanId: sourcePlan.id,
+                revision: 1,
+                currentWorkoutCount: 1,
+            },
+            plans: new Map([[sourcePlan.id, sourcePlan]]),
+            workouts: new Map([[scheduled.id, scheduled]]),
+        };
+        const moveRequest: MutateTrainingScheduleRequestV1 = {
+            mutationId: 'detach',
+            expectedRevisions: [
+                { scope: 'state', id: 'current', revision: 1 },
+                { scope: 'plan', id: sourcePlan.id, revision: sourcePlan.revision },
+                { scope: 'workout', id: scheduled.id, revision: scheduled.revision },
+            ],
+            operation: {
+                kind: 'move-workout',
+                workoutId: scheduled.id,
+                planId: null,
+                localDate: '2026-09-03',
+                confirmPlanRangeExtension: false,
+            },
+        };
+        const applied = applyTrainingScheduleMutation(snapshot, moveRequest, NOW_MS);
+        const revisions = buildTrainingScheduleRevisionWrites(applied, moveRequest, NOW_MS);
+
+        expect(revisions.planRevisions.get(sourcePlan.id)?.delta).toMatchObject({
+            workoutCount: 1,
+            workoutChunkCount: 1,
+            workoutEncoding: 'gzip-json-base64-v1',
+        });
+        const encodedDelta = (revisions.planRevisionChunks.get(sourcePlan.id) ?? [])
+            .filter(chunk => chunk.kind === 'delta-workouts')
+            .map(chunk => chunk.payloadBase64)
+            .join('');
+        const workoutDeltas = JSON.parse(
+            gunzipSync(Buffer.from(encodedDelta, 'base64')).toString('utf8'),
+        ) as unknown[];
+        expect(workoutDeltas).toEqual([expect.objectContaining({
+            workoutId: scheduled.id,
+            before: expect.objectContaining({ planId: sourcePlan.id }),
+            after: expect.objectContaining({ planId: null }),
+        })]);
+        expect(revisions.standaloneWorkoutRevisions.get(scheduled.id)?.snapshot).toMatchObject({
+            id: scheduled.id,
+            planId: null,
+        });
+    });
+
+    it('writes the complete plan state in first and bulk checkpoints', () => {
+        const newPlanRequest = request({
+            kind: 'create-plan',
+            planId: 'plan-new',
+            name: 'New plan',
+            startLocalDate: '2026-09-01',
+            endLocalDate: '2026-09-30',
+            activate: false,
+        });
+        const snapshot: TrainingScheduleSnapshotV1 = {
+            state: createEmptyTrainingPlanState(),
+            plans: new Map(),
+            workouts: new Map(),
+        };
+        const applied = applyTrainingScheduleMutation(snapshot, newPlanRequest, NOW_MS);
+        const revision = buildTrainingScheduleRevisionWrites(applied, newPlanRequest, NOW_MS)
+            .planRevisions.get('plan-new');
+
+        expect(revision).toMatchObject({
+            revision: 1,
+            checkpointRevision: 1,
+            checkpoint: {
+                plan: { id: 'plan-new' },
+                workoutCount: 0,
+                workoutChunkCount: 0,
+                workoutEncoding: 'gzip-json-base64-v1',
+            },
+        });
+
+        const existingPlan = plan();
+        const scheduled = workout({ planId: existingPlan.id });
+        const bulkSnapshot: TrainingScheduleSnapshotV1 = {
+            state: {
+                ...createEmptyTrainingPlanState(),
+                activePlanId: existingPlan.id,
+                revision: 1,
+                currentWorkoutCount: 1,
+            },
+            plans: new Map([[existingPlan.id, existingPlan]]),
+            workouts: new Map([[scheduled.id, scheduled]]),
+        };
+        const shiftRequest: MutateTrainingScheduleRequestV1 = {
+            mutationId: 'bulk-shift',
+            expectedRevisions: [
+                { scope: 'state', id: 'current', revision: 1 },
+                { scope: 'plan', id: existingPlan.id, revision: existingPlan.revision },
+            ],
+            operation: { kind: 'shift-plan', planId: existingPlan.id, days: 1 },
+        };
+        const shifted = applyTrainingScheduleMutation(bulkSnapshot, shiftRequest, NOW_MS);
+        const shiftedWrites = buildTrainingScheduleRevisionWrites(shifted, shiftRequest, NOW_MS);
+        expect(shiftedWrites.planRevisions.get(existingPlan.id)?.checkpoint).toMatchObject({
+            workoutCount: 1,
+            workoutChunkCount: 1,
+        });
+        const checkpointPayload = shiftedWrites.planRevisionChunks.get(existingPlan.id)
+            ?.filter(chunk => chunk.kind === 'checkpoint-workouts')
+            .map(chunk => chunk.payloadBase64)
+            .join('') ?? '';
+        expect(JSON.parse(
+            gunzipSync(Buffer.from(checkpointPayload, 'base64')).toString('utf8'),
+        )).toEqual([expect.objectContaining({ id: scheduled.id, localDate: '2026-09-03' })]);
+    });
+
+    it('hashes canonical request content independently of object key order', () => {
+        const first = request({
+            kind: 'rename-plan', planId: 'plan-1', name: 'Updated',
+        }, [{ scope: 'plan', id: 'plan-1', revision: 1 }]);
+        const second = {
+            operation: { name: 'Updated', planId: 'plan-1', kind: 'rename-plan' as const },
+            expectedRevisions: first.expectedRevisions.map(item => ({
+                revision: item.revision, id: item.id, scope: item.scope,
+            })),
+            mutationId: first.mutationId,
+        };
+        expect(hashTrainingScheduleMutationRequest(first)).toBe(hashTrainingScheduleMutationRequest(second));
+    });
+});
+
+describe('mutateTrainingScheduleForUser persistence', () => {
+    let db: FakeFirestore;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        db = new FakeFirestore();
+        guard.result = { shouldSkip: false };
+        guard.getUserDeletionGuardStateInTransaction.mockImplementation(async () => guard.result);
+    });
+
+    it('persists current state, a standalone snapshot, and an internal idempotency receipt', async () => {
+        const mutation = request({
+            kind: 'create-workout',
+            workoutId: 'standalone-1',
+            planId: null,
+            localDate: '2026-09-03',
+            title: 'Standalone run',
+            structure: STRUCTURE,
+            confirmPlanRangeExtension: false,
+        });
+
+        const response = await mutateTrainingScheduleForUser('user-1', mutation, {
+            db: db as never,
+            nowMs: NOW_MS,
+        });
+
+        expect(response.workouts).toEqual([expect.objectContaining({ id: 'standalone-1', planId: null })]);
+        expect(db.read('users/user-1/trainingPlanState/current')).toMatchObject({
+            revision: 1,
+            currentWorkoutCount: 1,
+        });
+        expect(db.read('users/user-1/scheduledWorkouts/standalone-1')).toMatchObject({ revision: 1 });
+        expect(db.read('users/user-1/scheduledWorkouts/standalone-1/revisions/0000000001')).toMatchObject({
+            operationKind: 'create-workout',
+            snapshot: { id: 'standalone-1' },
+        });
+        expect(db.read('users/user-1/trainingPlanState/current/mutationReceipts/mutation-create-workout'))
+            .toMatchObject({ requestHash: hashTrainingScheduleMutationRequest(mutation) });
+    });
+
+    it('returns the stored response for exact retries without creating another revision', async () => {
+        const mutation = request({
+            kind: 'create-workout',
+            workoutId: 'standalone-1',
+            planId: null,
+            localDate: '2026-09-03',
+            title: 'Standalone run',
+            structure: STRUCTURE,
+            confirmPlanRangeExtension: false,
+        });
+        const first = await mutateTrainingScheduleForUser('user-1', mutation, { db: db as never, nowMs: NOW_MS });
+        const second = await mutateTrainingScheduleForUser('user-1', mutation, { db: db as never, nowMs: NOW_MS + 100 });
+
+        expect(second).toEqual(first);
+        expect(db.read('users/user-1/trainingPlanState/current')).toMatchObject({ revision: 1 });
+        expect([...db.documents.keys()].filter(path => path.includes('/revisions/'))).toHaveLength(1);
+    });
+
+    it('rejects mutation-ID reuse with different content', async () => {
+        const first = request({
+            kind: 'create-plan',
+            planId: 'plan-1',
+            name: 'First',
+            startLocalDate: '2026-09-01',
+            endLocalDate: '2026-09-30',
+            activate: false,
+        }, [], 'same-id');
+        await mutateTrainingScheduleForUser('user-1', first, { db: db as never, nowMs: NOW_MS });
+
+        const reused = {
+            ...first,
+            operation: { ...first.operation, name: 'Different' },
+        } as MutateTrainingScheduleRequestV1;
+        await expect(mutateTrainingScheduleForUser('user-1', reused, { db: db as never, nowMs: NOW_MS + 1 }))
+            .rejects.toMatchObject({ code: 'failed-precondition' });
+    });
+
+    it('rechecks account deletion inside the transaction before every write', async () => {
+        guard.result = { shouldSkip: true };
+        const mutation = request({
+            kind: 'create-plan',
+            planId: 'plan-1',
+            name: 'Blocked',
+            startLocalDate: '2026-09-01',
+            endLocalDate: '2026-09-30',
+            activate: false,
+        });
+
+        await expect(mutateTrainingScheduleForUser('user-1', mutation, { db: db as never, nowMs: NOW_MS }))
+            .rejects.toMatchObject({ code: 'failed-precondition' });
+        expect(db.documents.size).toBe(0);
+    });
+
+    it('fences all schedule mutations while a resumable plan deletion is active', async () => {
+        db.seed('users/user-1/trainingPlanState/current/planDeletionLocks/plan-1', {
+            schemaVersion: 1,
+            mutationId: 'delete-plan-1',
+        });
+        const mutation = request({
+            kind: 'create-workout',
+            workoutId: 'standalone-1',
+            planId: null,
+            localDate: '2026-09-03',
+            title: 'Blocked standalone run',
+            structure: STRUCTURE,
+            confirmPlanRangeExtension: false,
+        });
+
+        await expect(mutateTrainingScheduleForUser('user-1', mutation, { db: db as never, nowMs: NOW_MS }))
+            .rejects.toThrow('plan deletion is in progress');
+        expect(db.read('users/user-1/scheduledWorkouts/standalone-1')).toBeUndefined();
+    });
+
+    it('recursively removes a permanently deleted workout history after the atomic receipt', async () => {
+        const deletedWorkout = workout({ lifecycle: 'deleted', deletedAtMs: NOW_MS - 1 });
+        db.seed('users/user-1/trainingPlanState/current', {
+            ...createEmptyTrainingPlanState(), revision: 2,
+        });
+        db.seed(`users/user-1/scheduledWorkouts/${deletedWorkout.id}`, deletedWorkout);
+        db.seed(`users/user-1/scheduledWorkouts/${deletedWorkout.id}/revisions/0000000002`, {
+            revision: 2,
+        });
+        const mutation: MutateTrainingScheduleRequestV1 = {
+            mutationId: 'permanent-delete',
+            expectedRevisions: [
+                { scope: 'state', id: 'current', revision: 2 },
+                { scope: 'workout', id: deletedWorkout.id, revision: deletedWorkout.revision },
+            ],
+            operation: {
+                kind: 'permanently-delete-workout',
+                workoutId: deletedWorkout.id,
+                confirmPermanentDeletion: true,
+            },
+        };
+
+        await mutateTrainingScheduleForUser('user-1', mutation, { db: db as never, nowMs: NOW_MS });
+
+        expect(db.recursiveDelete).toHaveBeenCalledWith(expect.objectContaining({
+            path: `users/user-1/scheduledWorkouts/${deletedWorkout.id}`,
+        }));
+        expect(db.read(`users/user-1/scheduledWorkouts/${deletedWorkout.id}`)).toBeUndefined();
+        expect(db.read(`users/user-1/scheduledWorkouts/${deletedWorkout.id}/revisions/0000000002`)).toBeUndefined();
+        const tombstoneId = trainingScheduleDeletionTombstoneDocumentId('workout', deletedWorkout.id);
+        expect(db.read(`users/user-1/trainingPlanState/current/deletionTombstones/${tombstoneId}`)).toMatchObject({
+            entityKind: 'workout',
+            entityIdHash: tombstoneId,
+            mutationId: mutation.mutationId,
+        });
+
+        const recreate = request({
+            kind: 'create-workout',
+            workoutId: deletedWorkout.id,
+            planId: null,
+            localDate: '2026-09-04',
+            title: 'Must not be recreated',
+            structure: STRUCTURE,
+            confirmPlanRangeExtension: false,
+        });
+        recreate.expectedRevisions[0].revision = 3;
+        await expect(mutateTrainingScheduleForUser('user-1', recreate, {
+            db: db as never,
+            nowMs: NOW_MS + 1,
+        })).rejects.toMatchObject({ code: 'already-exists' });
+    });
+});

--- a/functions/src/training-plans/persistence.ts
+++ b/functions/src/training-plans/persistence.ts
@@ -1,0 +1,517 @@
+import { createHash } from 'node:crypto';
+import { gzipSync } from 'node:zlib';
+import * as admin from 'firebase-admin';
+import { Timestamp } from 'firebase-admin/firestore';
+import {
+    SCHEDULED_WORKOUTS_COLLECTION_ID,
+    TRAINING_PLAN_MUTATION_RECEIPTS_COLLECTION_ID,
+    TRAINING_PLAN_REVISIONS_COLLECTION_ID,
+    TRAINING_PLAN_SCHEMA_VERSION,
+    TRAINING_PLANS_COLLECTION_ID,
+    TRAINING_SCHEDULE_DELETION_TOMBSTONES_COLLECTION_ID,
+    parseScheduledWorkoutV1,
+    parseTrainingPlanStateV1,
+    parseTrainingPlanV1,
+    type MutateTrainingScheduleRequestV1,
+    type MutateTrainingScheduleResponseV1,
+    type ScheduledWorkoutV1,
+    type TrainingPlanV1,
+} from '../../../shared/training-plans';
+import { getUserDeletionGuardStateInTransaction } from '../shared/user-deletion-guard';
+import {
+    TrainingScheduleMutationError,
+    applyTrainingScheduleMutation,
+    createEmptyTrainingPlanState,
+    type AppliedTrainingScheduleMutationV1,
+    type TrainingScheduleSnapshotV1,
+} from './mutation';
+import { assertNoTrainingPlanDeletionInProgress } from './deletion-lock';
+
+const MUTATION_RECEIPT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+const FIRESTORE_TRANSACTION_WRITE_BUDGET = 490;
+
+export const TRAINING_PLAN_REVISION_CHUNKS_COLLECTION_ID = 'chunks';
+export const TRAINING_PLAN_REVISION_CHUNK_ENCODING = 'gzip-json-base64-v1' as const;
+export const TRAINING_PLAN_REVISION_CHUNK_MAX_BASE64_CHARACTERS = 700_000;
+export const TRAINING_PLAN_REVISION_MAX_CHUNKS = 100;
+
+export interface TrainingPlanWorkoutDeltaV1 {
+    workoutId: string;
+    before: ScheduledWorkoutV1 | null;
+    after: ScheduledWorkoutV1 | null;
+}
+
+export interface TrainingPlanRevisionDocumentV1 {
+    schemaVersion: typeof TRAINING_PLAN_SCHEMA_VERSION;
+    revision: number;
+    mutationId: string;
+    operationKind: string;
+    createdAtMs: number;
+    checkpointRevision: number;
+    delta: {
+        planBefore: TrainingPlanV1 | null;
+        planAfter: TrainingPlanV1;
+        workoutCount: number;
+        workoutChunkCount: number;
+        workoutEncoding: typeof TRAINING_PLAN_REVISION_CHUNK_ENCODING;
+    };
+    checkpoint?: {
+        plan: TrainingPlanV1;
+        workoutCount: number;
+        workoutChunkCount: number;
+        workoutEncoding: typeof TRAINING_PLAN_REVISION_CHUNK_ENCODING;
+    };
+}
+
+export type TrainingPlanRevisionChunkKindV1 = 'delta-workouts' | 'checkpoint-workouts';
+
+export interface TrainingPlanRevisionChunkDocumentV1 {
+    schemaVersion: typeof TRAINING_PLAN_SCHEMA_VERSION;
+    revision: number;
+    kind: TrainingPlanRevisionChunkKindV1;
+    chunkIndex: number;
+    chunkCount: number;
+    encoding: typeof TRAINING_PLAN_REVISION_CHUNK_ENCODING;
+    payloadBase64: string;
+}
+
+export interface StandaloneWorkoutRevisionDocumentV1 {
+    schemaVersion: typeof TRAINING_PLAN_SCHEMA_VERSION;
+    revision: number;
+    mutationId: string;
+    operationKind: string;
+    createdAtMs: number;
+    snapshot: ScheduledWorkoutV1;
+}
+
+export type TrainingScheduleDeletionTombstoneKindV1 = 'plan' | 'workout';
+
+export interface TrainingScheduleDeletionTombstoneV1 {
+    schemaVersion: typeof TRAINING_PLAN_SCHEMA_VERSION;
+    entityKind: TrainingScheduleDeletionTombstoneKindV1;
+    entityIdHash: string;
+    mutationId: string;
+    createdAtMs: number;
+}
+
+export interface TrainingScheduleRevisionWritesV1 {
+    planRevisions: Map<string, TrainingPlanRevisionDocumentV1>;
+    planRevisionChunks: Map<string, TrainingPlanRevisionChunkDocumentV1[]>;
+    standaloneWorkoutRevisions: Map<string, StandaloneWorkoutRevisionDocumentV1>;
+}
+
+interface StoredMutationReceiptV1 {
+    schemaVersion: typeof TRAINING_PLAN_SCHEMA_VERSION;
+    requestHash: string;
+    response: MutateTrainingScheduleResponseV1;
+    createdAtMs: number;
+    expireAt: Timestamp;
+}
+
+function stableJson(value: unknown): string {
+    if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+    if (value && typeof value === 'object') {
+        const record = value as Record<string, unknown>;
+        return `{${Object.keys(record).sort().map(key => `${JSON.stringify(key)}:${stableJson(record[key])}`).join(',')}}`;
+    }
+    return JSON.stringify(value);
+}
+
+export function hashTrainingScheduleRequestPayload(request: unknown): string {
+    return createHash('sha256').update(stableJson(request)).digest('hex');
+}
+
+export function hashTrainingScheduleMutationRequest(request: MutateTrainingScheduleRequestV1): string {
+    return hashTrainingScheduleRequestPayload(request);
+}
+
+export function trainingScheduleDeletionTombstoneDocumentId(
+    entityKind: TrainingScheduleDeletionTombstoneKindV1,
+    entityId: string,
+): string {
+    return createHash('sha256').update(`${entityKind}:${entityId}`).digest('hex');
+}
+
+export function buildTrainingScheduleDeletionTombstone(
+    entityKind: TrainingScheduleDeletionTombstoneKindV1,
+    entityId: string,
+    mutationId: string,
+    createdAtMs: number,
+): TrainingScheduleDeletionTombstoneV1 {
+    return {
+        schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+        entityKind,
+        entityIdHash: trainingScheduleDeletionTombstoneDocumentId(entityKind, entityId),
+        mutationId,
+        createdAtMs,
+    };
+}
+
+function cloneValue<T>(value: T): T {
+    return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+    return stableJson(left) === stableJson(right);
+}
+
+function workoutsForPlan(snapshot: TrainingScheduleSnapshotV1, planId: string): ScheduledWorkoutV1[] {
+    return [...snapshot.workouts.values()]
+        .filter(workout => workout.planId === planId && workout.lifecycle !== 'deleted')
+        .map(cloneValue)
+        .sort((left, right) => left.localDate.localeCompare(right.localDate) || left.id.localeCompare(right.id));
+}
+
+function encodeRevisionChunks(
+    revision: number,
+    kind: TrainingPlanRevisionChunkKindV1,
+    value: readonly unknown[],
+): TrainingPlanRevisionChunkDocumentV1[] {
+    if (value.length === 0) return [];
+    const payloadBase64 = gzipSync(Buffer.from(JSON.stringify(value), 'utf8')).toString('base64');
+    const chunkCount = Math.ceil(payloadBase64.length / TRAINING_PLAN_REVISION_CHUNK_MAX_BASE64_CHARACTERS);
+    if (chunkCount > TRAINING_PLAN_REVISION_MAX_CHUNKS) {
+        throw new TrainingScheduleMutationError(
+            'limit-exceeded',
+            'This plan snapshot is too large to store as bounded revision history.',
+        );
+    }
+    return Array.from({ length: chunkCount }, (_, chunkIndex) => ({
+        schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+        revision,
+        kind,
+        chunkIndex,
+        chunkCount,
+        encoding: TRAINING_PLAN_REVISION_CHUNK_ENCODING,
+        payloadBase64: payloadBase64.slice(
+            chunkIndex * TRAINING_PLAN_REVISION_CHUNK_MAX_BASE64_CHARACTERS,
+            (chunkIndex + 1) * TRAINING_PLAN_REVISION_CHUNK_MAX_BASE64_CHARACTERS,
+        ),
+    }));
+}
+
+export function trainingPlanRevisionChunkDocumentId(
+    kind: TrainingPlanRevisionChunkKindV1,
+    chunkIndex: number,
+): string {
+    return `${kind}-${`${chunkIndex}`.padStart(4, '0')}`;
+}
+
+export function buildTrainingScheduleRevisionWrites(
+    applied: AppliedTrainingScheduleMutationV1,
+    request: { mutationId: string; operation: { kind: string } },
+    nowMs: number,
+): TrainingScheduleRevisionWritesV1 {
+    const planRevisions = new Map<string, TrainingPlanRevisionDocumentV1>();
+    const planRevisionChunks = new Map<string, TrainingPlanRevisionChunkDocumentV1[]>();
+    const standaloneWorkoutRevisions = new Map<string, StandaloneWorkoutRevisionDocumentV1>();
+
+    for (const planId of applied.affectedPlanIds) {
+        const beforePlan = applied.before.plans.get(planId) ?? null;
+        const afterPlan = applied.after.plans.get(planId);
+        if (!afterPlan) continue;
+        const workoutIds = new Set<string>();
+        for (const workoutId of applied.changedWorkoutIds) {
+            const beforeWorkout = applied.before.workouts.get(workoutId);
+            const afterWorkout = applied.after.workouts.get(workoutId);
+            if (beforeWorkout?.planId === planId || afterWorkout?.planId === planId) workoutIds.add(workoutId);
+        }
+        const workoutDeltas = [...workoutIds]
+            .map(workoutId => ({
+                workoutId,
+                before: cloneValue(applied.before.workouts.get(workoutId) ?? null),
+                after: cloneValue(applied.after.workouts.get(workoutId) ?? null),
+            }))
+            .filter(delta => !valuesEqual(delta.before, delta.after))
+            .sort((left, right) => left.workoutId.localeCompare(right.workoutId));
+        const isCheckpoint = afterPlan.lastCheckpointRevision === afterPlan.revision;
+        const deltaChunks = encodeRevisionChunks(afterPlan.revision, 'delta-workouts', workoutDeltas);
+        const checkpointWorkouts = isCheckpoint ? workoutsForPlan(applied.after, planId) : [];
+        const checkpointChunks = encodeRevisionChunks(
+            afterPlan.revision,
+            'checkpoint-workouts',
+            checkpointWorkouts,
+        );
+        const revision: TrainingPlanRevisionDocumentV1 = {
+            schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+            revision: afterPlan.revision,
+            mutationId: request.mutationId,
+            operationKind: request.operation.kind,
+            createdAtMs: nowMs,
+            checkpointRevision: afterPlan.lastCheckpointRevision,
+            delta: {
+                planBefore: cloneValue(beforePlan),
+                planAfter: cloneValue(afterPlan),
+                workoutCount: workoutDeltas.length,
+                workoutChunkCount: deltaChunks.length,
+                workoutEncoding: TRAINING_PLAN_REVISION_CHUNK_ENCODING,
+            },
+        };
+        planRevisions.set(planId, isCheckpoint ? {
+            ...revision,
+            checkpoint: {
+                plan: cloneValue(afterPlan),
+                workoutCount: checkpointWorkouts.length,
+                workoutChunkCount: checkpointChunks.length,
+                workoutEncoding: TRAINING_PLAN_REVISION_CHUNK_ENCODING,
+            },
+        } : revision);
+        planRevisionChunks.set(planId, [...deltaChunks, ...checkpointChunks]);
+    }
+
+    for (const workoutId of applied.changedWorkoutIds) {
+        const beforeWorkout = applied.before.workouts.get(workoutId);
+        const afterWorkout = applied.after.workouts.get(workoutId);
+        if (!afterWorkout) continue;
+        if (beforeWorkout?.planId !== null && afterWorkout.planId !== null) continue;
+        standaloneWorkoutRevisions.set(workoutId, {
+            schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+            revision: afterWorkout.revision,
+            mutationId: request.mutationId,
+            operationKind: request.operation.kind,
+            createdAtMs: nowMs,
+            snapshot: cloneValue(afterWorkout),
+        });
+    }
+
+    const estimatedWriteCount = 2
+        + applied.affectedPlanIds.length * 2
+        + applied.changedWorkoutIds.length
+        + applied.permanentlyDeletedWorkoutIds.length * 2
+        + standaloneWorkoutRevisions.size
+        + [...planRevisionChunks.values()].reduce((total, chunks) => total + chunks.length, 0);
+    if (estimatedWriteCount > FIRESTORE_TRANSACTION_WRITE_BUDGET) {
+        throw new TrainingScheduleMutationError(
+            'limit-exceeded',
+            'This change produces too much revision history for one atomic operation. Split it into smaller changes.',
+        );
+    }
+
+    return { planRevisions, planRevisionChunks, standaloneWorkoutRevisions };
+}
+
+function parseStoredMutationResponse(value: unknown): MutateTrainingScheduleResponseV1 {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('Invalid mutation receipt response.');
+    const record = value as Record<string, unknown>;
+    if (typeof record.mutationId !== 'string' || !Array.isArray(record.plans) || !Array.isArray(record.workouts)) {
+        throw new Error('Invalid mutation receipt response.');
+    }
+    if (!Array.isArray(record.removedPlanIds) || !Array.isArray(record.permanentlyDeletedWorkoutIds)) {
+        throw new Error('Invalid mutation receipt response.');
+    }
+    return {
+        mutationId: record.mutationId,
+        state: parseTrainingPlanStateV1(record.state),
+        plans: record.plans.map(parseTrainingPlanV1),
+        workouts: record.workouts.map(parseScheduledWorkoutV1),
+        removedPlanIds: record.removedPlanIds.map((id) => {
+            if (typeof id !== 'string') throw new Error('Invalid removed plan ID.');
+            return id;
+        }),
+        permanentlyDeletedWorkoutIds: record.permanentlyDeletedWorkoutIds.map((id) => {
+            if (typeof id !== 'string') throw new Error('Invalid deleted workout ID.');
+            return id;
+        }),
+    };
+}
+
+function getOperationWorkoutIds(request: MutateTrainingScheduleRequestV1): string[] {
+    switch (request.operation.kind) {
+        case 'create-plan':
+        case 'rename-plan':
+        case 'set-plan-lifecycle':
+        case 'shift-plan':
+            return [];
+        case 'copy-workout':
+            return [request.operation.sourceWorkoutId, request.operation.workoutId];
+        default:
+            return [request.operation.workoutId];
+    }
+}
+
+function getOperationCreatedEntityIds(
+    request: MutateTrainingScheduleRequestV1,
+): Array<{ kind: TrainingScheduleDeletionTombstoneKindV1; id: string }> {
+    switch (request.operation.kind) {
+        case 'create-plan':
+            return [{ kind: 'plan', id: request.operation.planId }];
+        case 'create-workout':
+            return [{ kind: 'workout', id: request.operation.workoutId }];
+        case 'copy-workout':
+            return [{ kind: 'workout', id: request.operation.workoutId }];
+        default:
+            return [];
+    }
+}
+
+function documentData(snapshot: admin.firestore.DocumentSnapshot): Record<string, unknown> {
+    return (snapshot.data() ?? {}) as Record<string, unknown>;
+}
+
+async function readTrainingScheduleSnapshotInTransaction(
+    transaction: admin.firestore.Transaction,
+    userRef: admin.firestore.DocumentReference,
+    request: MutateTrainingScheduleRequestV1,
+): Promise<TrainingScheduleSnapshotV1> {
+    const stateRef = userRef.collection('trainingPlanState').doc('current');
+    const plansRef = userRef.collection(TRAINING_PLANS_COLLECTION_ID);
+    const workoutsRef = userRef.collection(SCHEDULED_WORKOUTS_COLLECTION_ID);
+    const deletionTombstonesRef = stateRef.collection(
+        TRAINING_SCHEDULE_DELETION_TOMBSTONES_COLLECTION_ID,
+    );
+    const currentWorkoutsQuery = workoutsRef.where('lifecycle', 'in', ['planned', 'skipped']);
+    const [stateSnapshot, plansSnapshot, currentWorkoutsSnapshot] = await Promise.all([
+        transaction.get(stateRef),
+        transaction.get(plansRef),
+        transaction.get(currentWorkoutsQuery),
+    ]);
+    const directWorkoutSnapshots = await Promise.all(getOperationWorkoutIds(request).map(workoutId => (
+        transaction.get(workoutsRef.doc(workoutId))
+    )));
+    const createdEntityIds = getOperationCreatedEntityIds(request);
+    const deletionTombstoneSnapshots = await Promise.all(createdEntityIds.map(entity => (
+        transaction.get(deletionTombstonesRef.doc(
+            trainingScheduleDeletionTombstoneDocumentId(entity.kind, entity.id),
+        ))
+    )));
+    const retiredEntityIndex = deletionTombstoneSnapshots.findIndex(snapshot => snapshot.exists);
+    if (retiredEntityIndex >= 0) {
+        const retired = createdEntityIds[retiredEntityIndex];
+        throw new TrainingScheduleMutationError(
+            'already-exists',
+            `The ${retired.kind} ID ${retired.id} was permanently retired and cannot be reused.`,
+        );
+    }
+
+    const plans = new Map<string, TrainingPlanV1>();
+    plansSnapshot.docs.forEach((planSnapshot) => {
+        const plan = parseTrainingPlanV1(documentData(planSnapshot));
+        if (plan.id !== planSnapshot.id) throw new Error('Training plan document ID mismatch.');
+        plans.set(plan.id, plan);
+    });
+    const workouts = new Map<string, ScheduledWorkoutV1>();
+    [...currentWorkoutsSnapshot.docs, ...directWorkoutSnapshots].forEach((workoutSnapshot) => {
+        if (!workoutSnapshot.exists) return;
+        const workout = parseScheduledWorkoutV1(documentData(workoutSnapshot));
+        if (workout.id !== workoutSnapshot.id) throw new Error('Scheduled workout document ID mismatch.');
+        workouts.set(workout.id, workout);
+    });
+
+    return {
+        state: stateSnapshot.exists
+            ? parseTrainingPlanStateV1(documentData(stateSnapshot))
+            : createEmptyTrainingPlanState(),
+        plans,
+        workouts,
+    };
+}
+
+export function trainingScheduleRevisionDocumentId(revision: number): string {
+    return `${revision}`.padStart(10, '0');
+}
+
+export async function mutateTrainingScheduleForUser(
+    uid: string,
+    request: MutateTrainingScheduleRequestV1,
+    options: {
+        db?: admin.firestore.Firestore;
+        nowMs?: number;
+    } = {},
+): Promise<MutateTrainingScheduleResponseV1> {
+    const db = options.db ?? admin.firestore();
+    const nowMs = options.nowMs ?? Date.now();
+    const requestHash = hashTrainingScheduleMutationRequest(request);
+    const userRef = db.collection('users').doc(uid);
+    const stateRef = userRef.collection('trainingPlanState').doc('current');
+    const receiptRef = stateRef.collection(TRAINING_PLAN_MUTATION_RECEIPTS_COLLECTION_ID).doc(request.mutationId);
+    const deletionTombstonesRef = stateRef.collection(
+        TRAINING_SCHEDULE_DELETION_TOMBSTONES_COLLECTION_ID,
+    );
+
+    const response = await db.runTransaction(async (transaction) => {
+        const deletionGuard = await getUserDeletionGuardStateInTransaction(db, transaction, uid, nowMs);
+        if (deletionGuard.shouldSkip) {
+            throw new TrainingScheduleMutationError(
+                'failed-precondition',
+                'This account is being deleted or is no longer available.',
+            );
+        }
+
+        const receiptSnapshot = await transaction.get(receiptRef);
+        if (receiptSnapshot.exists) {
+            const receipt = documentData(receiptSnapshot);
+            if (receipt.requestHash !== requestHash) {
+                throw new TrainingScheduleMutationError(
+                    'failed-precondition',
+                    'This mutation ID was already used for a different request.',
+                );
+            }
+            return parseStoredMutationResponse(receipt.response);
+        }
+
+        await assertNoTrainingPlanDeletionInProgress(transaction, stateRef);
+
+        const snapshot = await readTrainingScheduleSnapshotInTransaction(transaction, userRef, request);
+        const applied = applyTrainingScheduleMutation(snapshot, request, nowMs);
+        const revisions = buildTrainingScheduleRevisionWrites(applied, request, nowMs);
+
+        transaction.set(stateRef, cloneValue(applied.after.state));
+        for (const planId of applied.affectedPlanIds) {
+            const plan = applied.after.plans.get(planId);
+            if (!plan) continue;
+            const planRef = userRef.collection(TRAINING_PLANS_COLLECTION_ID).doc(planId);
+            transaction.set(planRef, cloneValue(plan));
+            const revision = revisions.planRevisions.get(planId);
+            if (revision) {
+                const revisionRef = planRef.collection(TRAINING_PLAN_REVISIONS_COLLECTION_ID)
+                    .doc(trainingScheduleRevisionDocumentId(revision.revision));
+                transaction.create(revisionRef, cloneValue(revision));
+                for (const chunk of revisions.planRevisionChunks.get(planId) ?? []) {
+                    transaction.create(
+                        revisionRef.collection(TRAINING_PLAN_REVISION_CHUNKS_COLLECTION_ID)
+                            .doc(trainingPlanRevisionChunkDocumentId(chunk.kind, chunk.chunkIndex)),
+                        cloneValue(chunk),
+                    );
+                }
+            }
+        }
+        for (const workoutId of applied.changedWorkoutIds) {
+            const workout = applied.after.workouts.get(workoutId);
+            if (!workout) continue;
+            const workoutRef = userRef.collection(SCHEDULED_WORKOUTS_COLLECTION_ID).doc(workoutId);
+            transaction.set(workoutRef, cloneValue(workout));
+            const revision = revisions.standaloneWorkoutRevisions.get(workoutId);
+            if (revision) {
+                transaction.create(
+                    workoutRef.collection(TRAINING_PLAN_REVISIONS_COLLECTION_ID).doc(trainingScheduleRevisionDocumentId(revision.revision)),
+                    cloneValue(revision),
+                );
+            }
+        }
+        for (const workoutId of applied.permanentlyDeletedWorkoutIds) {
+            const tombstone = buildTrainingScheduleDeletionTombstone(
+                'workout',
+                workoutId,
+                request.mutationId,
+                nowMs,
+            );
+            transaction.create(deletionTombstonesRef.doc(tombstone.entityIdHash), tombstone);
+            transaction.delete(userRef.collection(SCHEDULED_WORKOUTS_COLLECTION_ID).doc(workoutId));
+        }
+
+        const receipt: StoredMutationReceiptV1 = {
+            schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+            requestHash,
+            response: cloneValue(applied.response),
+            createdAtMs: nowMs,
+            expireAt: Timestamp.fromMillis(nowMs + MUTATION_RECEIPT_RETENTION_MS),
+        };
+        transaction.create(receiptRef, receipt);
+        return applied.response;
+    });
+
+    for (const workoutId of response.permanentlyDeletedWorkoutIds) {
+        await db.recursiveDelete(userRef.collection(SCHEDULED_WORKOUTS_COLLECTION_ID).doc(workoutId));
+    }
+    return response;
+}

--- a/functions/src/training-plans/providers/coros-training-plan.serializer.ts
+++ b/functions/src/training-plans/providers/coros-training-plan.serializer.ts
@@ -1,0 +1,392 @@
+import { ActivityTypes } from '@sports-alliance/sports-lib';
+import {
+    parseWorkoutStructureV1,
+    type WorkoutEndingV1,
+    type WorkoutStepPurposeV1,
+    type WorkoutStepV1 as CanonicalWorkoutStepV1,
+    type WorkoutStructureV1,
+    type WorkoutTargetV1,
+} from '../../../../shared/planned-workout';
+import { normalizeTrainingLocalDate } from '../../../../shared/training-plans';
+import {
+    createStableProviderIntegerId,
+    resolveProviderSerializationIssuesV1,
+    type ProviderSerializationIssueV1,
+    type ProviderSerializationResultV1,
+} from './provider-mapping';
+
+export type CorosWorkoutTypeV1 = 'run' | 'bike';
+export type CorosIntensityClassV1 = 'WarmUp' | 'CoolDown' | 'Active' | 'Rest';
+export type CorosIntensityTargetUnitV1 =
+    | 'PercentOfFtp'
+    | 'PercentOfThresholdHr'
+    | 'PercentOfThresholdSpeed'
+    | 'RangeOfFtp'
+    | 'RangeOfCandence'
+    | 'RangeOfThresholdHr'
+    | 'RangeOfThresholdSpeed';
+export type CorosLengthV1 =
+    | { Unit: 'Second'; Value: number }
+    | { Unit: 'Meter'; Value: number }
+    | { Unit: 'EndManually' }
+    | { Unit: 'Repetition'; Value: number };
+export type CorosIntensityTargetV1 = [] | {
+    Unit: CorosIntensityTargetUnitV1;
+    Value?: number;
+    MinValue?: number;
+    MaxValue?: number;
+};
+
+export interface CorosTrainingStepV1 {
+    Type: 'Step';
+    IntensityClass: CorosIntensityClassV1;
+    Name: string;
+    Description: string;
+    Ftp: number;
+    ThresholdHr: number;
+    ThresholdSpeed: number;
+    Length: Exclude<CorosLengthV1, { Unit: 'Repetition' }>;
+    IntensityTarget: CorosIntensityTargetV1;
+}
+
+export interface CorosTrainingRepeatV1 {
+    Type: 'Repetition';
+    Length: { Unit: 'Repetition'; Value: number };
+    Steps: CorosTrainingStepV1[];
+}
+
+export type CorosTrainingNodeV1 = CorosTrainingStepV1 | CorosTrainingRepeatV1;
+
+export interface CorosTrainingWorkoutV1 {
+    Description?: string;
+    LastModifiedDate: string;
+    Title: string;
+    Id: number;
+    WorkoutDay: string;
+    WorkoutType: CorosWorkoutTypeV1;
+    Structure: CorosTrainingNodeV1[];
+}
+
+export interface CorosTrainingPlanPushDataV1 {
+    AthleteId: number;
+    StartDate: string;
+    EndDate: string;
+    Workouts: [CorosTrainingWorkoutV1];
+}
+
+export interface SerializeCorosTrainingPlanOptionsV1 {
+    athleteId: number;
+    sourceWorkoutId: string;
+    title: string;
+    description?: string;
+    localDate: string;
+    lastModifiedDate: string;
+    allowDegraded: boolean;
+}
+
+function requiredText(value: string, label: string): string {
+    const normalized = value.trim();
+    if (normalized.length === 0) throw new Error(`${label} must not be empty.`);
+    return normalized;
+}
+
+function positiveCorosInteger(value: number, label: string): number {
+    if (!Number.isSafeInteger(value) || value <= 0 || value > 2_147_483_647) {
+        throw new Error(`${label} must be a positive signed 32-bit integer.`);
+    }
+    return value;
+}
+
+function normalizeCorosLocalDateTime(value: string): string {
+    const normalized = requiredText(value, 'COROS last-modified datetime');
+    const match = /^(\d{4}-\d{2}-\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?$/.exec(normalized);
+    if (!match) {
+        throw new Error('COROS last-modified datetime must use YYYY-MM-DDTHH:mm:ss or millisecond precision.');
+    }
+    normalizeTrainingLocalDate(match[1]);
+    const hour = Number(match[2]);
+    const minute = Number(match[3]);
+    const second = Number(match[4]);
+    if (hour > 23 || minute > 59 || second > 59) {
+        throw new Error('COROS last-modified datetime contains an invalid time.');
+    }
+    return normalized;
+}
+
+function sportToCoros(sport: ActivityTypes): CorosWorkoutTypeV1 {
+    if (sport === ActivityTypes.Running) return 'run';
+    if (sport === ActivityTypes.Cycling) return 'bike';
+    throw new Error(`Unsupported COROS sport reached after compatibility validation: ${sport}.`);
+}
+
+function purposeToCoros(purpose: WorkoutStepPurposeV1): CorosIntensityClassV1 {
+    switch (purpose) {
+        case 'warmup': return 'WarmUp';
+        case 'cooldown': return 'CoolDown';
+        case 'recovery':
+        case 'rest':
+            return 'Rest';
+        case 'work':
+        case 'other':
+            return 'Active';
+    }
+}
+
+function purposeName(purpose: WorkoutStepPurposeV1): string {
+    switch (purpose) {
+        case 'warmup': return 'Warm up';
+        case 'cooldown': return 'Cool down';
+        case 'recovery': return 'Recovery';
+        case 'rest': return 'Rest';
+        case 'work': return 'Work';
+        case 'other': return 'Next';
+    }
+}
+
+function endingToCoros(ending: WorkoutEndingV1): Exclude<CorosLengthV1, { Unit: 'Repetition' }> {
+    switch (ending.kind) {
+        case 'time': return { Unit: 'Second', Value: Math.max(1, Math.round(ending.seconds)) };
+        case 'distance': return { Unit: 'Meter', Value: Math.max(1, Math.round(ending.meters)) };
+        case 'manual': return { Unit: 'EndManually' };
+        case 'kilojoules':
+        case 'repetitions':
+            throw new Error(`Unsupported COROS ending reached after compatibility validation: ${ending.kind}.`);
+    }
+}
+
+function absoluteRange(target: Exclude<WorkoutTargetV1, { mode: 'relative' }>): {
+    minimum: number;
+    maximum: number;
+} {
+    switch (target.kind) {
+        case 'heart-rate': return { minimum: target.minimumBpm, maximum: target.maximumBpm };
+        case 'power': return { minimum: target.minimumWatts, maximum: target.maximumWatts };
+        case 'speed':
+            return {
+                minimum: target.minimumMetersPerSecond,
+                maximum: target.maximumMetersPerSecond,
+            };
+        case 'cadence': return { minimum: target.minimumRpm, maximum: target.maximumRpm };
+    }
+}
+
+function frozenRelativeRange(target: Exclude<WorkoutTargetV1, { mode: 'absolute' }>): {
+    minimum: number;
+    maximum: number;
+} {
+    const scale = (value: number, percent: number): number => value * percent / 100;
+    switch (target.kind) {
+        case 'heart-rate':
+            return {
+                minimum: scale(target.reference.bpm, target.minimumPercent),
+                maximum: scale(target.reference.bpm, target.maximumPercent),
+            };
+        case 'power':
+            return {
+                minimum: scale(target.reference.watts, target.minimumPercent),
+                maximum: scale(target.reference.watts, target.maximumPercent),
+            };
+        case 'speed':
+            return {
+                minimum: scale(target.reference.metersPerSecond, target.minimumPercent),
+                maximum: scale(target.reference.metersPerSecond, target.maximumPercent),
+            };
+        case 'cadence':
+            return {
+                minimum: scale(target.reference.rpm, target.minimumPercent),
+                maximum: scale(target.reference.rpm, target.maximumPercent),
+            };
+    }
+}
+
+function rangeTarget(
+    unit: CorosIntensityTargetUnitV1,
+    minimum: number,
+    maximum: number,
+): Exclude<CorosIntensityTargetV1, []> {
+    return { Unit: unit, MinValue: minimum, MaxValue: maximum };
+}
+
+function percentTarget(
+    unit: 'PercentOfFtp' | 'PercentOfThresholdHr' | 'PercentOfThresholdSpeed',
+    minimum: number,
+    maximum: number,
+): Exclude<CorosIntensityTargetV1, []> {
+    const roundedMinimum = Math.round(minimum);
+    const roundedMaximum = Math.round(maximum);
+    if (roundedMinimum === roundedMaximum) return { Unit: unit, Value: roundedMinimum };
+    return { Unit: unit, MinValue: roundedMinimum, MaxValue: roundedMaximum };
+}
+
+function targetToCoros(target: WorkoutTargetV1 | undefined): {
+    Ftp: number;
+    ThresholdHr: number;
+    ThresholdSpeed: number;
+    IntensityTarget: CorosIntensityTargetV1;
+} {
+    if (!target) {
+        return { Ftp: 0, ThresholdHr: 0, ThresholdSpeed: 0, IntensityTarget: [] };
+    }
+
+    if (target.mode === 'absolute') {
+        const range = absoluteRange(target);
+        const units = {
+            'heart-rate': 'RangeOfThresholdHr',
+            power: 'RangeOfFtp',
+            speed: 'RangeOfThresholdSpeed',
+            cadence: 'RangeOfCandence',
+        } as const;
+        return {
+            Ftp: 0,
+            ThresholdHr: 0,
+            ThresholdSpeed: 0,
+            IntensityTarget: rangeTarget(units[target.kind], range.minimum, range.maximum),
+        };
+    }
+
+    if (target.kind === 'heart-rate' && target.reference.kind === 'threshold-heart-rate') {
+        return {
+            Ftp: 0,
+            ThresholdHr: target.reference.bpm,
+            ThresholdSpeed: 0,
+            IntensityTarget: percentTarget(
+                'PercentOfThresholdHr',
+                target.minimumPercent,
+                target.maximumPercent,
+            ),
+        };
+    }
+    if (target.kind === 'power' && target.reference.kind === 'functional-threshold-power') {
+        return {
+            Ftp: target.reference.watts,
+            ThresholdHr: 0,
+            ThresholdSpeed: 0,
+            IntensityTarget: percentTarget('PercentOfFtp', target.minimumPercent, target.maximumPercent),
+        };
+    }
+    if (target.kind === 'speed') {
+        return {
+            Ftp: 0,
+            ThresholdHr: 0,
+            ThresholdSpeed: target.reference.metersPerSecond,
+            IntensityTarget: percentTarget(
+                'PercentOfThresholdSpeed',
+                target.minimumPercent,
+                target.maximumPercent,
+            ),
+        };
+    }
+
+    const range = frozenRelativeRange(target);
+    const unit = target.kind === 'heart-rate'
+        ? 'RangeOfThresholdHr'
+        : target.kind === 'power'
+            ? 'RangeOfFtp'
+            : 'RangeOfCandence';
+    return {
+        Ftp: 0,
+        ThresholdHr: 0,
+        ThresholdSpeed: 0,
+        IntensityTarget: rangeTarget(unit, range.minimum, range.maximum),
+    };
+}
+
+function stepToCoros(step: CanonicalWorkoutStepV1): CorosTrainingStepV1 {
+    return {
+        Type: 'Step',
+        IntensityClass: purposeToCoros(step.purpose),
+        Name: purposeName(step.purpose),
+        Description: step.note ?? '',
+        ...targetToCoros(step.targets[0]),
+        Length: endingToCoros(step.ending),
+    };
+}
+
+function structureToCorosNodes(structure: WorkoutStructureV1): CorosTrainingNodeV1[] {
+    return structure.nodes.map(node => {
+        if (node.kind === 'step') return stepToCoros(node);
+        return {
+            Type: 'Repetition',
+            Length: { Unit: 'Repetition', Value: node.count },
+            Steps: node.steps.map(stepToCoros),
+        };
+    });
+}
+
+function collectCorosRoundingIssues(
+    structure: WorkoutStructureV1,
+    issues: ProviderSerializationIssueV1[],
+): void {
+    const visit = (step: CanonicalWorkoutStepV1, path: string): void => {
+        if (
+            (step.ending.kind === 'time' && !Number.isInteger(step.ending.seconds))
+            || (step.ending.kind === 'distance' && !Number.isInteger(step.ending.meters))
+        ) {
+            issues.push({
+                severity: 'degraded',
+                code: 'ending_value_rounded',
+                path: `${path}.ending`,
+                message: 'COROS requires integer step lengths, so this value will be rounded.',
+            });
+        }
+        const target = step.targets[0];
+        if (
+            target?.mode === 'relative'
+            && (!Number.isInteger(target.minimumPercent) || !Number.isInteger(target.maximumPercent))
+        ) {
+            issues.push({
+                severity: 'degraded',
+                code: 'target_percentage_rounded',
+                path: `${path}.targets[0]`,
+                message: 'COROS requires integer target percentages, so this range will be rounded.',
+            });
+        }
+    };
+
+    structure.nodes.forEach((node, nodeIndex) => {
+        if (node.kind === 'step') {
+            visit(node, `$.nodes[${nodeIndex}]`);
+            return;
+        }
+        node.steps.forEach((step, stepIndex) => visit(step, `$.nodes[${nodeIndex}].steps[${stepIndex}]`));
+    });
+}
+
+export function serializeCorosTrainingPlanV1(
+    structureValue: unknown,
+    options: SerializeCorosTrainingPlanOptionsV1,
+): ProviderSerializationResultV1<CorosTrainingPlanPushDataV1> {
+    const structure = parseWorkoutStructureV1(structureValue);
+    const athleteId = positiveCorosInteger(options.athleteId, 'COROS athlete ID');
+    const title = requiredText(options.title, 'COROS workout title');
+    const description = options.description?.trim();
+    const localDate = normalizeTrainingLocalDate(options.localDate);
+    const lastModifiedDate = normalizeCorosLocalDateTime(options.lastModifiedDate);
+    const additionalIssues: ProviderSerializationIssueV1[] = [];
+    collectCorosRoundingIssues(structure, additionalIssues);
+
+    const resolved = resolveProviderSerializationIssuesV1({
+        provider: 'coros',
+        structure,
+        additionalIssues,
+        allowDegraded: options.allowDegraded,
+    });
+    const workout: CorosTrainingWorkoutV1 = {
+        ...(description ? { Description: description } : {}),
+        LastModifiedDate: lastModifiedDate,
+        Title: title,
+        Id: createStableProviderIntegerId('coros', options.sourceWorkoutId),
+        WorkoutDay: localDate,
+        WorkoutType: sportToCoros(structure.sport),
+        Structure: structureToCorosNodes(structure),
+    };
+    return {
+        ...resolved,
+        artifact: {
+            AthleteId: athleteId,
+            StartDate: localDate,
+            EndDate: localDate,
+            Workouts: [workout],
+        },
+    };
+}

--- a/functions/src/training-plans/providers/fixtures/canonical-running-v1.json
+++ b/functions/src/training-plans/providers/fixtures/canonical-running-v1.json
@@ -1,0 +1,74 @@
+{
+  "version": 1,
+  "sport": "Running",
+  "nodes": [
+    {
+      "kind": "step",
+      "id": "warmup",
+      "purpose": "warmup",
+      "ending": { "kind": "time", "seconds": 600 },
+      "targets": [
+        {
+          "kind": "heart-rate",
+          "mode": "absolute",
+          "minimumBpm": 130,
+          "maximumBpm": 145
+        }
+      ],
+      "note": "Easy warm up"
+    },
+    {
+      "kind": "repeat",
+      "id": "intervals",
+      "count": 3,
+      "steps": [
+        {
+          "kind": "step",
+          "id": "fast",
+          "purpose": "work",
+          "ending": { "kind": "distance", "meters": 400 },
+          "targets": [
+            {
+              "kind": "speed",
+              "mode": "absolute",
+              "minimumMetersPerSecond": 4.3,
+              "maximumMetersPerSecond": 4.55,
+              "presentation": "pace"
+            }
+          ],
+          "note": "Fast 400"
+        },
+        {
+          "kind": "step",
+          "id": "recover",
+          "purpose": "recovery",
+          "ending": { "kind": "time", "seconds": 60 },
+          "targets": [
+            {
+              "kind": "heart-rate",
+              "mode": "absolute",
+              "minimumBpm": 110,
+              "maximumBpm": 130
+            }
+          ],
+          "note": "Jog easy"
+        }
+      ]
+    },
+    {
+      "kind": "step",
+      "id": "cooldown",
+      "purpose": "cooldown",
+      "ending": { "kind": "time", "seconds": 300 },
+      "targets": [
+        {
+          "kind": "cadence",
+          "mode": "absolute",
+          "minimumRpm": 80,
+          "maximumRpm": 90
+        }
+      ],
+      "note": "Relax"
+    }
+  ]
+}

--- a/functions/src/training-plans/providers/fixtures/coros-running-v1.json
+++ b/functions/src/training-plans/providers/fixtures/coros-running-v1.json
@@ -1,0 +1,83 @@
+{
+  "AthleteId": 24680,
+  "StartDate": "2026-09-03",
+  "EndDate": "2026-09-03",
+  "Workouts": [
+    {
+      "Description": "Redacted provider contract fixture.",
+      "LastModifiedDate": "2026-09-02T12:00:00.000",
+      "Title": "Fixture intervals",
+      "Id": 1191908854,
+      "WorkoutDay": "2026-09-03",
+      "WorkoutType": "run",
+      "Structure": [
+        {
+          "Type": "Step",
+          "IntensityClass": "WarmUp",
+          "Name": "Warm up",
+          "Description": "Easy warm up",
+          "Ftp": 0,
+          "ThresholdHr": 0,
+          "ThresholdSpeed": 0,
+          "Length": { "Unit": "Second", "Value": 600 },
+          "IntensityTarget": {
+            "Unit": "RangeOfThresholdHr",
+            "MinValue": 130,
+            "MaxValue": 145
+          }
+        },
+        {
+          "Type": "Repetition",
+          "Length": { "Unit": "Repetition", "Value": 3 },
+          "Steps": [
+            {
+              "Type": "Step",
+              "IntensityClass": "Active",
+              "Name": "Work",
+              "Description": "Fast 400",
+              "Ftp": 0,
+              "ThresholdHr": 0,
+              "ThresholdSpeed": 0,
+              "Length": { "Unit": "Meter", "Value": 400 },
+              "IntensityTarget": {
+                "Unit": "RangeOfThresholdSpeed",
+                "MinValue": 4.3,
+                "MaxValue": 4.55
+              }
+            },
+            {
+              "Type": "Step",
+              "IntensityClass": "Rest",
+              "Name": "Recovery",
+              "Description": "Jog easy",
+              "Ftp": 0,
+              "ThresholdHr": 0,
+              "ThresholdSpeed": 0,
+              "Length": { "Unit": "Second", "Value": 60 },
+              "IntensityTarget": {
+                "Unit": "RangeOfThresholdHr",
+                "MinValue": 110,
+                "MaxValue": 130
+              }
+            }
+          ]
+        },
+        {
+          "Type": "Step",
+          "IntensityClass": "CoolDown",
+          "Name": "Cool down",
+          "Description": "Relax",
+          "Ftp": 0,
+          "ThresholdHr": 0,
+          "ThresholdSpeed": 0,
+          "Length": { "Unit": "Second", "Value": 300 },
+          "IntensityTarget": {
+            "Unit": "RangeOfCandence",
+            "MinValue": 80,
+            "MaxValue": 90
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/functions/src/training-plans/providers/fixtures/garmin-running-v1.json
+++ b/functions/src/training-plans/providers/fixtures/garmin-running-v1.json
@@ -1,0 +1,103 @@
+{
+  "workoutName": "Fixture intervals",
+  "description": "Redacted provider contract fixture.",
+  "sport": "RUNNING",
+  "workoutProvider": "Quantified Self",
+  "workoutSourceId": "Quantified Self",
+  "isSessionTransitionEnabled": false,
+  "segments": [
+    {
+      "segmentOrder": 1,
+      "sport": "RUNNING",
+      "poolLength": null,
+      "poolLengthUnit": null,
+      "steps": [
+        {
+          "type": "WorkoutStep",
+          "stepOrder": 1,
+          "intensity": "WARMUP",
+          "description": "Easy warm up",
+          "durationType": "TIME",
+          "durationValue": 600,
+          "durationValueType": null,
+          "targetType": "HEART_RATE",
+          "targetValue": null,
+          "targetValueLow": 130,
+          "targetValueHigh": 145,
+          "targetValueType": null,
+          "secondaryTargetType": null,
+          "secondaryTargetValue": null,
+          "secondaryTargetValueLow": null,
+          "secondaryTargetValueHigh": null,
+          "secondaryTargetValueType": null
+        },
+        {
+          "type": "WorkoutRepeatStep",
+          "stepOrder": 2,
+          "repeatType": "REPEAT_UNTIL_STEPS_CMPLT",
+          "repeatValue": 3,
+          "skipLastRestStep": false,
+          "steps": [
+            {
+              "type": "WorkoutStep",
+              "stepOrder": 3,
+              "intensity": "ACTIVE",
+              "description": "Fast 400",
+              "durationType": "DISTANCE",
+              "durationValue": 400,
+              "durationValueType": "METER",
+              "targetType": "PACE",
+              "targetValue": null,
+              "targetValueLow": 4.3,
+              "targetValueHigh": 4.55,
+              "targetValueType": null,
+              "secondaryTargetType": null,
+              "secondaryTargetValue": null,
+              "secondaryTargetValueLow": null,
+              "secondaryTargetValueHigh": null,
+              "secondaryTargetValueType": null
+            },
+            {
+              "type": "WorkoutStep",
+              "stepOrder": 4,
+              "intensity": "RECOVERY",
+              "description": "Jog easy",
+              "durationType": "TIME",
+              "durationValue": 60,
+              "durationValueType": null,
+              "targetType": "HEART_RATE",
+              "targetValue": null,
+              "targetValueLow": 110,
+              "targetValueHigh": 130,
+              "targetValueType": null,
+              "secondaryTargetType": null,
+              "secondaryTargetValue": null,
+              "secondaryTargetValueLow": null,
+              "secondaryTargetValueHigh": null,
+              "secondaryTargetValueType": null
+            }
+          ]
+        },
+        {
+          "type": "WorkoutStep",
+          "stepOrder": 5,
+          "intensity": "COOLDOWN",
+          "description": "Relax",
+          "durationType": "TIME",
+          "durationValue": 300,
+          "durationValueType": null,
+          "targetType": "CADENCE",
+          "targetValue": null,
+          "targetValueLow": 80,
+          "targetValueHigh": 90,
+          "targetValueType": null,
+          "secondaryTargetType": null,
+          "secondaryTargetValue": null,
+          "secondaryTargetValueLow": null,
+          "secondaryTargetValueHigh": null,
+          "secondaryTargetValueType": null
+        }
+      ]
+    }
+  ]
+}

--- a/functions/src/training-plans/providers/fixtures/suunto-running-v1.json
+++ b/functions/src/training-plans/providers/fixtures/suunto-running-v1.json
@@ -1,0 +1,73 @@
+{
+  "type": "sequence",
+  "name": "Fixture intervals",
+  "description": "Redacted provider contract fixture.",
+  "shortDescription": "Fixture intervals",
+  "owner": "Quantified Self",
+  "url": "https://quantified-self.io/plans",
+  "activities": [1],
+  "usage": "workout",
+  "localDate": "2026-09-03",
+  "externalId": "qs-suunto-9FY_Ylbw0yViEKcPFAx4RKg3Hm9mnnFTRTE37sW_HYg",
+  "steps": [
+    {
+      "id": "qs-suunto-Wwd4-55rgq5haBzZEQg02b_tyv7_YA-8ejjONM6owkU",
+      "type": "fields",
+      "title": "Warm up",
+      "fields": [
+        { "type": "stepDurationCountdown", "value": 600, "title": "Remaining" },
+        { "type": "targetHeartRate", "min": 130, "max": 145, "title": "Target HR" },
+        { "type": "text", "value": "Easy warm up" }
+      ],
+      "transitions": [
+        { "condition": { "type": "stepDuration", "value": 600 } }
+      ]
+    },
+    {
+      "id": "qs-suunto-QOEl3Sis2am5LJuYjjrO_FpvHYCx-4ifBXnd4OaFPR4",
+      "type": "repeat",
+      "times": 3,
+      "steps": [
+        {
+          "id": "qs-suunto-1JegEtu7HBcXo2h_f8x8n_rQRjiarq7THcULNA8ceAQ",
+          "type": "fields",
+          "title": "Work",
+          "fields": [
+            { "type": "stepDistanceCountdown", "value": 400, "title": "Remaining" },
+            { "type": "targetPace", "min": 4.3, "max": 4.55, "title": "Tgt pace" },
+            { "type": "text", "value": "Fast 400" }
+          ],
+          "transitions": [
+            { "condition": { "type": "stepDistance", "value": 400 } }
+          ]
+        },
+        {
+          "id": "qs-suunto-FO7CjCYL0dGFE2Y04aTmFTaX_JkSP_JL_hikp9hWKP8",
+          "type": "fields",
+          "title": "Recovery",
+          "fields": [
+            { "type": "stepDurationCountdown", "value": 60, "title": "Remaining" },
+            { "type": "targetHeartRate", "min": 110, "max": 130, "title": "Target HR" },
+            { "type": "text", "value": "Jog easy" }
+          ],
+          "transitions": [
+            { "condition": { "type": "stepDuration", "value": 60 } }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "qs-suunto-e-IgQ0-6lE7Fh6C1hRNE5S-WcJ9XS7I7vcSNoGvlKGo",
+      "type": "fields",
+      "title": "Cool down",
+      "fields": [
+        { "type": "stepDurationCountdown", "value": 300, "title": "Remaining" },
+        { "type": "targetCadence", "min": 1.3333333333333333, "max": 1.5, "title": "Tgt cadence" },
+        { "type": "text", "value": "Relax" }
+      ],
+      "transitions": [
+        { "condition": { "type": "stepDuration", "value": 300 } }
+      ]
+    }
+  ]
+}

--- a/functions/src/training-plans/providers/fixtures/wahoo-running-v1.json
+++ b/functions/src/training-plans/providers/fixtures/wahoo-running-v1.json
@@ -1,0 +1,53 @@
+{
+  "header": {
+    "name": "Fixture intervals",
+    "version": "1.0.0",
+    "description": "Redacted provider contract fixture.",
+    "workout_type_family": 1,
+    "workout_type_location": 1
+  },
+  "intervals": [
+    {
+      "name": "Easy warm up",
+      "exit_trigger_type": "time",
+      "exit_trigger_value": 600,
+      "intensity_type": "wu",
+      "targets": [
+        { "type": "hr", "low": 130, "high": 145 }
+      ]
+    },
+    {
+      "exit_trigger_type": "repeat",
+      "exit_trigger_value": 2,
+      "intervals": [
+        {
+          "name": "Fast 400",
+          "exit_trigger_type": "distance",
+          "exit_trigger_value": 400,
+          "intensity_type": "active",
+          "targets": [
+            { "type": "speed", "low": 4.3, "high": 4.55 }
+          ]
+        },
+        {
+          "name": "Jog easy",
+          "exit_trigger_type": "time",
+          "exit_trigger_value": 60,
+          "intensity_type": "recover",
+          "targets": [
+            { "type": "hr", "low": 110, "high": 130 }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Relax",
+      "exit_trigger_type": "time",
+      "exit_trigger_value": 300,
+      "intensity_type": "cd",
+      "targets": [
+        { "type": "rpm", "low": 80, "high": 90 }
+      ]
+    }
+  ]
+}

--- a/functions/src/training-plans/providers/garmin-workout.serializer.ts
+++ b/functions/src/training-plans/providers/garmin-workout.serializer.ts
@@ -1,0 +1,329 @@
+import { ActivityTypes } from '@sports-alliance/sports-lib';
+import {
+    parseWorkoutStructureV1,
+    type WorkoutEndingV1,
+    type WorkoutStepPurposeV1,
+    type WorkoutStepV1 as CanonicalWorkoutStepV1,
+    type WorkoutStructureV1,
+    type WorkoutTargetV1,
+} from '../../../../shared/planned-workout';
+import { normalizeTrainingLocalDate } from '../../../../shared/training-plans';
+import {
+    resolveProviderSerializationIssuesV1,
+    type ProviderSerializationIssueV1,
+    type ProviderSerializationResultV1,
+} from './provider-mapping';
+
+export type GarminWorkoutSportV1 = 'RUNNING' | 'CYCLING';
+export type GarminWorkoutIntensityV1 = 'REST' | 'WARMUP' | 'COOLDOWN' | 'RECOVERY' | 'ACTIVE';
+export type GarminWorkoutDurationTypeV1 = 'TIME' | 'DISTANCE' | 'OPEN' | 'FIXED_REST';
+export type GarminWorkoutTargetTypeV1 = 'SPEED' | 'PACE' | 'HEART_RATE' | 'CADENCE' | 'POWER' | 'OPEN';
+
+interface GarminTargetFieldsV1 {
+    targetType: GarminWorkoutTargetTypeV1;
+    targetValue: null;
+    targetValueLow: number | null;
+    targetValueHigh: number | null;
+    targetValueType: null;
+}
+
+interface GarminSecondaryTargetFieldsV1 {
+    secondaryTargetType: Exclude<GarminWorkoutTargetTypeV1, 'OPEN'> | null;
+    secondaryTargetValue: null;
+    secondaryTargetValueLow: number | null;
+    secondaryTargetValueHigh: number | null;
+    secondaryTargetValueType: null;
+}
+
+export interface GarminWorkoutStepV1 extends GarminTargetFieldsV1, GarminSecondaryTargetFieldsV1 {
+    type: 'WorkoutStep';
+    stepOrder: number;
+    intensity: GarminWorkoutIntensityV1;
+    description: string;
+    durationType: GarminWorkoutDurationTypeV1;
+    durationValue: number | null;
+    durationValueType: 'METER' | null;
+}
+
+export interface GarminWorkoutRepeatStepV1 {
+    type: 'WorkoutRepeatStep';
+    stepOrder: number;
+    repeatType: 'REPEAT_UNTIL_STEPS_CMPLT';
+    repeatValue: number;
+    skipLastRestStep: false;
+    steps: GarminWorkoutStepV1[];
+}
+
+export type GarminWorkoutNodeV1 = GarminWorkoutStepV1 | GarminWorkoutRepeatStepV1;
+
+export interface GarminWorkoutPayloadV1 {
+    ownerId?: number;
+    workoutName: string;
+    description: string;
+    sport: GarminWorkoutSportV1;
+    workoutProvider: 'Quantified Self';
+    workoutSourceId: 'Quantified Self';
+    isSessionTransitionEnabled: false;
+    segments: [{
+        segmentOrder: 1;
+        sport: GarminWorkoutSportV1;
+        poolLength: null;
+        poolLengthUnit: null;
+        steps: GarminWorkoutNodeV1[];
+    }];
+}
+
+export interface GarminWorkoutSchedulePayloadV1 {
+    workoutId: number;
+    date: string;
+}
+
+export interface SerializeGarminWorkoutOptionsV1 {
+    name: string;
+    description?: string;
+    ownerId?: number;
+    allowDegraded: boolean;
+}
+
+function codePointLength(value: string): number {
+    return Array.from(value).length;
+}
+
+function truncateCodePoints(value: string, maximum: number): string {
+    return Array.from(value).slice(0, maximum).join('');
+}
+
+function requiredText(value: string, label: string): string {
+    const normalized = value.trim();
+    if (normalized.length === 0) throw new Error(`${label} must not be empty.`);
+    return normalized;
+}
+
+function optionalPositiveSafeInteger(value: number | undefined, label: string): number | undefined {
+    if (value === undefined) return undefined;
+    if (!Number.isSafeInteger(value) || value <= 0) {
+        throw new Error(`${label} must be a positive safe integer.`);
+    }
+    return value;
+}
+
+function sportToGarmin(sport: ActivityTypes): GarminWorkoutSportV1 {
+    if (sport === ActivityTypes.Running) return 'RUNNING';
+    if (sport === ActivityTypes.Cycling) return 'CYCLING';
+    throw new Error(`Unsupported Garmin sport reached after compatibility validation: ${sport}.`);
+}
+
+function purposeToGarmin(purpose: WorkoutStepPurposeV1): GarminWorkoutIntensityV1 {
+    switch (purpose) {
+        case 'warmup': return 'WARMUP';
+        case 'recovery': return 'RECOVERY';
+        case 'cooldown': return 'COOLDOWN';
+        case 'rest': return 'REST';
+        case 'work':
+        case 'other':
+            return 'ACTIVE';
+    }
+}
+
+function endingToGarmin(
+    ending: WorkoutEndingV1,
+    purpose: WorkoutStepPurposeV1,
+): Pick<GarminWorkoutStepV1, 'durationType' | 'durationValue' | 'durationValueType'> {
+    switch (ending.kind) {
+        case 'time':
+            return {
+                durationType: purpose === 'rest' ? 'FIXED_REST' : 'TIME',
+                durationValue: ending.seconds,
+                durationValueType: null,
+            };
+        case 'distance':
+            return {
+                durationType: 'DISTANCE',
+                durationValue: ending.meters,
+                durationValueType: 'METER',
+            };
+        case 'manual':
+            return { durationType: 'OPEN', durationValue: null, durationValueType: null };
+        case 'kilojoules':
+        case 'repetitions':
+            throw new Error(`Unsupported Garmin ending reached after compatibility validation: ${ending.kind}.`);
+    }
+}
+
+function absoluteTargetRange(target: WorkoutTargetV1): {
+    type: Exclude<GarminWorkoutTargetTypeV1, 'OPEN'>;
+    low: number;
+    high: number;
+} {
+    const scale = (value: number, percent: number): number => value * percent / 100;
+    if (target.mode === 'absolute') {
+        switch (target.kind) {
+            case 'heart-rate':
+                return { type: 'HEART_RATE', low: target.minimumBpm, high: target.maximumBpm };
+            case 'power':
+                return { type: 'POWER', low: target.minimumWatts, high: target.maximumWatts };
+            case 'speed':
+                return {
+                    type: target.presentation === 'pace' ? 'PACE' : 'SPEED',
+                    low: target.minimumMetersPerSecond,
+                    high: target.maximumMetersPerSecond,
+                };
+            case 'cadence':
+                return { type: 'CADENCE', low: target.minimumRpm, high: target.maximumRpm };
+        }
+    }
+
+    switch (target.kind) {
+        case 'heart-rate':
+            return {
+                type: 'HEART_RATE',
+                low: scale(target.reference.bpm, target.minimumPercent),
+                high: scale(target.reference.bpm, target.maximumPercent),
+            };
+        case 'power':
+            return {
+                type: 'POWER',
+                low: scale(target.reference.watts, target.minimumPercent),
+                high: scale(target.reference.watts, target.maximumPercent),
+            };
+        case 'speed':
+            return {
+                type: target.presentation === 'pace' ? 'PACE' : 'SPEED',
+                low: scale(target.reference.metersPerSecond, target.minimumPercent),
+                high: scale(target.reference.metersPerSecond, target.maximumPercent),
+            };
+        case 'cadence':
+            return {
+                type: 'CADENCE',
+                low: scale(target.reference.rpm, target.minimumPercent),
+                high: scale(target.reference.rpm, target.maximumPercent),
+            };
+    }
+}
+
+function primaryTargetFields(target: WorkoutTargetV1 | undefined): GarminTargetFieldsV1 {
+    if (!target) {
+        return {
+            targetType: 'OPEN',
+            targetValue: null,
+            targetValueLow: null,
+            targetValueHigh: null,
+            targetValueType: null,
+        };
+    }
+    const range = absoluteTargetRange(target);
+    return {
+        targetType: range.type,
+        targetValue: null,
+        targetValueLow: range.low,
+        targetValueHigh: range.high,
+        targetValueType: null,
+    };
+}
+
+function secondaryTargetFields(target: WorkoutTargetV1 | undefined): GarminSecondaryTargetFieldsV1 {
+    if (!target) {
+        return {
+            secondaryTargetType: null,
+            secondaryTargetValue: null,
+            secondaryTargetValueLow: null,
+            secondaryTargetValueHigh: null,
+            secondaryTargetValueType: null,
+        };
+    }
+    const range = absoluteTargetRange(target);
+    return {
+        secondaryTargetType: range.type,
+        secondaryTargetValue: null,
+        secondaryTargetValueLow: range.low,
+        secondaryTargetValueHigh: range.high,
+        secondaryTargetValueType: null,
+    };
+}
+
+function stepToGarmin(step: CanonicalWorkoutStepV1, stepOrder: number): GarminWorkoutStepV1 {
+    return {
+        type: 'WorkoutStep',
+        stepOrder,
+        intensity: purposeToGarmin(step.purpose),
+        description: step.note ?? '',
+        ...endingToGarmin(step.ending, step.purpose),
+        ...primaryTargetFields(step.targets[0]),
+        ...secondaryTargetFields(step.targets[1]),
+    };
+}
+
+function structureToGarminNodes(structure: WorkoutStructureV1): GarminWorkoutNodeV1[] {
+    let stepOrder = 0;
+    return structure.nodes.map(node => {
+        stepOrder += 1;
+        if (node.kind === 'step') return stepToGarmin(node, stepOrder);
+        const repeatOrder = stepOrder;
+        const steps = node.steps.map(step => {
+            stepOrder += 1;
+            return stepToGarmin(step, stepOrder);
+        });
+        return {
+            type: 'WorkoutRepeatStep',
+            stepOrder: repeatOrder,
+            repeatType: 'REPEAT_UNTIL_STEPS_CMPLT',
+            repeatValue: node.count,
+            skipLastRestStep: false,
+            steps,
+        };
+    });
+}
+
+export function serializeGarminWorkoutV1(
+    structureValue: unknown,
+    options: SerializeGarminWorkoutOptionsV1,
+): ProviderSerializationResultV1<GarminWorkoutPayloadV1> {
+    const structure = parseWorkoutStructureV1(structureValue);
+    const workoutName = requiredText(options.name, 'Garmin workout name');
+    const rawDescription = options.description?.trim() ?? '';
+    const ownerId = optionalPositiveSafeInteger(options.ownerId, 'Garmin owner ID');
+    const additionalIssues: ProviderSerializationIssueV1[] = [];
+    if (codePointLength(rawDescription) > 1024) {
+        additionalIssues.push({
+            severity: 'degraded',
+            code: 'description_truncated',
+            path: '$.description',
+            message: 'Garmin workout descriptions are limited to 1024 characters.',
+        });
+    }
+
+    const resolved = resolveProviderSerializationIssuesV1({
+        provider: 'garmin',
+        structure,
+        additionalIssues,
+        allowDegraded: options.allowDegraded,
+    });
+    const sport = sportToGarmin(structure.sport);
+    const artifact: GarminWorkoutPayloadV1 = {
+        ...(ownerId === undefined ? {} : { ownerId }),
+        workoutName,
+        description: truncateCodePoints(rawDescription, 1024),
+        sport,
+        workoutProvider: 'Quantified Self',
+        workoutSourceId: 'Quantified Self',
+        isSessionTransitionEnabled: false,
+        segments: [{
+            segmentOrder: 1,
+            sport,
+            poolLength: null,
+            poolLengthUnit: null,
+            steps: structureToGarminNodes(structure),
+        }],
+    };
+    return { ...resolved, artifact };
+}
+
+export function serializeGarminWorkoutScheduleV1(
+    workoutId: number,
+    localDate: string,
+): GarminWorkoutSchedulePayloadV1 {
+    if (!Number.isSafeInteger(workoutId) || workoutId <= 0) {
+        throw new Error('Garmin workout ID must be a positive safe integer.');
+    }
+    return { workoutId, date: normalizeTrainingLocalDate(localDate) };
+}

--- a/functions/src/training-plans/providers/provider-mapping.spec.ts
+++ b/functions/src/training-plans/providers/provider-mapping.spec.ts
@@ -1,0 +1,222 @@
+import { ActivityTypes } from '@sports-alliance/sports-lib';
+import { describe, expect, it } from 'vitest';
+import {
+    PLANNED_WORKOUT_PROVIDER_CAPABILITIES_V1,
+    assessPlannedWorkoutProviderMappingV1,
+    isPlannedWorkoutProviderDeliveryEnabled,
+} from '../../../../shared/planned-workout-providers';
+import type { WorkoutStructureV1 } from '../../../../shared/planned-workout';
+import canonicalRunningFixture from './fixtures/canonical-running-v1.json';
+import expectedSuuntoFixture from './fixtures/suunto-running-v1.json';
+import expectedWahooFixture from './fixtures/wahoo-running-v1.json';
+import {
+    ProviderWorkoutMappingError,
+    createStableProviderExternalId,
+} from './provider-mapping';
+import { serializeSuuntoGuideJsonV1 } from './suunto-guide.serializer';
+import { serializeWahooPlanJsonV1 } from './wahoo-plan.serializer';
+
+const RUNNING_FIXTURE = canonicalRunningFixture as WorkoutStructureV1;
+
+function oneStepStructure(overrides: Partial<WorkoutStructureV1['nodes'][number]> = {}): WorkoutStructureV1 {
+    return {
+        version: 1,
+        sport: ActivityTypes.Cycling,
+        nodes: [{
+            kind: 'step',
+            id: 'main',
+            purpose: 'work',
+            ending: { kind: 'time', seconds: 600 },
+            targets: [],
+            ...overrides,
+        } as WorkoutStructureV1['nodes'][number]],
+    };
+}
+
+describe('planned-workout provider proof fixtures', () => {
+    it('keeps every provider delivery path disabled before sandbox evidence exists', () => {
+        expect(Object.values(PLANNED_WORKOUT_PROVIDER_CAPABILITIES_V1)).toHaveLength(4);
+        expect(Object.values(PLANNED_WORKOUT_PROVIDER_CAPABILITIES_V1).every(capability => (
+            capability.deliveryEnabled === false
+        ))).toBe(true);
+        expect(isPlannedWorkoutProviderDeliveryEnabled('garmin')).toBe(false);
+        expect(isPlannedWorkoutProviderDeliveryEnabled('coros')).toBe(false);
+        expect(PLANNED_WORKOUT_PROVIDER_CAPABILITIES_V1.wahoo.implementationState).toBe('fixture-only');
+        expect(PLANNED_WORKOUT_PROVIDER_CAPABILITIES_V1.suunto.implementationState).toBe('fixture-only');
+    });
+
+    it('does not invent Garmin or COROS mappings without current partner contracts', () => {
+        expect(assessPlannedWorkoutProviderMappingV1('garmin', RUNNING_FIXTURE)).toMatchObject({
+            level: 'unsupported',
+            issues: [{ code: 'provider_contract_unavailable' }],
+        });
+        expect(assessPlannedWorkoutProviderMappingV1('coros', RUNNING_FIXTURE)).toMatchObject({
+            level: 'unsupported',
+            issues: [{ code: 'provider_contract_unavailable' }],
+        });
+    });
+
+    it('matches the redacted Wahoo plan.json fixture exactly', () => {
+        const result = serializeWahooPlanJsonV1(RUNNING_FIXTURE, {
+            name: 'Fixture intervals',
+            description: 'Redacted provider contract fixture.',
+            location: 'outdoor',
+            allowDegraded: false,
+        });
+
+        expect(result.level).toBe('exact');
+        expect(result.issues).toEqual([]);
+        expect(result.artifact).toEqual(expectedWahooFixture);
+    });
+
+    it('matches the redacted Suunto Guide fixture exactly', () => {
+        const result = serializeSuuntoGuideJsonV1(RUNNING_FIXTURE, {
+            name: 'Fixture intervals',
+            description: 'Redacted provider contract fixture.',
+            owner: 'Quantified Self',
+            url: 'https://quantified-self.io/plans',
+            localDate: '2026-09-03',
+            sourceWorkoutId: 'fixture-workout-001',
+            allowDegraded: false,
+        });
+
+        expect(result.level).toBe('exact');
+        expect(result.issues).toEqual([]);
+        expect(result.artifact).toEqual(expectedSuuntoFixture);
+    });
+
+    it('maps Wahoo native relative FTP targets through the header', () => {
+        const structure = oneStepStructure({
+            kind: 'step',
+            id: 'ftp',
+            purpose: 'work',
+            ending: { kind: 'kilojoules', kilojoules: 120 },
+            targets: [{
+                kind: 'power',
+                mode: 'relative',
+                minimumPercent: 90,
+                maximumPercent: 105,
+                reference: { kind: 'functional-threshold-power', watts: 300 },
+            }],
+        });
+        const result = serializeWahooPlanJsonV1(structure, {
+            name: 'FTP work',
+            location: 'indoor',
+            allowDegraded: false,
+        });
+
+        expect(result.level).toBe('exact');
+        expect(result.artifact.header.ftp).toBe(300);
+        expect(result.artifact.intervals[0]).toMatchObject({
+            exit_trigger_type: 'kj2',
+            exit_trigger_value: 120,
+            targets: [{ type: 'ftp', low: 0.9, high: 1.05 }],
+        });
+    });
+
+    it('requires explicit approval before Wahoo freezes a critical-power target', () => {
+        const structure = oneStepStructure({
+            kind: 'step',
+            id: 'critical',
+            purpose: 'work',
+            ending: { kind: 'time', seconds: 300 },
+            targets: [{
+                kind: 'power',
+                mode: 'relative',
+                minimumPercent: 90,
+                maximumPercent: 110,
+                reference: { kind: 'critical-power', watts: 250 },
+            }],
+        });
+
+        expect(() => serializeWahooPlanJsonV1(structure, {
+            name: 'Critical power',
+            location: 'indoor',
+            allowDegraded: false,
+        })).toThrow(expect.objectContaining({
+            code: 'degradation-confirmation-required',
+        } satisfies Partial<ProviderWorkoutMappingError>));
+
+        const approved = serializeWahooPlanJsonV1(structure, {
+            name: 'Critical power',
+            location: 'indoor',
+            allowDegraded: true,
+        });
+        expect(approved.level).toBe('degraded');
+        expect(approved.artifact.intervals[0].targets).toEqual([
+            { type: 'watts', low: 225, high: 275 },
+        ]);
+    });
+
+    it('freezes Suunto relative targets and converts cadence from rpm to hertz only with approval', () => {
+        const structure = oneStepStructure({
+            kind: 'step',
+            id: 'cadence',
+            purpose: 'work',
+            ending: { kind: 'manual' },
+            targets: [{
+                kind: 'cadence',
+                mode: 'relative',
+                minimumPercent: 90,
+                maximumPercent: 110,
+                reference: { kind: 'preferred-cadence', rpm: 90 },
+            }],
+        });
+
+        expect(() => serializeSuuntoGuideJsonV1(structure, {
+            name: 'Cadence',
+            owner: 'Quantified Self',
+            url: 'https://quantified-self.io/plans',
+            localDate: '2026-09-03',
+            sourceWorkoutId: 'cadence-workout',
+            allowDegraded: false,
+        })).toThrow(expect.objectContaining({ code: 'degradation-confirmation-required' }));
+
+        const approved = serializeSuuntoGuideJsonV1(structure, {
+            name: 'Cadence',
+            owner: 'Quantified Self',
+            url: 'https://quantified-self.io/plans',
+            localDate: '2026-09-03',
+            sourceWorkoutId: 'cadence-workout',
+            allowDegraded: true,
+        });
+        expect(approved.level).toBe('degraded');
+        expect(approved.artifact.steps[0]).toMatchObject({
+            type: 'fields',
+            fields: [{ type: 'targetCadence', min: 1.35, max: 1.65 }],
+            transitions: [{ condition: { type: 'manualLap' } }],
+        });
+    });
+
+    it('rejects endings that cannot be truthfully mapped', () => {
+        const repetitions = oneStepStructure({
+            kind: 'step',
+            id: 'strength',
+            purpose: 'work',
+            ending: { kind: 'repetitions', repetitions: 12 },
+            targets: [],
+        });
+
+        expect(() => serializeWahooPlanJsonV1(repetitions, {
+            name: 'Repetitions',
+            location: 'indoor',
+            allowDegraded: true,
+        })).toThrow(expect.objectContaining({ code: 'unsupported' }));
+        expect(() => serializeSuuntoGuideJsonV1(repetitions, {
+            name: 'Repetitions',
+            owner: 'Quantified Self',
+            url: 'https://quantified-self.io/plans',
+            localDate: '2026-09-03',
+            sourceWorkoutId: 'repetitions',
+            allowDegraded: true,
+        })).toThrow(expect.objectContaining({ code: 'unsupported' }));
+    });
+
+    it('creates stable opaque provider IDs within the strict Suunto limit', () => {
+        const first = createStableProviderExternalId('suunto', 'internal-workout-id');
+        expect(first).toBe(createStableProviderExternalId('suunto', 'internal-workout-id'));
+        expect(first).not.toContain('internal-workout-id');
+        expect(first.length).toBeLessThanOrEqual(64);
+        expect(createStableProviderExternalId('wahoo', 'internal-workout-id')).not.toBe(first);
+    });
+});

--- a/functions/src/training-plans/providers/provider-mapping.spec.ts
+++ b/functions/src/training-plans/providers/provider-mapping.spec.ts
@@ -7,11 +7,19 @@ import {
 } from '../../../../shared/planned-workout-providers';
 import type { WorkoutStructureV1 } from '../../../../shared/planned-workout';
 import canonicalRunningFixture from './fixtures/canonical-running-v1.json';
+import expectedCorosFixture from './fixtures/coros-running-v1.json';
+import expectedGarminFixture from './fixtures/garmin-running-v1.json';
 import expectedSuuntoFixture from './fixtures/suunto-running-v1.json';
 import expectedWahooFixture from './fixtures/wahoo-running-v1.json';
+import { serializeCorosTrainingPlanV1 } from './coros-training-plan.serializer';
+import {
+    serializeGarminWorkoutScheduleV1,
+    serializeGarminWorkoutV1,
+} from './garmin-workout.serializer';
 import {
     ProviderWorkoutMappingError,
     createStableProviderExternalId,
+    createStableProviderIntegerId,
 } from './provider-mapping';
 import { serializeSuuntoGuideJsonV1 } from './suunto-guide.serializer';
 import { serializeWahooPlanJsonV1 } from './wahoo-plan.serializer';
@@ -41,19 +49,54 @@ describe('planned-workout provider proof fixtures', () => {
         ))).toBe(true);
         expect(isPlannedWorkoutProviderDeliveryEnabled('garmin')).toBe(false);
         expect(isPlannedWorkoutProviderDeliveryEnabled('coros')).toBe(false);
+        expect(PLANNED_WORKOUT_PROVIDER_CAPABILITIES_V1.garmin.implementationState).toBe('fixture-only');
+        expect(PLANNED_WORKOUT_PROVIDER_CAPABILITIES_V1.coros.implementationState).toBe('fixture-only');
         expect(PLANNED_WORKOUT_PROVIDER_CAPABILITIES_V1.wahoo.implementationState).toBe('fixture-only');
         expect(PLANNED_WORKOUT_PROVIDER_CAPABILITIES_V1.suunto.implementationState).toBe('fixture-only');
     });
 
-    it('does not invent Garmin or COROS mappings without current partner contracts', () => {
-        expect(assessPlannedWorkoutProviderMappingV1('garmin', RUNNING_FIXTURE)).toMatchObject({
-            level: 'unsupported',
-            issues: [{ code: 'provider_contract_unavailable' }],
+    it('matches the redacted Garmin workout and separate schedule contracts exactly', () => {
+        const result = serializeGarminWorkoutV1(RUNNING_FIXTURE, {
+            name: 'Fixture intervals',
+            description: 'Redacted provider contract fixture.',
+            allowDegraded: false,
         });
-        expect(assessPlannedWorkoutProviderMappingV1('coros', RUNNING_FIXTURE)).toMatchObject({
-            level: 'unsupported',
-            issues: [{ code: 'provider_contract_unavailable' }],
+
+        expect(result.level).toBe('exact');
+        expect(result.issues).toEqual([]);
+        expect(result.artifact).toEqual(expectedGarminFixture);
+        expect(serializeGarminWorkoutScheduleV1(123456789, '2026-09-03')).toEqual({
+            workoutId: 123456789,
+            date: '2026-09-03',
         });
+    });
+
+    it('matches the redacted COROS training-plan contract exactly', () => {
+        expect(() => serializeCorosTrainingPlanV1(RUNNING_FIXTURE, {
+            athleteId: 24680,
+            sourceWorkoutId: 'fixture-workout-001',
+            title: 'Fixture intervals',
+            description: 'Redacted provider contract fixture.',
+            localDate: '2026-09-03',
+            lastModifiedDate: '2026-09-02T12:00:00.000',
+            allowDegraded: false,
+        })).toThrow(expect.objectContaining({ code: 'degradation-confirmation-required' }));
+
+        const result = serializeCorosTrainingPlanV1(RUNNING_FIXTURE, {
+            athleteId: 24680,
+            sourceWorkoutId: 'fixture-workout-001',
+            title: 'Fixture intervals',
+            description: 'Redacted provider contract fixture.',
+            localDate: '2026-09-03',
+            lastModifiedDate: '2026-09-02T12:00:00.000',
+            allowDegraded: true,
+        });
+        expect(result.level).toBe('degraded');
+        expect(result.issues).toContainEqual(expect.objectContaining({
+            code: 'purpose_degraded',
+            path: '$.nodes[1].steps[1].purpose',
+        }));
+        expect(result.artifact).toEqual(expectedCorosFixture);
     });
 
     it('matches the redacted Wahoo plan.json fixture exactly', () => {
@@ -114,6 +157,72 @@ describe('planned-workout provider proof fixtures', () => {
         });
     });
 
+    it('requires approval before rounding Wahoo integer header references', () => {
+        const structure = oneStepStructure({
+            kind: 'step',
+            id: 'fractional-ftp',
+            purpose: 'work',
+            ending: { kind: 'time', seconds: 600 },
+            targets: [{
+                kind: 'power',
+                mode: 'relative',
+                minimumPercent: 90,
+                maximumPercent: 100,
+                reference: { kind: 'functional-threshold-power', watts: 299.5 },
+            }],
+        });
+
+        expect(() => serializeWahooPlanJsonV1(structure, {
+            name: 'Fractional FTP',
+            location: 'indoor',
+            allowDegraded: false,
+        })).toThrow(expect.objectContaining({ code: 'degradation-confirmation-required' }));
+
+        const approved = serializeWahooPlanJsonV1(structure, {
+            name: 'Fractional FTP',
+            location: 'indoor',
+            allowDegraded: true,
+        });
+        expect(approved.level).toBe('degraded');
+        expect(approved.issues).toContainEqual(expect.objectContaining({ code: 'relative_reference_rounded' }));
+        expect(approved.artifact.header.ftp).toBe(300);
+    });
+
+    it('does not claim universal device support for Wahoo relative heart-rate targets', () => {
+        const structure = oneStepStructure({
+            kind: 'step',
+            id: 'threshold-heart-rate',
+            purpose: 'work',
+            ending: { kind: 'time', seconds: 600 },
+            targets: [{
+                kind: 'heart-rate',
+                mode: 'relative',
+                minimumPercent: 90,
+                maximumPercent: 100,
+                reference: { kind: 'threshold-heart-rate', bpm: 170 },
+            }],
+        });
+
+        expect(() => serializeWahooPlanJsonV1(structure, {
+            name: 'Threshold HR',
+            location: 'indoor',
+            allowDegraded: false,
+        })).toThrow(expect.objectContaining({ code: 'degradation-confirmation-required' }));
+
+        const approved = serializeWahooPlanJsonV1(structure, {
+            name: 'Threshold HR',
+            location: 'indoor',
+            allowDegraded: true,
+        });
+        expect(approved.issues).toContainEqual(expect.objectContaining({
+            code: 'relative_target_device_support_limited',
+        }));
+        expect(approved.artifact.header.threshold_hr).toBe(170);
+        expect(approved.artifact.intervals[0].targets).toEqual([
+            { type: 'threshold_hr', low: 0.9, high: 1 },
+        ]);
+    });
+
     it('requires explicit approval before Wahoo freezes a critical-power target', () => {
         const structure = oneStepStructure({
             kind: 'step',
@@ -146,6 +255,139 @@ describe('planned-workout provider proof fixtures', () => {
         expect(approved.artifact.intervals[0].targets).toEqual([
             { type: 'watts', low: 225, high: 275 },
         ]);
+    });
+
+    it('requires explicit approval before Garmin freezes a relative target snapshot', () => {
+        const structure = oneStepStructure({
+            kind: 'step',
+            id: 'ftp',
+            purpose: 'work',
+            ending: { kind: 'time', seconds: 300 },
+            targets: [{
+                kind: 'power',
+                mode: 'relative',
+                minimumPercent: 90,
+                maximumPercent: 110,
+                reference: { kind: 'functional-threshold-power', watts: 250 },
+            }],
+        });
+
+        expect(() => serializeGarminWorkoutV1(structure, {
+            name: 'FTP work',
+            allowDegraded: false,
+        })).toThrow(expect.objectContaining({ code: 'degradation-confirmation-required' }));
+
+        const approved = serializeGarminWorkoutV1(structure, {
+            name: 'FTP work',
+            allowDegraded: true,
+        });
+        expect(approved.issues).toContainEqual(expect.objectContaining({ code: 'relative_target_degraded' }));
+        expect(approved.artifact.segments[0].steps[0]).toMatchObject({
+            targetType: 'POWER',
+            targetValueLow: 225,
+            targetValueHigh: 275,
+        });
+    });
+
+    it('uses COROS native threshold snapshots and gates lossy integer rounding', () => {
+        const structure = oneStepStructure({
+            kind: 'step',
+            id: 'threshold-speed',
+            purpose: 'work',
+            ending: { kind: 'distance', meters: 1000.4 },
+            targets: [{
+                kind: 'speed',
+                mode: 'relative',
+                minimumPercent: 89.5,
+                maximumPercent: 100.4,
+                presentation: 'pace',
+                reference: { kind: 'threshold-speed', metersPerSecond: 4.2 },
+            }],
+        });
+        const options = {
+            athleteId: 24680,
+            sourceWorkoutId: 'coros-threshold',
+            title: 'Threshold work',
+            localDate: '2026-09-03',
+            lastModifiedDate: '2026-09-02T12:00:00',
+        };
+
+        expect(() => serializeCorosTrainingPlanV1(structure, {
+            ...options,
+            allowDegraded: false,
+        })).toThrow(expect.objectContaining({ code: 'degradation-confirmation-required' }));
+
+        const approved = serializeCorosTrainingPlanV1(structure, {
+            ...options,
+            allowDegraded: true,
+        });
+        expect(approved.issues).toEqual(expect.arrayContaining([
+            expect.objectContaining({ code: 'ending_value_rounded' }),
+            expect.objectContaining({ code: 'target_percentage_rounded' }),
+        ]));
+        expect(approved.artifact.Workouts[0].Structure[0]).toMatchObject({
+            Length: { Unit: 'Meter', Value: 1000 },
+            ThresholdSpeed: 4.2,
+            IntensityTarget: {
+                Unit: 'PercentOfThresholdSpeed',
+                MinValue: 90,
+                MaxValue: 100,
+            },
+        });
+    });
+
+    it('keeps an approved tiny COROS step positive after integer rounding', () => {
+        const structure = oneStepStructure({
+            ending: { kind: 'time', seconds: 0.1 },
+        });
+        const result = serializeCorosTrainingPlanV1(structure, {
+            athleteId: 24680,
+            sourceWorkoutId: 'coros-tiny-step',
+            title: 'Tiny step',
+            localDate: '2026-09-03',
+            lastModifiedDate: '2026-09-02T12:00:00',
+            allowDegraded: true,
+        });
+
+        expect(result.issues).toContainEqual(expect.objectContaining({ code: 'ending_value_rounded' }));
+        expect(result.artifact.Workouts[0].Structure[0]).toMatchObject({
+            Length: { Unit: 'Second', Value: 1 },
+        });
+    });
+
+    it('rejects COROS athlete IDs outside the provider signed-int range', () => {
+        expect(() => serializeCorosTrainingPlanV1(oneStepStructure(), {
+            athleteId: 2_147_483_648,
+            sourceWorkoutId: 'coros-athlete-overflow',
+            title: 'Overflow',
+            localDate: '2026-09-03',
+            lastModifiedDate: '2026-09-02T12:00:00',
+            allowDegraded: false,
+        })).toThrow('positive signed 32-bit integer');
+    });
+
+    it('rejects provider-specific target combinations that the contracts cannot carry', () => {
+        const runningWithTwoTargets: WorkoutStructureV1 = {
+            ...oneStepStructure({
+                targets: [
+                    { kind: 'heart-rate', mode: 'absolute', minimumBpm: 120, maximumBpm: 140 },
+                    { kind: 'power', mode: 'absolute', minimumWatts: 200, maximumWatts: 240 },
+                ],
+            }),
+            sport: ActivityTypes.Running,
+        };
+        const cyclingCadence = oneStepStructure({
+            targets: [{ kind: 'cadence', mode: 'absolute', minimumRpm: 80, maximumRpm: 90 }],
+        });
+
+        expect(assessPlannedWorkoutProviderMappingV1('garmin', runningWithTwoTargets)).toMatchObject({
+            level: 'unsupported',
+            issues: [expect.objectContaining({ code: 'unsupported_target' })],
+        });
+        expect(assessPlannedWorkoutProviderMappingV1('coros', cyclingCadence)).toMatchObject({
+            level: 'unsupported',
+            issues: [expect.objectContaining({ code: 'unsupported_target' })],
+        });
     });
 
     it('freezes Suunto relative targets and converts cadence from rpm to hertz only with approval', () => {
@@ -188,6 +430,42 @@ describe('planned-workout provider proof fixtures', () => {
         });
     });
 
+    it('does not claim exact Suunto rendering outside the guaranteed watch character set', () => {
+        const structure = oneStepStructure({
+            kind: 'step',
+            id: 'unicode-note',
+            purpose: 'work',
+            ending: { kind: 'time', seconds: 600 },
+            targets: [],
+            note: 'Push steady 🚴',
+        });
+        const options = {
+            name: 'Unicode guidance',
+            owner: 'Quantified Self',
+            url: 'https://quantified-self.io/plans',
+            localDate: '2026-09-03',
+            sourceWorkoutId: 'unicode-workout',
+        };
+
+        expect(() => serializeSuuntoGuideJsonV1(structure, {
+            ...options,
+            allowDegraded: false,
+        })).toThrow(expect.objectContaining({ code: 'degradation-confirmation-required' }));
+
+        const approved = serializeSuuntoGuideJsonV1(structure, {
+            ...options,
+            allowDegraded: true,
+        });
+        expect(approved.issues).toContainEqual(expect.objectContaining({
+            code: 'device_character_support_unverified',
+            path: '$.nodes[0].note',
+        }));
+        expect(approved.artifact.steps[0]).toMatchObject({
+            type: 'fields',
+            fields: expect.arrayContaining([{ type: 'text', value: 'Push steady 🚴' }]),
+        });
+    });
+
     it('rejects endings that cannot be truthfully mapped', () => {
         const repetitions = oneStepStructure({
             kind: 'step',
@@ -218,5 +496,11 @@ describe('planned-workout provider proof fixtures', () => {
         expect(first).not.toContain('internal-workout-id');
         expect(first.length).toBeLessThanOrEqual(64);
         expect(createStableProviderExternalId('wahoo', 'internal-workout-id')).not.toBe(first);
+
+        const integerId = createStableProviderIntegerId('coros', 'internal-workout-id');
+        expect(integerId).toBe(createStableProviderIntegerId('coros', 'internal-workout-id'));
+        expect(Number.isSafeInteger(integerId)).toBe(true);
+        expect(integerId).toBeGreaterThan(0);
+        expect(integerId).toBeLessThanOrEqual(2_147_483_647);
     });
 });

--- a/functions/src/training-plans/providers/provider-mapping.ts
+++ b/functions/src/training-plans/providers/provider-mapping.ts
@@ -1,0 +1,108 @@
+import { createHash } from 'crypto';
+import {
+    assessPlannedWorkoutProviderMappingV1,
+    type PlannedWorkoutProviderId,
+    type PlannedWorkoutProviderMappingIssueV1,
+    type PlannedWorkoutProviderMappingLevel,
+} from '../../../../shared/planned-workout-providers';
+
+export interface ProviderSerializationIssueV1 {
+    severity: Exclude<PlannedWorkoutProviderMappingLevel, 'exact'>;
+    code: string;
+    path: string;
+    message: string;
+}
+
+export interface ProviderSerializationResultV1<T> {
+    provider: PlannedWorkoutProviderId;
+    level: PlannedWorkoutProviderMappingLevel;
+    issues: ProviderSerializationIssueV1[];
+    artifact: T;
+}
+
+export class ProviderWorkoutMappingError extends Error {
+    readonly code: 'unsupported' | 'degradation-confirmation-required';
+    readonly provider: PlannedWorkoutProviderId;
+    readonly issues: ProviderSerializationIssueV1[];
+
+    constructor(
+        provider: PlannedWorkoutProviderId,
+        code: ProviderWorkoutMappingError['code'],
+        issues: ProviderSerializationIssueV1[],
+    ) {
+        const reason = code === 'unsupported'
+            ? 'cannot be represented'
+            : 'requires explicit degradation approval';
+        super(`${provider} workout ${reason}: ${issues.map(issue => `${issue.path}: ${issue.message}`).join('; ')}`);
+        this.name = 'ProviderWorkoutMappingError';
+        this.code = code;
+        this.provider = provider;
+        this.issues = issues;
+    }
+}
+
+export function createStableProviderExternalId(
+    provider: PlannedWorkoutProviderId,
+    sourceWorkoutId: string,
+): string {
+    if (sourceWorkoutId.trim().length === 0) {
+        throw new Error('A non-empty source workout ID is required.');
+    }
+    const digest = createHash('sha256')
+        .update(`${provider}\u0000${sourceWorkoutId}`, 'utf8')
+        .digest('base64url');
+    return `qs-${provider}-${digest}`;
+}
+
+export function buildProviderSerializationResultV1<T>(params: {
+    provider: PlannedWorkoutProviderId;
+    structure: unknown;
+    artifact: T;
+    additionalIssues?: readonly ProviderSerializationIssueV1[];
+    allowDegraded: boolean;
+}): ProviderSerializationResultV1<T> {
+    const resolved = resolveProviderSerializationIssuesV1({
+        provider: params.provider,
+        structure: params.structure,
+        additionalIssues: params.additionalIssues,
+        allowDegraded: params.allowDegraded,
+    });
+
+    return {
+        provider: params.provider,
+        level: resolved.level,
+        issues: resolved.issues,
+        artifact: params.artifact,
+    };
+}
+
+export function resolveProviderSerializationIssuesV1(params: {
+    provider: PlannedWorkoutProviderId;
+    structure: unknown;
+    additionalIssues?: readonly ProviderSerializationIssueV1[];
+    allowDegraded: boolean;
+}): Pick<ProviderSerializationResultV1<never>, 'provider' | 'level' | 'issues'> {
+    const assessment = assessPlannedWorkoutProviderMappingV1(params.provider, params.structure);
+    const issues: ProviderSerializationIssueV1[] = [
+        ...assessment.issues.map((issue: PlannedWorkoutProviderMappingIssueV1) => ({ ...issue })),
+        ...(params.additionalIssues ?? []),
+    ];
+    const level: PlannedWorkoutProviderMappingLevel = issues.some(issue => issue.severity === 'unsupported')
+        ? 'unsupported'
+        : issues.some(issue => issue.severity === 'degraded')
+            ? 'degraded'
+            : 'exact';
+
+    if (level === 'unsupported') {
+        throw new ProviderWorkoutMappingError(params.provider, 'unsupported', issues);
+    }
+    if (level === 'degraded' && !params.allowDegraded) {
+        throw new ProviderWorkoutMappingError(params.provider, 'degradation-confirmation-required', issues);
+    }
+
+    return {
+        provider: params.provider,
+        level,
+        issues,
+    };
+}

--- a/functions/src/training-plans/providers/provider-mapping.ts
+++ b/functions/src/training-plans/providers/provider-mapping.ts
@@ -54,6 +54,25 @@ export function createStableProviderExternalId(
     return `qs-${provider}-${digest}`;
 }
 
+/**
+ * Produces an opaque positive signed 32-bit integer for provider contracts
+ * that declare partner-owned IDs as `int`. The provider remains part of the
+ * digest namespace and the original Quantified Self ID is never disclosed.
+ */
+export function createStableProviderIntegerId(
+    provider: PlannedWorkoutProviderId,
+    sourceId: string,
+): number {
+    if (sourceId.trim().length === 0) {
+        throw new Error('A non-empty source ID is required.');
+    }
+    const digest = createHash('sha256')
+        .update(`${provider}\u0000integer\u0000${sourceId}`, 'utf8')
+        .digest();
+    const value = digest.readUInt32BE(0) & 0x7fffffff;
+    return value === 0 ? 1 : value;
+}
+
 export function buildProviderSerializationResultV1<T>(params: {
     provider: PlannedWorkoutProviderId;
     structure: unknown;

--- a/functions/src/training-plans/providers/suunto-guide.serializer.ts
+++ b/functions/src/training-plans/providers/suunto-guide.serializer.ts
@@ -73,6 +73,22 @@ export interface SerializeSuuntoGuideOptionsV1 {
     allowDegraded: boolean;
 }
 
+const SUUNTO_MINIMUM_SUPPORTED_CHARACTERS = new Set(Array.from(
+    "\n !\"#$%&'()*+,-./0123456789:;<=>?ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz|°",
+));
+
+function codePointLength(value: string): number {
+    return Array.from(value).length;
+}
+
+function truncateCodePoints(value: string, maximum: number): string {
+    return Array.from(value).slice(0, maximum).join('');
+}
+
+function usesCharactersOutsideSuuntoMinimum(value: string): boolean {
+    return Array.from(value).some(character => !SUUNTO_MINIMUM_SUPPORTED_CHARACTERS.has(character));
+}
+
 function normalizedRequiredText(value: string, label: string): string {
     const normalized = value.trim();
     if (normalized.length === 0) throw new Error(`${label} must not be empty.`);
@@ -105,6 +121,20 @@ function addTruncationIssue(
         code: 'text_truncated',
         path,
         message: `${label} is limited to ${maximum} characters by Suunto.`,
+    });
+}
+
+function addCharacterSetIssue(
+    issues: ProviderSerializationIssueV1[],
+    path: string,
+    value: string,
+): void {
+    if (!usesCharactersOutsideSuuntoMinimum(value)) return;
+    issues.push({
+        severity: 'degraded',
+        code: 'device_character_support_unverified',
+        path,
+        message: 'This text contains characters outside Suunto\'s guaranteed watch character set and may not render on every device.',
     });
 }
 
@@ -220,10 +250,10 @@ function collectStepIssues(
     issues: ProviderSerializationIssueV1[],
 ): void {
     const visit = (step: WorkoutStepV1, path: string): void => {
-        if (step.note && step.note.length > 54) {
+        if (step.note && codePointLength(step.note) > 54) {
             addTruncationIssue(issues, `${path}.note`, 'Suunto step text', 54);
         }
-        if (step.note && step.note.length > 40 && (step.targets.length > 0 || step.ending.kind !== 'manual')) {
+        if (step.note && codePointLength(step.note) > 40 && (step.targets.length > 0 || step.ending.kind !== 'manual')) {
             issues.push({
                 severity: 'degraded',
                 code: 'text_truncated_for_metrics',
@@ -231,6 +261,7 @@ function collectStepIssues(
                 message: 'Suunto cannot show other fields alongside text longer than 40 characters.',
             });
         }
+        if (step.note) addCharacterSetIssue(issues, `${path}.note`, step.note);
         step.targets.forEach((target, targetIndex) => {
             if (target.kind !== 'heart-rate') return;
             const values = absoluteTargetValues(target);
@@ -261,7 +292,7 @@ function stepToSuunto(step: WorkoutStepV1): SuuntoGuideFieldsStepV1 {
     ];
     if (step.note) {
         const maximum = fields.length > 0 ? 40 : 54;
-        fields.push({ type: 'text', value: step.note.slice(0, maximum) });
+        fields.push({ type: 'text', value: truncateCodePoints(step.note, maximum) });
     }
     if (fields.length === 0) fields.push({ type: 'text', value: 'Press lap' });
 
@@ -306,14 +337,18 @@ export function serializeSuuntoGuideJsonV1(
     if (externalId.length > 64) throw new Error('Suunto Guide external ID must not exceed 64 characters.');
 
     const additionalIssues: ProviderSerializationIssueV1[] = [];
-    if (rawName.length > 60) addTruncationIssue(additionalIssues, '$.name', 'Suunto Guide name', 60);
-    if (rawDescription.length > 256) {
+    if (codePointLength(rawName) > 60) addTruncationIssue(additionalIssues, '$.name', 'Suunto Guide name', 60);
+    if (codePointLength(rawDescription) > 256) {
         addTruncationIssue(additionalIssues, '$.description', 'Suunto Guide description', 256);
     }
-    if (rawShortDescription.length > 23) {
+    if (codePointLength(rawShortDescription) > 23) {
         addTruncationIssue(additionalIssues, '$.shortDescription', 'Suunto Guide short description', 23);
     }
-    if (rawOwner.length > 64) addTruncationIssue(additionalIssues, '$.owner', 'Suunto Guide owner', 64);
+    if (codePointLength(rawOwner) > 64) addTruncationIssue(additionalIssues, '$.owner', 'Suunto Guide owner', 64);
+    addCharacterSetIssue(additionalIssues, '$.name', rawName);
+    addCharacterSetIssue(additionalIssues, '$.description', rawDescription);
+    addCharacterSetIssue(additionalIssues, '$.shortDescription', rawShortDescription);
+    addCharacterSetIssue(additionalIssues, '$.owner', rawOwner);
     collectStepIssues(structure, additionalIssues);
 
     const resolved = resolveProviderSerializationIssuesV1({
@@ -325,10 +360,10 @@ export function serializeSuuntoGuideJsonV1(
     const activity: 1 | 2 = structure.sport === ActivityTypes.Running ? 1 : 2;
     const artifact: SuuntoGuideJsonV1 = {
         type: 'sequence',
-        name: rawName.slice(0, 60),
-        description: rawDescription.slice(0, 256),
-        shortDescription: rawShortDescription.slice(0, 23),
-        owner: rawOwner.slice(0, 64),
+        name: truncateCodePoints(rawName, 60),
+        description: truncateCodePoints(rawDescription, 256),
+        shortDescription: truncateCodePoints(rawShortDescription, 23),
+        owner: truncateCodePoints(rawOwner, 64),
         url,
         activities: [activity],
         usage: 'workout',

--- a/functions/src/training-plans/providers/suunto-guide.serializer.ts
+++ b/functions/src/training-plans/providers/suunto-guide.serializer.ts
@@ -1,0 +1,341 @@
+import { ActivityTypes } from '@sports-alliance/sports-lib';
+import {
+    parseWorkoutStructureV1,
+    type WorkoutEndingV1,
+    type WorkoutStepPurposeV1,
+    type WorkoutStepV1,
+    type WorkoutStructureV1,
+    type WorkoutTargetV1,
+} from '../../../../shared/planned-workout';
+import { normalizeTrainingLocalDate } from '../../../../shared/training-plans';
+import {
+    createStableProviderExternalId,
+    resolveProviderSerializationIssuesV1,
+    type ProviderSerializationIssueV1,
+    type ProviderSerializationResultV1,
+} from './provider-mapping';
+
+export type SuuntoGuideConditionV1 =
+    | { type: 'stepDuration'; value: number }
+    | { type: 'stepDistance'; value: number }
+    | { type: 'manualLap' };
+
+export type SuuntoGuideFieldV1 =
+    | { type: 'text'; value: string }
+    | { type: 'stepDurationCountdown'; value: number; title: string }
+    | { type: 'stepDistanceCountdown'; value: number; title: string }
+    | { type: 'targetHeartRate'; min: number; max: number; title: string }
+    | { type: 'targetPower'; min: number; max: number; title: string }
+    | { type: 'targetSpeed'; min: number; max: number; title: string }
+    | { type: 'targetPace'; min: number; max: number; title: string }
+    | { type: 'targetCadence'; min: number; max: number; title: string };
+
+export interface SuuntoGuideFieldsStepV1 {
+    id: string;
+    type: 'fields';
+    title: string;
+    fields: SuuntoGuideFieldV1[];
+    transitions: Array<{ condition: SuuntoGuideConditionV1 }>;
+}
+
+export interface SuuntoGuideRepeatStepV1 {
+    id: string;
+    type: 'repeat';
+    times: number;
+    steps: SuuntoGuideFieldsStepV1[];
+}
+
+export type SuuntoGuideStepV1 = SuuntoGuideFieldsStepV1 | SuuntoGuideRepeatStepV1;
+
+export interface SuuntoGuideJsonV1 {
+    type: 'sequence';
+    name: string;
+    description: string;
+    shortDescription: string;
+    owner: string;
+    url: string;
+    activities: [1 | 2];
+    usage: 'workout';
+    localDate: string;
+    externalId: string;
+    steps: SuuntoGuideStepV1[];
+}
+
+export interface SerializeSuuntoGuideOptionsV1 {
+    name: string;
+    description?: string;
+    shortDescription?: string;
+    owner: string;
+    url: string;
+    localDate: string;
+    sourceWorkoutId: string;
+    externalId?: string;
+    allowDegraded: boolean;
+}
+
+function normalizedRequiredText(value: string, label: string): string {
+    const normalized = value.trim();
+    if (normalized.length === 0) throw new Error(`${label} must not be empty.`);
+    return normalized;
+}
+
+function validateGuideUrl(value: string): string {
+    const normalized = normalizedRequiredText(value, 'Suunto Guide URL');
+    let url: URL;
+    try {
+        url = new URL(normalized);
+    } catch {
+        throw new Error('Suunto Guide URL must be a valid HTTP or HTTPS URL.');
+    }
+    if (!['http:', 'https:'].includes(url.protocol)) {
+        throw new Error('Suunto Guide URL must be a valid HTTP or HTTPS URL.');
+    }
+    if (normalized.length > 256) throw new Error('Suunto Guide URL must not exceed 256 characters.');
+    return normalized;
+}
+
+function addTruncationIssue(
+    issues: ProviderSerializationIssueV1[],
+    path: string,
+    label: string,
+    maximum: number,
+): void {
+    issues.push({
+        severity: 'degraded',
+        code: 'text_truncated',
+        path,
+        message: `${label} is limited to ${maximum} characters by Suunto.`,
+    });
+}
+
+function purposeTitle(purpose: WorkoutStepPurposeV1): string {
+    switch (purpose) {
+        case 'warmup': return 'Warm up';
+        case 'work': return 'Work';
+        case 'recovery': return 'Recovery';
+        case 'cooldown': return 'Cool down';
+        case 'rest': return 'Rest';
+        case 'other': return 'Next';
+    }
+}
+
+function endingFields(ending: WorkoutEndingV1): SuuntoGuideFieldV1[] {
+    switch (ending.kind) {
+        case 'time':
+            return [{ type: 'stepDurationCountdown', value: ending.seconds, title: 'Remaining' }];
+        case 'distance':
+            return [{ type: 'stepDistanceCountdown', value: ending.meters, title: 'Remaining' }];
+        case 'manual':
+            return [];
+        case 'kilojoules':
+        case 'repetitions':
+            throw new Error(`Unsupported Suunto ending reached after compatibility validation: ${ending.kind}.`);
+    }
+}
+
+function endingCondition(ending: WorkoutEndingV1): SuuntoGuideConditionV1 {
+    switch (ending.kind) {
+        case 'time':
+            return { type: 'stepDuration', value: ending.seconds };
+        case 'distance':
+            return { type: 'stepDistance', value: ending.meters };
+        case 'manual':
+            return { type: 'manualLap' };
+        case 'kilojoules':
+        case 'repetitions':
+            throw new Error(`Unsupported Suunto ending reached after compatibility validation: ${ending.kind}.`);
+    }
+}
+
+function absoluteTargetValues(target: WorkoutTargetV1): { minimum: number; maximum: number } {
+    if (target.mode === 'absolute') {
+        switch (target.kind) {
+            case 'heart-rate': return { minimum: target.minimumBpm, maximum: target.maximumBpm };
+            case 'power': return { minimum: target.minimumWatts, maximum: target.maximumWatts };
+            case 'speed':
+                return {
+                    minimum: target.minimumMetersPerSecond,
+                    maximum: target.maximumMetersPerSecond,
+                };
+            case 'cadence': return { minimum: target.minimumRpm, maximum: target.maximumRpm };
+        }
+    }
+
+    const scale = (value: number, percent: number): number => value * percent / 100;
+    switch (target.kind) {
+        case 'heart-rate':
+            return {
+                minimum: scale(target.reference.bpm, target.minimumPercent),
+                maximum: scale(target.reference.bpm, target.maximumPercent),
+            };
+        case 'power':
+            return {
+                minimum: scale(target.reference.watts, target.minimumPercent),
+                maximum: scale(target.reference.watts, target.maximumPercent),
+            };
+        case 'speed':
+            return {
+                minimum: scale(target.reference.metersPerSecond, target.minimumPercent),
+                maximum: scale(target.reference.metersPerSecond, target.maximumPercent),
+            };
+        case 'cadence':
+            return {
+                minimum: scale(target.reference.rpm, target.minimumPercent),
+                maximum: scale(target.reference.rpm, target.maximumPercent),
+            };
+    }
+}
+
+function targetToSuunto(target: WorkoutTargetV1): SuuntoGuideFieldV1 {
+    const values = absoluteTargetValues(target);
+    switch (target.kind) {
+        case 'heart-rate':
+            return {
+                type: 'targetHeartRate',
+                min: Math.round(values.minimum),
+                max: Math.round(values.maximum),
+                title: 'Target HR',
+            };
+        case 'power':
+            return { type: 'targetPower', min: values.minimum, max: values.maximum, title: 'Tgt power' };
+        case 'speed':
+            return {
+                type: target.presentation === 'pace' ? 'targetPace' : 'targetSpeed',
+                min: values.minimum,
+                max: values.maximum,
+                title: target.presentation === 'pace' ? 'Tgt pace' : 'Tgt speed',
+            };
+        case 'cadence':
+            return {
+                type: 'targetCadence',
+                min: values.minimum / 60,
+                max: values.maximum / 60,
+                title: 'Tgt cadence',
+            };
+    }
+}
+
+function collectStepIssues(
+    structure: WorkoutStructureV1,
+    issues: ProviderSerializationIssueV1[],
+): void {
+    const visit = (step: WorkoutStepV1, path: string): void => {
+        if (step.note && step.note.length > 54) {
+            addTruncationIssue(issues, `${path}.note`, 'Suunto step text', 54);
+        }
+        if (step.note && step.note.length > 40 && (step.targets.length > 0 || step.ending.kind !== 'manual')) {
+            issues.push({
+                severity: 'degraded',
+                code: 'text_truncated_for_metrics',
+                path: `${path}.note`,
+                message: 'Suunto cannot show other fields alongside text longer than 40 characters.',
+            });
+        }
+        step.targets.forEach((target, targetIndex) => {
+            if (target.kind !== 'heart-rate') return;
+            const values = absoluteTargetValues(target);
+            if (!Number.isInteger(values.minimum) || !Number.isInteger(values.maximum)) {
+                issues.push({
+                    severity: 'degraded',
+                    code: 'heart_rate_rounded',
+                    path: `${path}.targets[${targetIndex}]`,
+                    message: 'Suunto heart-rate targets require integer bpm values and will be rounded.',
+                });
+            }
+        });
+    };
+
+    structure.nodes.forEach((node, nodeIndex) => {
+        if (node.kind === 'step') {
+            visit(node, `$.nodes[${nodeIndex}]`);
+            return;
+        }
+        node.steps.forEach((step, stepIndex) => visit(step, `$.nodes[${nodeIndex}].steps[${stepIndex}]`));
+    });
+}
+
+function stepToSuunto(step: WorkoutStepV1): SuuntoGuideFieldsStepV1 {
+    const fields = [
+        ...endingFields(step.ending),
+        ...step.targets.map(targetToSuunto),
+    ];
+    if (step.note) {
+        const maximum = fields.length > 0 ? 40 : 54;
+        fields.push({ type: 'text', value: step.note.slice(0, maximum) });
+    }
+    if (fields.length === 0) fields.push({ type: 'text', value: 'Press lap' });
+
+    return {
+        id: createStableProviderExternalId('suunto', `node:${step.id}`),
+        type: 'fields',
+        title: purposeTitle(step.purpose),
+        fields,
+        transitions: [{ condition: endingCondition(step.ending) }],
+    };
+}
+
+function structureToSteps(structure: WorkoutStructureV1): SuuntoGuideStepV1[] {
+    return structure.nodes.map(node => {
+        if (node.kind === 'step') return stepToSuunto(node);
+        return {
+            id: createStableProviderExternalId('suunto', `node:${node.id}`),
+            type: 'repeat',
+            times: node.count,
+            steps: node.steps.map(stepToSuunto),
+        };
+    });
+}
+
+export function serializeSuuntoGuideJsonV1(
+    structureValue: unknown,
+    options: SerializeSuuntoGuideOptionsV1,
+): ProviderSerializationResultV1<SuuntoGuideJsonV1> {
+    const structure = parseWorkoutStructureV1(structureValue);
+    const rawName = normalizedRequiredText(options.name, 'Suunto Guide name');
+    const rawDescription = normalizedRequiredText(options.description ?? rawName, 'Suunto Guide description');
+    const rawShortDescription = normalizedRequiredText(
+        options.shortDescription ?? rawName,
+        'Suunto Guide short description',
+    );
+    const rawOwner = normalizedRequiredText(options.owner, 'Suunto Guide owner');
+    const url = validateGuideUrl(options.url);
+    const localDate = normalizeTrainingLocalDate(options.localDate);
+    const externalId = options.externalId
+        ? normalizedRequiredText(options.externalId, 'Suunto Guide external ID')
+        : createStableProviderExternalId('suunto', options.sourceWorkoutId);
+    if (externalId.length > 64) throw new Error('Suunto Guide external ID must not exceed 64 characters.');
+
+    const additionalIssues: ProviderSerializationIssueV1[] = [];
+    if (rawName.length > 60) addTruncationIssue(additionalIssues, '$.name', 'Suunto Guide name', 60);
+    if (rawDescription.length > 256) {
+        addTruncationIssue(additionalIssues, '$.description', 'Suunto Guide description', 256);
+    }
+    if (rawShortDescription.length > 23) {
+        addTruncationIssue(additionalIssues, '$.shortDescription', 'Suunto Guide short description', 23);
+    }
+    if (rawOwner.length > 64) addTruncationIssue(additionalIssues, '$.owner', 'Suunto Guide owner', 64);
+    collectStepIssues(structure, additionalIssues);
+
+    const resolved = resolveProviderSerializationIssuesV1({
+        provider: 'suunto',
+        structure,
+        additionalIssues,
+        allowDegraded: options.allowDegraded,
+    });
+    const activity: 1 | 2 = structure.sport === ActivityTypes.Running ? 1 : 2;
+    const artifact: SuuntoGuideJsonV1 = {
+        type: 'sequence',
+        name: rawName.slice(0, 60),
+        description: rawDescription.slice(0, 256),
+        shortDescription: rawShortDescription.slice(0, 23),
+        owner: rawOwner.slice(0, 64),
+        url,
+        activities: [activity],
+        usage: 'workout',
+        localDate,
+        externalId,
+        steps: structureToSteps(structure),
+    };
+
+    return { ...resolved, artifact };
+}

--- a/functions/src/training-plans/providers/wahoo-plan.serializer.ts
+++ b/functions/src/training-plans/providers/wahoo-plan.serializer.ts
@@ -65,6 +65,15 @@ type WahooReferenceHeaderKey = 'ftp' | 'threshold_hr' | 'max_hr' | 'threshold_sp
 
 interface WahooMappingContext {
     headerReferences: Partial<Record<WahooReferenceHeaderKey, number>>;
+    rawHeaderReferences: Partial<Record<WahooReferenceHeaderKey, number>>;
+}
+
+function codePointLength(value: string): number {
+    return Array.from(value).length;
+}
+
+function truncateCodePoints(value: string, maximum: number): string {
+    return Array.from(value).slice(0, maximum).join('');
 }
 
 function assertNonEmpty(value: string, label: string): string {
@@ -120,6 +129,10 @@ function nativeReference(target: WorkoutTargetV1): { key: WahooReferenceHeaderKe
     }
 }
 
+function normalizedNativeReferenceValue(reference: { key: WahooReferenceHeaderKey; value: number }): number {
+    return reference.key === 'threshold_speed' ? reference.value : Math.round(reference.value);
+}
+
 function freezeRelativeTarget(target: Exclude<WorkoutTargetV1, { mode: 'absolute' }>): WahooPlanTargetV1 {
     const scale = (value: number, percent: number): number => value * percent / 100;
     switch (target.kind) {
@@ -170,16 +183,42 @@ function targetToWahoo(target: WorkoutTargetV1, context: WahooMappingContext): W
 
     const reference = nativeReference(target);
     if (reference === null) return freezeRelativeTarget(target);
-    const existingReference = context.headerReferences[reference.key];
+    const existingReference = context.rawHeaderReferences[reference.key];
     if (existingReference !== undefined && existingReference !== reference.value) {
         return freezeRelativeTarget(target);
     }
-    context.headerReferences[reference.key] = reference.value;
+    context.rawHeaderReferences[reference.key] = reference.value;
+    context.headerReferences[reference.key] = normalizedNativeReferenceValue(reference);
     return {
         type: reference.key,
         low: target.minimumPercent / 100,
         high: target.maximumPercent / 100,
     };
+}
+
+function collectReferenceRoundingIssues(
+    structure: WorkoutStructureV1,
+    issues: ProviderSerializationIssueV1[],
+): void {
+    const visit = (step: WorkoutStepV1, path: string): void => {
+        step.targets.forEach((target, targetIndex) => {
+            const reference = nativeReference(target);
+            if (!reference || reference.key === 'threshold_speed' || Number.isInteger(reference.value)) return;
+            issues.push({
+                severity: 'degraded',
+                code: 'relative_reference_rounded',
+                path: `${path}.targets[${targetIndex}].reference`,
+                message: 'Wahoo requires an integer FTP or heart-rate header reference, so this snapshot will be rounded.',
+            });
+        });
+    };
+    structure.nodes.forEach((node, nodeIndex) => {
+        if (node.kind === 'step') {
+            visit(node, `$.nodes[${nodeIndex}]`);
+            return;
+        }
+        node.steps.forEach((step, stepIndex) => visit(step, `$.nodes[${nodeIndex}].steps[${stepIndex}]`));
+    });
 }
 
 function stepToWahoo(step: WorkoutStepV1, context: WahooMappingContext): WahooPlanIntervalV1 {
@@ -215,7 +254,7 @@ export function serializeWahooPlanJsonV1(
     const name = assertNonEmpty(options.name, 'Wahoo plan name');
     const normalizedDescription = options.description?.trim();
     const additionalIssues: ProviderSerializationIssueV1[] = [];
-    if (normalizedDescription && normalizedDescription.length > 5000) {
+    if (normalizedDescription && codePointLength(normalizedDescription) > 5000) {
         additionalIssues.push({
             severity: 'degraded',
             code: 'description_truncated',
@@ -223,6 +262,7 @@ export function serializeWahooPlanJsonV1(
             message: 'Wahoo descriptions are limited to 5000 characters.',
         });
     }
+    collectReferenceRoundingIssues(structure, additionalIssues);
 
     const resolved = resolveProviderSerializationIssuesV1({
         provider: 'wahoo',
@@ -230,7 +270,7 @@ export function serializeWahooPlanJsonV1(
         additionalIssues,
         allowDegraded: options.allowDegraded,
     });
-    const context: WahooMappingContext = { headerReferences: {} };
+    const context: WahooMappingContext = { headerReferences: {}, rawHeaderReferences: {} };
     const intervals = structureToIntervals(structure, context);
     const workoutTypeFamily: 0 | 1 = structure.sport === ActivityTypes.Cycling ? 0 : 1;
     const workoutTypeLocation: 0 | 1 = options.location === 'indoor' ? 0 : 1;
@@ -239,7 +279,7 @@ export function serializeWahooPlanJsonV1(
             name,
             version: '1.0.0',
             ...(normalizedDescription
-                ? { description: normalizedDescription.slice(0, 5000) }
+                ? { description: truncateCodePoints(normalizedDescription, 5000) }
                 : {}),
             workout_type_family: workoutTypeFamily,
             workout_type_location: workoutTypeLocation,

--- a/functions/src/training-plans/providers/wahoo-plan.serializer.ts
+++ b/functions/src/training-plans/providers/wahoo-plan.serializer.ts
@@ -1,0 +1,252 @@
+import { ActivityTypes } from '@sports-alliance/sports-lib';
+import {
+    parseWorkoutStructureV1,
+    type WorkoutEndingV1,
+    type WorkoutStepPurposeV1,
+    type WorkoutStepV1,
+    type WorkoutStructureV1,
+    type WorkoutTargetV1,
+} from '../../../../shared/planned-workout';
+import {
+    resolveProviderSerializationIssuesV1,
+    type ProviderSerializationIssueV1,
+    type ProviderSerializationResultV1,
+} from './provider-mapping';
+
+export type WahooWorkoutLocationV1 = 'indoor' | 'outdoor';
+export type WahooPlanTargetTypeV1 =
+    | 'rpm'
+    | 'watts'
+    | 'hr'
+    | 'speed'
+    | 'ftp'
+    | 'threshold_hr'
+    | 'max_hr'
+    | 'threshold_speed';
+
+export interface WahooPlanTargetV1 {
+    type: WahooPlanTargetTypeV1;
+    low: number;
+    high: number;
+}
+
+export interface WahooPlanIntervalV1 {
+    name?: string;
+    exit_trigger_type: 'time' | 'distance' | 'kj2' | 'repeat';
+    exit_trigger_value: number;
+    intensity_type?: 'active' | 'wu' | 'cd' | 'recover' | 'rest';
+    targets?: WahooPlanTargetV1[];
+    intervals?: WahooPlanIntervalV1[];
+}
+
+export interface WahooPlanJsonV1 {
+    header: {
+        name: string;
+        version: '1.0.0';
+        description?: string;
+        workout_type_family: 0 | 1;
+        workout_type_location: 0 | 1;
+        ftp?: number;
+        threshold_hr?: number;
+        max_hr?: number;
+        threshold_speed?: number;
+    };
+    intervals: WahooPlanIntervalV1[];
+}
+
+export interface SerializeWahooPlanOptionsV1 {
+    name: string;
+    description?: string;
+    location: WahooWorkoutLocationV1;
+    allowDegraded: boolean;
+}
+
+type WahooReferenceHeaderKey = 'ftp' | 'threshold_hr' | 'max_hr' | 'threshold_speed';
+
+interface WahooMappingContext {
+    headerReferences: Partial<Record<WahooReferenceHeaderKey, number>>;
+}
+
+function assertNonEmpty(value: string, label: string): string {
+    const normalized = value.trim();
+    if (normalized.length === 0) throw new Error(`${label} must not be empty.`);
+    return normalized;
+}
+
+function purposeToIntensity(purpose: WorkoutStepPurposeV1): WahooPlanIntervalV1['intensity_type'] {
+    switch (purpose) {
+        case 'warmup': return 'wu';
+        case 'recovery': return 'recover';
+        case 'cooldown': return 'cd';
+        case 'rest': return 'rest';
+        case 'work':
+        case 'other':
+            return 'active';
+    }
+}
+
+function endingToTrigger(ending: WorkoutEndingV1): Pick<
+WahooPlanIntervalV1,
+'exit_trigger_type' | 'exit_trigger_value'
+> {
+    switch (ending.kind) {
+        case 'time':
+            return { exit_trigger_type: 'time', exit_trigger_value: ending.seconds };
+        case 'distance':
+            return { exit_trigger_type: 'distance', exit_trigger_value: ending.meters };
+        case 'kilojoules':
+            return { exit_trigger_type: 'kj2', exit_trigger_value: ending.kilojoules };
+        case 'repetitions':
+        case 'manual':
+            throw new Error(`Unsupported Wahoo ending reached after compatibility validation: ${ending.kind}.`);
+    }
+}
+
+function nativeReference(target: WorkoutTargetV1): { key: WahooReferenceHeaderKey; value: number } | null {
+    if (target.mode !== 'relative') return null;
+    switch (target.kind) {
+        case 'heart-rate':
+            return target.reference.kind === 'max-heart-rate'
+                ? { key: 'max_hr', value: target.reference.bpm }
+                : { key: 'threshold_hr', value: target.reference.bpm };
+        case 'power':
+            return target.reference.kind === 'functional-threshold-power'
+                ? { key: 'ftp', value: target.reference.watts }
+                : null;
+        case 'speed':
+            return { key: 'threshold_speed', value: target.reference.metersPerSecond };
+        case 'cadence':
+            return null;
+    }
+}
+
+function freezeRelativeTarget(target: Exclude<WorkoutTargetV1, { mode: 'absolute' }>): WahooPlanTargetV1 {
+    const scale = (value: number, percent: number): number => value * percent / 100;
+    switch (target.kind) {
+        case 'heart-rate':
+            return {
+                type: 'hr',
+                low: scale(target.reference.bpm, target.minimumPercent),
+                high: scale(target.reference.bpm, target.maximumPercent),
+            };
+        case 'power':
+            return {
+                type: 'watts',
+                low: scale(target.reference.watts, target.minimumPercent),
+                high: scale(target.reference.watts, target.maximumPercent),
+            };
+        case 'speed':
+            return {
+                type: 'speed',
+                low: scale(target.reference.metersPerSecond, target.minimumPercent),
+                high: scale(target.reference.metersPerSecond, target.maximumPercent),
+            };
+        case 'cadence':
+            return {
+                type: 'rpm',
+                low: scale(target.reference.rpm, target.minimumPercent),
+                high: scale(target.reference.rpm, target.maximumPercent),
+            };
+    }
+}
+
+function targetToWahoo(target: WorkoutTargetV1, context: WahooMappingContext): WahooPlanTargetV1 {
+    if (target.mode === 'absolute') {
+        switch (target.kind) {
+            case 'heart-rate':
+                return { type: 'hr', low: target.minimumBpm, high: target.maximumBpm };
+            case 'power':
+                return { type: 'watts', low: target.minimumWatts, high: target.maximumWatts };
+            case 'speed':
+                return {
+                    type: 'speed',
+                    low: target.minimumMetersPerSecond,
+                    high: target.maximumMetersPerSecond,
+                };
+            case 'cadence':
+                return { type: 'rpm', low: target.minimumRpm, high: target.maximumRpm };
+        }
+    }
+
+    const reference = nativeReference(target);
+    if (reference === null) return freezeRelativeTarget(target);
+    const existingReference = context.headerReferences[reference.key];
+    if (existingReference !== undefined && existingReference !== reference.value) {
+        return freezeRelativeTarget(target);
+    }
+    context.headerReferences[reference.key] = reference.value;
+    return {
+        type: reference.key,
+        low: target.minimumPercent / 100,
+        high: target.maximumPercent / 100,
+    };
+}
+
+function stepToWahoo(step: WorkoutStepV1, context: WahooMappingContext): WahooPlanIntervalV1 {
+    const targets = step.targets.map(target => targetToWahoo(target, context));
+    return {
+        ...(step.note ? { name: step.note } : {}),
+        ...endingToTrigger(step.ending),
+        intensity_type: purposeToIntensity(step.purpose),
+        ...(targets.length > 0 ? { targets } : {}),
+    };
+}
+
+function structureToIntervals(
+    structure: WorkoutStructureV1,
+    context: WahooMappingContext,
+): WahooPlanIntervalV1[] {
+    return structure.nodes.map(node => {
+        if (node.kind === 'step') return stepToWahoo(node, context);
+        return {
+            exit_trigger_type: 'repeat',
+            // Wahoo encodes repeats after the first pass; canonical count is total passes.
+            exit_trigger_value: node.count - 1,
+            intervals: node.steps.map(step => stepToWahoo(step, context)),
+        };
+    });
+}
+
+export function serializeWahooPlanJsonV1(
+    structureValue: unknown,
+    options: SerializeWahooPlanOptionsV1,
+): ProviderSerializationResultV1<WahooPlanJsonV1> {
+    const structure = parseWorkoutStructureV1(structureValue);
+    const name = assertNonEmpty(options.name, 'Wahoo plan name');
+    const normalizedDescription = options.description?.trim();
+    const additionalIssues: ProviderSerializationIssueV1[] = [];
+    if (normalizedDescription && normalizedDescription.length > 5000) {
+        additionalIssues.push({
+            severity: 'degraded',
+            code: 'description_truncated',
+            path: '$.header.description',
+            message: 'Wahoo descriptions are limited to 5000 characters.',
+        });
+    }
+
+    const resolved = resolveProviderSerializationIssuesV1({
+        provider: 'wahoo',
+        structure,
+        additionalIssues,
+        allowDegraded: options.allowDegraded,
+    });
+    const context: WahooMappingContext = { headerReferences: {} };
+    const intervals = structureToIntervals(structure, context);
+    const workoutTypeFamily: 0 | 1 = structure.sport === ActivityTypes.Cycling ? 0 : 1;
+    const workoutTypeLocation: 0 | 1 = options.location === 'indoor' ? 0 : 1;
+    const artifact: WahooPlanJsonV1 = {
+        header: {
+            name,
+            version: '1.0.0',
+            ...(normalizedDescription
+                ? { description: normalizedDescription.slice(0, 5000) }
+                : {}),
+            workout_type_family: workoutTypeFamily,
+            workout_type_location: workoutTypeLocation,
+            ...context.headerReferences,
+        },
+        intervals,
+    };
+
+    return { ...resolved, artifact };
+}

--- a/functions/src/training-plans/restore-callable.spec.ts
+++ b/functions/src/training-plans/restore-callable.spec.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+    enforceAppCheck: vi.fn(),
+    restore: vi.fn(),
+    loggerError: vi.fn(),
+}));
+
+vi.mock('firebase-functions/v2/https', () => ({
+    HttpsError: class MockHttpsError extends Error {
+        constructor(public readonly code: string, message: string) { super(message); }
+    },
+    onCall: (_options: unknown, handler: unknown) => handler,
+}));
+vi.mock('firebase-functions/logger', () => ({ error: hoisted.loggerError }));
+vi.mock('../../../shared/functions-manifest', () => ({
+    FUNCTIONS_MANIFEST: { restoreTrainingScheduleRevision: { region: 'europe-west2' } },
+}));
+vi.mock('../utils', () => ({ enforceAppCheck: hoisted.enforceAppCheck }));
+vi.mock('./restore', async () => {
+    const actual = await vi.importActual<typeof import('./restore')>('./restore');
+    return { ...actual, restoreTrainingScheduleRevisionForUser: hoisted.restore };
+});
+
+import { TrainingScheduleMutationError } from './mutation';
+import { restoreTrainingScheduleRevision } from './restore-callable';
+
+const DATA = {
+    mutationId: 'restore-1',
+    scope: { kind: 'plan', id: 'plan-1' },
+    targetRevision: 2,
+    expectedRevisions: [
+        { scope: 'state', id: 'current', revision: 3 },
+        { scope: 'plan', id: 'plan-1', revision: 4 },
+    ],
+};
+
+describe('restoreTrainingScheduleRevision callable', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        hoisted.restore.mockResolvedValue({ skippedWorkoutIds: [] });
+    });
+
+    it('requires auth and App Check', async () => {
+        await expect((restoreTrainingScheduleRevision as never as (request: unknown) => Promise<unknown>)({ data: DATA }))
+            .rejects.toMatchObject({ code: 'unauthenticated' });
+        expect(hoisted.enforceAppCheck).not.toHaveBeenCalled();
+
+        hoisted.enforceAppCheck.mockImplementationOnce(() => { throw new Error('App Check failed.'); });
+        await expect((restoreTrainingScheduleRevision as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'owner' }, data: DATA,
+        })).rejects.toThrow('App Check failed');
+    });
+
+    it('derives the owner from auth and passes only validated input', async () => {
+        await (restoreTrainingScheduleRevision as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'owner' }, app: {}, data: DATA,
+        });
+        expect(hoisted.restore).toHaveBeenCalledWith('owner', DATA);
+    });
+
+    it('rejects unknown fields before persistence', async () => {
+        await expect((restoreTrainingScheduleRevision as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'owner' }, app: {}, data: { ...DATA, uid: 'other' },
+        })).rejects.toMatchObject({ code: 'invalid-argument' });
+        expect(hoisted.restore).not.toHaveBeenCalled();
+    });
+
+    it('maps revision conflicts to aborted', async () => {
+        hoisted.restore.mockRejectedValueOnce(new TrainingScheduleMutationError('revision-conflict', 'Changed.'));
+        await expect((restoreTrainingScheduleRevision as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'owner' }, app: {}, data: DATA,
+        })).rejects.toMatchObject({ code: 'aborted', message: 'Changed.' });
+    });
+
+    it('redacts unexpected persistence failures', async () => {
+        hoisted.restore.mockRejectedValueOnce(new Error('private document path'));
+        await expect((restoreTrainingScheduleRevision as never as (request: unknown) => Promise<unknown>)({
+            auth: { uid: 'owner' }, app: {}, data: DATA,
+        })).rejects.toMatchObject({
+            code: 'internal', message: 'Unable to restore this training schedule revision.',
+        });
+        expect(hoisted.loggerError).toHaveBeenCalledWith(
+            '[TrainingPlans] Revision restore failed.', { errorName: 'Error' },
+        );
+    });
+});

--- a/functions/src/training-plans/restore-callable.ts
+++ b/functions/src/training-plans/restore-callable.ts
@@ -1,0 +1,49 @@
+import * as logger from 'firebase-functions/logger';
+import { HttpsError, onCall } from 'firebase-functions/v2/https';
+import { FUNCTIONS_MANIFEST } from '../../../shared/functions-manifest';
+import { TrainingPlanContractError } from '../../../shared/training-plans';
+import { enforceAppCheck } from '../utils';
+import { TrainingScheduleMutationError } from './mutation';
+import {
+    parseRestoreTrainingScheduleRevisionRequest,
+    restoreTrainingScheduleRevisionForUser,
+} from './restore';
+
+function mapRestoreError(error: TrainingScheduleMutationError): HttpsError {
+    switch (error.code) {
+        case 'not-found':
+            return new HttpsError('not-found', error.message);
+        case 'revision-conflict':
+            return new HttpsError('aborted', error.message);
+        case 'limit-exceeded':
+            return new HttpsError('resource-exhausted', error.message);
+        case 'already-exists':
+            return new HttpsError('already-exists', error.message);
+        case 'range-extension-required':
+        case 'failed-precondition':
+            return new HttpsError('failed-precondition', error.message);
+    }
+}
+
+export const restoreTrainingScheduleRevision = onCall({
+    region: FUNCTIONS_MANIFEST.restoreTrainingScheduleRevision.region,
+}, async (request) => {
+    if (!request.auth) throw new HttpsError('unauthenticated', 'The function must be called while authenticated.');
+    enforceAppCheck(request);
+    try {
+        return await restoreTrainingScheduleRevisionForUser(
+            request.auth.uid,
+            parseRestoreTrainingScheduleRevisionRequest(request.data),
+        );
+    } catch (error) {
+        if (error instanceof TrainingPlanContractError) {
+            throw new HttpsError('invalid-argument', error.message);
+        }
+        if (error instanceof TrainingScheduleMutationError) throw mapRestoreError(error);
+        if (error instanceof HttpsError) throw error;
+        logger.error('[TrainingPlans] Revision restore failed.', {
+            errorName: error instanceof Error ? error.name : 'UnknownError',
+        });
+        throw new HttpsError('internal', 'Unable to restore this training schedule revision.');
+    }
+});

--- a/functions/src/training-plans/restore.persistence.spec.ts
+++ b/functions/src/training-plans/restore.persistence.spec.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+    RestoreTrainingScheduleRevisionRequestV1,
+    RestoreTrainingScheduleRevisionResponseV1,
+} from '../../../shared/training-plans';
+
+const dependencies = vi.hoisted(() => ({
+    guard: vi.fn(),
+    readPlanSnapshotAtRevision: vi.fn(),
+    readStandaloneWorkoutAtRevision: vi.fn(),
+}));
+
+vi.mock('../shared/user-deletion-guard', () => ({
+    getUserDeletionGuardStateInTransaction: dependencies.guard,
+}));
+
+vi.mock('./history', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('./history')>();
+    return {
+        ...actual,
+        readPlanSnapshotAtRevision: dependencies.readPlanSnapshotAtRevision,
+        readStandaloneWorkoutAtRevision: dependencies.readStandaloneWorkoutAtRevision,
+    };
+});
+
+import { hashTrainingScheduleRequestPayload } from './persistence';
+import { restoreTrainingScheduleRevisionForUser } from './restore';
+
+type Stored = Record<string, unknown>;
+
+class FakeSnapshot {
+    constructor(private readonly stored: Stored | undefined) {}
+    get exists(): boolean { return this.stored !== undefined; }
+    data(): Stored | undefined {
+        return this.stored === undefined
+            ? undefined
+            : JSON.parse(JSON.stringify(this.stored)) as Stored;
+    }
+}
+
+class FakeDocumentReference {
+    constructor(readonly db: FakeFirestore, readonly path: string) {}
+    collection(id: string): FakeCollectionReference {
+        return new FakeCollectionReference(this.db, `${this.path}/${id}`);
+    }
+}
+
+class FakeCollectionReference {
+    constructor(readonly db: FakeFirestore, readonly path: string) {}
+    doc(id: string): FakeDocumentReference {
+        return new FakeDocumentReference(this.db, `${this.path}/${id}`);
+    }
+}
+
+class FakeTransaction {
+    constructor(private readonly db: FakeFirestore) {}
+    async get(ref: FakeDocumentReference): Promise<FakeSnapshot> {
+        return new FakeSnapshot(this.db.documents.get(ref.path));
+    }
+}
+
+class FakeFirestore {
+    readonly documents = new Map<string, Stored>();
+    readonly runTransaction = vi.fn(async <T>(handler: (transaction: FakeTransaction) => Promise<T>): Promise<T> => (
+        handler(new FakeTransaction(this))
+    ));
+
+    collection(id: string): FakeCollectionReference {
+        return new FakeCollectionReference(this, id);
+    }
+}
+
+const REQUEST: RestoreTrainingScheduleRevisionRequestV1 = {
+    mutationId: 'restore-plan-retry',
+    expectedRevisions: [
+        { scope: 'state', id: 'current', revision: 8 },
+        { scope: 'plan', id: 'plan-1', revision: 4 },
+    ],
+    scope: { kind: 'plan', id: 'plan-1' },
+    targetRevision: 2,
+};
+
+const RESPONSE: RestoreTrainingScheduleRevisionResponseV1 = {
+    mutation: {
+        mutationId: REQUEST.mutationId,
+        state: {
+            schemaVersion: 1,
+            activePlanId: null,
+            revision: 9,
+            currentWorkoutCount: 0,
+            updatedAtMs: 10,
+        },
+        plans: [],
+        workouts: [],
+        removedPlanIds: [],
+        permanentlyDeletedWorkoutIds: [],
+    },
+    skippedWorkoutIds: [],
+};
+
+describe('restoreTrainingScheduleRevisionForUser receipt preflight', () => {
+    beforeEach(() => {
+        dependencies.guard.mockReset().mockResolvedValue({ shouldSkip: false });
+        dependencies.readPlanSnapshotAtRevision.mockReset();
+        dependencies.readStandaloneWorkoutAtRevision.mockReset();
+    });
+
+    it('returns a completed retry before reading history that may already be gone', async () => {
+        const db = new FakeFirestore();
+        db.documents.set(
+            `users/user-1/trainingPlanState/current/mutationReceipts/${REQUEST.mutationId}`,
+            {
+                schemaVersion: 1,
+                requestHash: hashTrainingScheduleRequestPayload(REQUEST),
+                response: RESPONSE,
+                createdAtMs: 10,
+            },
+        );
+        dependencies.readPlanSnapshotAtRevision.mockRejectedValue(new Error('History was deleted.'));
+
+        await expect(restoreTrainingScheduleRevisionForUser('user-1', REQUEST, {
+            db: db as never,
+            nowMs: 20,
+        })).resolves.toEqual(RESPONSE);
+        expect(dependencies.readPlanSnapshotAtRevision).not.toHaveBeenCalled();
+        expect(dependencies.readStandaloneWorkoutAtRevision).not.toHaveBeenCalled();
+        expect(db.runTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects mutation-ID reuse before reading the requested history', async () => {
+        const db = new FakeFirestore();
+        db.documents.set(
+            `users/user-1/trainingPlanState/current/mutationReceipts/${REQUEST.mutationId}`,
+            { requestHash: 'different-request', response: RESPONSE },
+        );
+
+        await expect(restoreTrainingScheduleRevisionForUser('user-1', REQUEST, {
+            db: db as never,
+            nowMs: 20,
+        })).rejects.toMatchObject({ code: 'failed-precondition' });
+        expect(dependencies.readPlanSnapshotAtRevision).not.toHaveBeenCalled();
+    });
+});

--- a/functions/src/training-plans/restore.spec.ts
+++ b/functions/src/training-plans/restore.spec.ts
@@ -1,0 +1,293 @@
+import { ActivityTypes } from '@sports-alliance/sports-lib';
+import { describe, expect, it } from 'vitest';
+import {
+    TRAINING_PLAN_MAX_CURRENT_WORKOUTS,
+    type RestoreTrainingScheduleRevisionRequestV1,
+    type ScheduledWorkoutV1,
+    type TrainingPlanV1,
+} from '../../../shared/training-plans';
+import type { ReconstructedTrainingPlanRevisionV1 } from './history';
+import { createEmptyTrainingPlanState, type TrainingScheduleSnapshotV1 } from './mutation';
+import {
+    applyPlanRevisionRestore,
+    applyStandaloneRevisionRestore,
+    parseRestoreTrainingScheduleRevisionRequest,
+} from './restore';
+
+const NOW_MS = Date.UTC(2026, 8, 2, 12);
+const STRUCTURE = {
+    version: 1 as const,
+    sport: ActivityTypes.Running,
+    nodes: [{
+        kind: 'step' as const,
+        id: 'steady',
+        purpose: 'work' as const,
+        ending: { kind: 'time' as const, seconds: 1800 },
+        targets: [],
+    }],
+};
+
+function plan(overrides: Partial<TrainingPlanV1> = {}): TrainingPlanV1 {
+    return {
+        schemaVersion: 1,
+        id: 'plan-1',
+        name: 'Current plan',
+        lifecycle: 'paused',
+        startLocalDate: '2026-09-01',
+        endLocalDate: '2026-09-30',
+        revision: 4,
+        lastCheckpointRevision: 1,
+        workoutCount: 1,
+        createdAtMs: 1,
+        updatedAtMs: 4,
+        ...overrides,
+    };
+}
+
+function workout(overrides: Partial<ScheduledWorkoutV1> = {}): ScheduledWorkoutV1 {
+    return {
+        schemaVersion: 1,
+        id: 'workout-1',
+        planId: 'plan-1',
+        localDate: '2026-09-02',
+        lifecycle: 'planned',
+        title: 'Current workout',
+        structure: STRUCTURE,
+        revision: 3,
+        createdAtMs: 1,
+        updatedAtMs: 3,
+        ...overrides,
+    };
+}
+
+function snapshot(
+    plans: TrainingPlanV1[],
+    workouts: ScheduledWorkoutV1[],
+    activePlanId: string | null = null,
+): TrainingScheduleSnapshotV1 {
+    return {
+        state: {
+            ...createEmptyTrainingPlanState(0),
+            activePlanId,
+            revision: 9,
+            currentWorkoutCount: workouts.filter(item => item.lifecycle !== 'deleted').length,
+        },
+        plans: new Map(plans.map(item => [item.id, item])),
+        workouts: new Map(workouts.map(item => [item.id, item])),
+    };
+}
+
+function planRequest(
+    expectedRevisions: RestoreTrainingScheduleRevisionRequestV1['expectedRevisions'] = [
+        { scope: 'state', id: 'current', revision: 9 },
+        { scope: 'plan', id: 'plan-1', revision: 4 },
+    ],
+): RestoreTrainingScheduleRevisionRequestV1 {
+    return {
+        mutationId: 'restore-plan-1',
+        expectedRevisions,
+        scope: { kind: 'plan', id: 'plan-1' },
+        targetRevision: 2,
+    };
+}
+
+describe('parseRestoreTrainingScheduleRevisionRequest', () => {
+    it('strictly parses a revision-checked restore request', () => {
+        expect(parseRestoreTrainingScheduleRevisionRequest(planRequest())).toEqual(planRequest());
+    });
+
+    it('rejects unknown fields and duplicate revision checks', () => {
+        expect(() => parseRestoreTrainingScheduleRevisionRequest({ ...planRequest(), uid: 'other' }))
+            .toThrow('Unknown field');
+        expect(() => parseRestoreTrainingScheduleRevisionRequest({
+            ...planRequest(),
+            expectedRevisions: [
+                { scope: 'state', id: 'current', revision: 9 },
+                { scope: 'state', id: 'current', revision: 9 },
+            ],
+        })).toThrow('Duplicate revision check');
+        expect(() => parseRestoreTrainingScheduleRevisionRequest({
+            ...planRequest(),
+            expectedRevisions: [
+                { scope: 'state', id: 'current', revision: 9, uid: 'other-user' },
+            ],
+        })).toThrow('Unknown field');
+    });
+});
+
+describe('applyPlanRevisionRestore', () => {
+    it('creates a new checkpoint revision and restores same-plan workout state', () => {
+        const currentPlan = plan();
+        const currentWorkout = workout();
+        const desiredWorkout = workout({ title: 'Earlier workout', revision: 1, updatedAtMs: 1 });
+        const desired: ReconstructedTrainingPlanRevisionV1 = {
+            plan: plan({ name: 'Earlier plan', revision: 2, lastCheckpointRevision: 1, updatedAtMs: 2 }),
+            workouts: new Map([[desiredWorkout.id, desiredWorkout]]),
+        };
+
+        const result = applyPlanRevisionRestore(
+            snapshot([currentPlan], [currentWorkout]), desired, planRequest(), NOW_MS,
+        );
+
+        expect(result.applied.after.plans.get('plan-1')).toMatchObject({
+            name: 'Earlier plan', revision: 5, lastCheckpointRevision: 5, workoutCount: 1,
+        });
+        expect(result.applied.after.workouts.get('workout-1')).toMatchObject({
+            title: 'Earlier workout', revision: 4, updatedAtMs: NOW_MS,
+        });
+        expect(result.applied.after.state.revision).toBe(10);
+        expect(result.applied.bulkOperation).toBe(true);
+        expect(result.response.skippedWorkoutIds).toEqual([]);
+    });
+
+    it('skips a desired workout that moved to another scope and deletes same-plan extras recoverably', () => {
+        const currentPlan = plan({ workoutCount: 1 });
+        const moved = workout({ planId: null, title: 'Now standalone' });
+        const extra = workout({ id: 'extra', title: 'Newer extra' });
+        const desired: ReconstructedTrainingPlanRevisionV1 = {
+            plan: plan({ revision: 2, lastCheckpointRevision: 1 }),
+            workouts: new Map([[moved.id, workout({ revision: 1, title: 'Old plan copy' })]]),
+        };
+
+        const result = applyPlanRevisionRestore(
+            snapshot([currentPlan], [moved, extra]), desired, planRequest(), NOW_MS,
+        );
+
+        expect(result.response.skippedWorkoutIds).toEqual(['workout-1']);
+        expect(result.applied.after.workouts.get('workout-1')).toEqual(moved);
+        expect(result.applied.after.workouts.get('extra')).toMatchObject({
+            lifecycle: 'deleted', revision: 4, deletedAtMs: NOW_MS,
+        });
+        expect(result.applied.after.state.currentWorkoutCount).toBe(1);
+        expect(result.applied.after.plans.get('plan-1')?.workoutCount).toBe(0);
+    });
+
+    it('does not recreate a workout that was permanently deleted after the target revision', () => {
+        const desiredWorkout = workout({ revision: 1, title: 'Deleted forever' });
+        const desired: ReconstructedTrainingPlanRevisionV1 = {
+            plan: plan({ revision: 2, lastCheckpointRevision: 1 }),
+            workouts: new Map([[desiredWorkout.id, desiredWorkout]]),
+        };
+
+        const result = applyPlanRevisionRestore(
+            snapshot([plan({ workoutCount: 0 })], []), desired, planRequest(), NOW_MS,
+        );
+
+        expect(result.response.skippedWorkoutIds).toEqual(['workout-1']);
+        expect(result.applied.after.workouts.has('workout-1')).toBe(false);
+        expect(result.applied.after.plans.get('plan-1')?.workoutCount).toBe(0);
+    });
+
+    it('atomically pauses the previous active plan when restoring an active lifecycle', () => {
+        const currentPlan = plan();
+        const previousActive = plan({ id: 'plan-2', name: 'Active plan', lifecycle: 'active', revision: 7 });
+        const desired: ReconstructedTrainingPlanRevisionV1 = {
+            plan: plan({ lifecycle: 'active', revision: 2, lastCheckpointRevision: 1 }),
+            workouts: new Map(),
+        };
+        const expected = [
+            { scope: 'state' as const, id: 'current', revision: 9 },
+            { scope: 'plan' as const, id: 'plan-1', revision: 4 },
+            { scope: 'plan' as const, id: 'plan-2', revision: 7 },
+        ];
+
+        const result = applyPlanRevisionRestore(
+            snapshot([currentPlan, previousActive], [], 'plan-2'), desired, planRequest(expected), NOW_MS,
+        );
+
+        expect(result.applied.after.state.activePlanId).toBe('plan-1');
+        expect(result.applied.after.plans.get('plan-2')).toMatchObject({
+            lifecycle: 'paused', revision: 8, lastCheckpointRevision: 8,
+        });
+        expect(result.applied.affectedPlanIds).toEqual(['plan-1', 'plan-2']);
+    });
+
+    it('requires matching current state and plan revisions', () => {
+        const desired: ReconstructedTrainingPlanRevisionV1 = {
+            plan: plan({ revision: 2, lastCheckpointRevision: 1 }),
+            workouts: new Map(),
+        };
+        expect(() => applyPlanRevisionRestore(
+            snapshot([plan()], []), desired, planRequest([
+                { scope: 'state', id: 'current', revision: 8 },
+                { scope: 'plan', id: 'plan-1', revision: 4 },
+            ]), NOW_MS,
+        )).toThrow(expect.objectContaining({ code: 'revision-conflict' }));
+    });
+
+    it('does not restore a plan beyond the account current-workout limit', () => {
+        const standalone = Array.from({ length: TRAINING_PLAN_MAX_CURRENT_WORKOUTS }, (_, index) => workout({
+            id: `standalone-${index}`,
+            planId: null,
+        }));
+        const desiredWorkout = workout({ id: 'restored-plan-workout', revision: 1 });
+        const recoverablyDeleted = workout({
+            id: desiredWorkout.id,
+            lifecycle: 'deleted',
+            deletedAtMs: 5,
+        });
+        const desired: ReconstructedTrainingPlanRevisionV1 = {
+            plan: plan({ workoutCount: 1, revision: 2, lastCheckpointRevision: 1 }),
+            workouts: new Map([[desiredWorkout.id, desiredWorkout]]),
+        };
+
+        expect(() => applyPlanRevisionRestore(
+            snapshot([plan({ workoutCount: 0 })], [recoverablyDeleted, ...standalone]),
+            desired,
+            planRequest(),
+            NOW_MS,
+        )).toThrow(expect.objectContaining({ code: 'limit-exceeded' }));
+    });
+});
+
+describe('applyStandaloneRevisionRestore', () => {
+    function standaloneRequest(): RestoreTrainingScheduleRevisionRequestV1 {
+        return {
+            mutationId: 'restore-workout-1',
+            expectedRevisions: [
+                { scope: 'state', id: 'current', revision: 9 },
+                { scope: 'workout', id: 'workout-1', revision: 3 },
+            ],
+            scope: { kind: 'workout', id: 'workout-1' },
+            targetRevision: 1,
+        };
+    }
+
+    it('restores a standalone snapshot as a new workout revision', () => {
+        const current = workout({ planId: null });
+        const desired = workout({ planId: null, title: 'Earlier title', revision: 1, updatedAtMs: 1 });
+        const result = applyStandaloneRevisionRestore(
+            snapshot([], [current]), desired, standaloneRequest(), NOW_MS,
+        );
+
+        expect(result.applied.after.workouts.get(current.id)).toMatchObject({
+            planId: null, title: 'Earlier title', revision: 4, updatedAtMs: NOW_MS,
+        });
+        expect(result.applied.after.state.revision).toBe(10);
+        expect(result.response.skippedWorkoutIds).toEqual([]);
+    });
+
+    it('does not reclaim a workout that is now plan-bound', () => {
+        const current = workout({ planId: 'plan-1' });
+        const desired = workout({ planId: null, revision: 1 });
+        expect(() => applyStandaloneRevisionRestore(
+            snapshot([plan()], [current]), desired, standaloneRequest(), NOW_MS,
+        )).toThrow('cannot be reclaimed');
+    });
+
+    it('does not resurrect a standalone workout beyond the account limit', () => {
+        const deleted = workout({ planId: null, lifecycle: 'deleted', deletedAtMs: 5 });
+        const current = Array.from({ length: TRAINING_PLAN_MAX_CURRENT_WORKOUTS }, (_, index) => workout({
+            id: `standalone-${index}`,
+            planId: null,
+        }));
+        const desired = workout({ planId: null, revision: 1 });
+
+        expect(() => applyStandaloneRevisionRestore(
+            snapshot([], [deleted, ...current]),
+            desired,
+            standaloneRequest(),
+            NOW_MS,
+        )).toThrow(expect.objectContaining({ code: 'limit-exceeded' }));
+    });
+});

--- a/functions/src/training-plans/restore.ts
+++ b/functions/src/training-plans/restore.ts
@@ -1,0 +1,475 @@
+import * as admin from 'firebase-admin';
+import { Timestamp } from 'firebase-admin/firestore';
+import {
+    SCHEDULED_WORKOUTS_COLLECTION_ID,
+    TRAINING_PLAN_MUTATION_RECEIPTS_COLLECTION_ID,
+    TRAINING_PLAN_REVISIONS_COLLECTION_ID,
+    TRAINING_PLAN_SCHEMA_VERSION,
+    TRAINING_PLAN_MAX_CURRENT_WORKOUTS,
+    TRAINING_PLANS_COLLECTION_ID,
+    TrainingPlanContractError,
+    normalizeTrainingScheduleMutationId,
+    parseScheduledWorkoutV1,
+    parseTrainingPlanStateV1,
+    parseTrainingPlanV1,
+    type ExpectedTrainingScheduleRevision,
+    type MutateTrainingScheduleResponseV1,
+    type RestoreTrainingScheduleRevisionRequestV1,
+    type RestoreTrainingScheduleRevisionResponseV1,
+    type ScheduledWorkoutV1,
+    type TrainingPlanV1,
+} from '../../../shared/training-plans';
+import { getUserDeletionGuardStateInTransaction } from '../shared/user-deletion-guard';
+import {
+    parsePreviewTrainingScheduleRestoreRequest,
+    readPlanSnapshotAtRevision,
+    readStandaloneWorkoutAtRevision,
+    type ReconstructedTrainingPlanRevisionV1,
+} from './history';
+import {
+    TrainingScheduleMutationError,
+    cloneTrainingScheduleSnapshot,
+    type AppliedTrainingScheduleMutationV1,
+    type TrainingScheduleSnapshotV1,
+} from './mutation';
+import {
+    TRAINING_PLAN_REVISION_CHUNKS_COLLECTION_ID,
+    buildTrainingScheduleRevisionWrites,
+    hashTrainingScheduleRequestPayload,
+    trainingPlanRevisionChunkDocumentId,
+    trainingScheduleRevisionDocumentId,
+} from './persistence';
+import { assertNoTrainingPlanDeletionInProgress } from './deletion-lock';
+
+const RESTORE_RECEIPT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+interface AppliedTrainingScheduleRestoreV1 {
+    applied: AppliedTrainingScheduleMutationV1;
+    response: RestoreTrainingScheduleRevisionResponseV1;
+}
+
+function asRecord(value: unknown, path: string): Record<string, unknown> {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new TrainingPlanContractError(path, 'Expected an object.');
+    }
+    return value as Record<string, unknown>;
+}
+
+function parseExpectedRevisions(value: unknown): ExpectedTrainingScheduleRevision[] {
+    if (!Array.isArray(value) || value.length > 4) {
+        throw new TrainingPlanContractError('$.expectedRevisions', 'Expected at most four revision checks.');
+    }
+    const seen = new Set<string>();
+    return value.map((entry, index) => {
+        const record = asRecord(entry, `$.expectedRevisions[${index}]`);
+        const unknown = Object.keys(record).find(field => !['scope', 'id', 'revision'].includes(field));
+        if (unknown) {
+            throw new TrainingPlanContractError(`$.expectedRevisions[${index}].${unknown}`, 'Unknown field.');
+        }
+        const scope = record.scope;
+        if (scope !== 'state' && scope !== 'plan' && scope !== 'workout') {
+            throw new TrainingPlanContractError(`$.expectedRevisions[${index}].scope`, 'Invalid revision scope.');
+        }
+        const id = record.id;
+        if (typeof id !== 'string' || (scope === 'state' ? id !== 'current' : !/^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/.test(id))) {
+            throw new TrainingPlanContractError(`$.expectedRevisions[${index}].id`, 'Invalid revision ID.');
+        }
+        if (!Number.isSafeInteger(record.revision) || (record.revision as number) < 0) {
+            throw new TrainingPlanContractError(`$.expectedRevisions[${index}].revision`, 'Invalid revision.');
+        }
+        const key = `${scope}:${id}`;
+        if (seen.has(key)) throw new TrainingPlanContractError(`$.expectedRevisions[${index}]`, 'Duplicate revision check.');
+        seen.add(key);
+        return { scope, id, revision: record.revision as number };
+    });
+}
+
+export function parseRestoreTrainingScheduleRevisionRequest(
+    value: unknown,
+): RestoreTrainingScheduleRevisionRequestV1 {
+    const record = asRecord(value, '$');
+    const unknown = Object.keys(record).find(field => ![
+        'mutationId', 'expectedRevisions', 'scope', 'targetRevision',
+    ].includes(field));
+    if (unknown) throw new TrainingPlanContractError(`$.${unknown}`, 'Unknown field.');
+    const preview = parsePreviewTrainingScheduleRestoreRequest({
+        scope: record.scope,
+        targetRevision: record.targetRevision,
+    });
+    return {
+        ...preview,
+        mutationId: normalizeTrainingScheduleMutationId(record.mutationId),
+        expectedRevisions: parseExpectedRevisions(record.expectedRevisions),
+    };
+}
+
+function expectedMap(expected: ExpectedTrainingScheduleRevision[]): Map<string, number> {
+    return new Map(expected.map(item => [`${item.scope}:${item.id}`, item.revision]));
+}
+
+function requireRevision(
+    expected: Map<string, number>,
+    scope: ExpectedTrainingScheduleRevision['scope'],
+    id: string,
+    actual: number,
+): void {
+    const key = `${scope}:${id}`;
+    if (!expected.has(key) || expected.get(key) !== actual) {
+        throw new TrainingScheduleMutationError('revision-conflict', `${scope} ${id} changed before the restore could be applied.`);
+    }
+}
+
+function logicalWorkoutValue(workout: ScheduledWorkoutV1 | null | undefined): unknown {
+    if (!workout) return null;
+    return {
+        planId: workout.planId,
+        localDate: workout.localDate,
+        lifecycle: workout.lifecycle,
+        title: workout.title,
+        structure: workout.structure,
+    };
+}
+
+function logicalValuesEqual(left: ScheduledWorkoutV1 | null | undefined, right: ScheduledWorkoutV1 | null | undefined): boolean {
+    return JSON.stringify(logicalWorkoutValue(left)) === JSON.stringify(logicalWorkoutValue(right));
+}
+
+function currentWorkoutCount(workouts: Map<string, ScheduledWorkoutV1>): number {
+    return [...workouts.values()].filter(workout => workout.lifecycle !== 'deleted').length;
+}
+
+function planWorkoutCount(workouts: Map<string, ScheduledWorkoutV1>, planId: string): number {
+    return [...workouts.values()].filter(workout => workout.planId === planId && workout.lifecycle !== 'deleted').length;
+}
+
+function responseForApplied(
+    request: RestoreTrainingScheduleRevisionRequestV1,
+    after: TrainingScheduleSnapshotV1,
+    affectedPlanIds: string[],
+    changedWorkoutIds: string[],
+    includeWorkoutSnapshots: boolean,
+): MutateTrainingScheduleResponseV1 {
+    return {
+        mutationId: request.mutationId,
+        state: after.state,
+        plans: affectedPlanIds.map(planId => after.plans.get(planId)!).filter(Boolean),
+        workouts: includeWorkoutSnapshots
+            ? changedWorkoutIds.map(workoutId => after.workouts.get(workoutId)!).filter(Boolean)
+            : [],
+        removedPlanIds: [],
+        permanentlyDeletedWorkoutIds: [],
+    };
+}
+
+export function applyPlanRevisionRestore(
+    snapshot: TrainingScheduleSnapshotV1,
+    desired: ReconstructedTrainingPlanRevisionV1,
+    request: RestoreTrainingScheduleRevisionRequestV1,
+    nowMs: number,
+): AppliedTrainingScheduleRestoreV1 {
+    if (request.scope.kind !== 'plan' || desired.plan.id !== request.scope.id) {
+        throw new TrainingScheduleMutationError('failed-precondition', 'The requested plan revision does not match its scope.');
+    }
+    const before = cloneTrainingScheduleSnapshot(snapshot);
+    const after = cloneTrainingScheduleSnapshot(snapshot);
+    const expected = expectedMap(request.expectedRevisions);
+    const currentPlan = after.plans.get(request.scope.id);
+    if (!currentPlan) throw new TrainingScheduleMutationError('not-found', 'The current training plan was not found.');
+    requireRevision(expected, 'state', 'current', before.state.revision);
+    requireRevision(expected, 'plan', currentPlan.id, currentPlan.revision);
+
+    const affectedPlanIds = new Set<string>([currentPlan.id]);
+    const changedWorkoutIds = new Set<string>();
+    const skippedWorkoutIds = new Set<string>();
+    const desiredLifecycle = desired.plan.lifecycle;
+    if (desiredLifecycle === 'active') {
+        const previousActiveId = after.state.activePlanId;
+        if (previousActiveId && previousActiveId !== currentPlan.id) {
+            const previousActive = after.plans.get(previousActiveId);
+            if (!previousActive) throw new TrainingScheduleMutationError('failed-precondition', 'The active plan is unavailable.');
+            requireRevision(expected, 'plan', previousActiveId, previousActive.revision);
+            previousActive.lifecycle = 'paused';
+            previousActive.revision += 1;
+            previousActive.lastCheckpointRevision = previousActive.revision;
+            previousActive.updatedAtMs = nowMs;
+            affectedPlanIds.add(previousActiveId);
+        }
+        after.state.activePlanId = currentPlan.id;
+    } else if (after.state.activePlanId === currentPlan.id) {
+        after.state.activePlanId = null;
+    }
+
+    desired.workouts.forEach((desiredWorkout, workoutId) => {
+        const current = after.workouts.get(workoutId);
+        // A recoverably deleted workout still has a current document and can
+        // be restored. A missing document has been permanently deleted, so an
+        // older plan checkpoint must never recreate it.
+        if (!current) {
+            skippedWorkoutIds.add(workoutId);
+            return;
+        }
+        if (current && current.planId !== currentPlan.id) {
+            skippedWorkoutIds.add(workoutId);
+            return;
+        }
+        const restored: ScheduledWorkoutV1 = parseScheduledWorkoutV1({
+            ...desiredWorkout,
+            planId: currentPlan.id,
+            revision: current.revision + 1,
+            createdAtMs: current.createdAtMs,
+            updatedAtMs: nowMs,
+        });
+        if (!logicalValuesEqual(current, restored)) {
+            after.workouts.set(workoutId, restored);
+            changedWorkoutIds.add(workoutId);
+        }
+    });
+
+    for (const current of [...after.workouts.values()]) {
+        if (
+            current.planId !== currentPlan.id
+            || current.lifecycle === 'deleted'
+            || desired.workouts.has(current.id)
+        ) continue;
+        after.workouts.set(current.id, parseScheduledWorkoutV1({
+            ...current,
+            lifecycle: 'deleted',
+            revision: current.revision + 1,
+            updatedAtMs: nowMs,
+            deletedAtMs: nowMs,
+        }));
+        changedWorkoutIds.add(current.id);
+    }
+
+    after.plans.set(currentPlan.id, parseTrainingPlanV1({
+        ...desired.plan,
+        id: currentPlan.id,
+        revision: currentPlan.revision + 1,
+        lastCheckpointRevision: currentPlan.revision + 1,
+        workoutCount: planWorkoutCount(after.workouts, currentPlan.id),
+        createdAtMs: currentPlan.createdAtMs,
+        updatedAtMs: nowMs,
+    }));
+    const restoredCurrentWorkoutCount = currentWorkoutCount(after.workouts);
+    if (restoredCurrentWorkoutCount > TRAINING_PLAN_MAX_CURRENT_WORKOUTS) {
+        throw new TrainingScheduleMutationError(
+            'limit-exceeded',
+            `A restore may not exceed ${TRAINING_PLAN_MAX_CURRENT_WORKOUTS} current workouts.`,
+        );
+    }
+    after.state = parseTrainingPlanStateV1({
+        ...after.state,
+        revision: before.state.revision + 1,
+        currentWorkoutCount: restoredCurrentWorkoutCount,
+        updatedAtMs: nowMs,
+    });
+
+    const affected = [...affectedPlanIds];
+    const changed = [...changedWorkoutIds];
+    const mutation = responseForApplied(request, after, affected, changed, false);
+    const applied: AppliedTrainingScheduleMutationV1 = {
+        response: mutation,
+        before,
+        after,
+        affectedPlanIds: affected,
+        changedWorkoutIds: changed,
+        permanentlyDeletedWorkoutIds: [],
+        bulkOperation: true,
+    };
+    return {
+        applied,
+        response: { mutation, skippedWorkoutIds: [...skippedWorkoutIds].sort() },
+    };
+}
+
+export function applyStandaloneRevisionRestore(
+    snapshot: TrainingScheduleSnapshotV1,
+    desired: ScheduledWorkoutV1,
+    request: RestoreTrainingScheduleRevisionRequestV1,
+    nowMs: number,
+): AppliedTrainingScheduleRestoreV1 {
+    if (request.scope.kind !== 'workout' || desired.id !== request.scope.id || desired.planId !== null) {
+        throw new TrainingScheduleMutationError('failed-precondition', 'The requested revision is not a standalone workout state.');
+    }
+    const before = cloneTrainingScheduleSnapshot(snapshot);
+    const after = cloneTrainingScheduleSnapshot(snapshot);
+    const expected = expectedMap(request.expectedRevisions);
+    const current = after.workouts.get(request.scope.id);
+    if (!current) throw new TrainingScheduleMutationError('not-found', 'The current scheduled workout was not found.');
+    requireRevision(expected, 'state', 'current', before.state.revision);
+    requireRevision(expected, 'workout', current.id, current.revision);
+    if (current.planId !== null) {
+        throw new TrainingScheduleMutationError(
+            'failed-precondition',
+            'This workout now belongs to a plan and cannot be reclaimed automatically.',
+        );
+    }
+    const restored = parseScheduledWorkoutV1({
+        ...desired,
+        planId: null,
+        revision: current.revision + 1,
+        createdAtMs: current.createdAtMs,
+        updatedAtMs: nowMs,
+    });
+    after.workouts.set(current.id, restored);
+    const restoredCurrentWorkoutCount = currentWorkoutCount(after.workouts);
+    if (restoredCurrentWorkoutCount > TRAINING_PLAN_MAX_CURRENT_WORKOUTS) {
+        throw new TrainingScheduleMutationError(
+            'limit-exceeded',
+            `A restore may not exceed ${TRAINING_PLAN_MAX_CURRENT_WORKOUTS} current workouts.`,
+        );
+    }
+    after.state = parseTrainingPlanStateV1({
+        ...after.state,
+        revision: before.state.revision + 1,
+        currentWorkoutCount: restoredCurrentWorkoutCount,
+        updatedAtMs: nowMs,
+    });
+    const mutation = responseForApplied(request, after, [], [current.id], true);
+    const applied: AppliedTrainingScheduleMutationV1 = {
+        response: mutation,
+        before,
+        after,
+        affectedPlanIds: [],
+        changedWorkoutIds: [current.id],
+        permanentlyDeletedWorkoutIds: [],
+        bulkOperation: false,
+    };
+    return { applied, response: { mutation, skippedWorkoutIds: [] } };
+}
+
+function documentData(snapshot: admin.firestore.DocumentSnapshot): Record<string, unknown> {
+    return (snapshot.data() ?? {}) as Record<string, unknown>;
+}
+
+async function readCurrentScheduleForRestore(
+    transaction: admin.firestore.Transaction,
+    userRef: admin.firestore.DocumentReference,
+    desiredWorkoutIds: string[],
+): Promise<TrainingScheduleSnapshotV1> {
+    const stateRef = userRef.collection('trainingPlanState').doc('current');
+    const plansRef = userRef.collection(TRAINING_PLANS_COLLECTION_ID);
+    const workoutsRef = userRef.collection(SCHEDULED_WORKOUTS_COLLECTION_ID);
+    const [stateSnapshot, plansSnapshot, workoutsSnapshot] = await Promise.all([
+        transaction.get(stateRef),
+        transaction.get(plansRef),
+        transaction.get(workoutsRef.where('lifecycle', 'in', ['planned', 'skipped'])),
+    ]);
+    if (!stateSnapshot.exists) throw new TrainingScheduleMutationError('failed-precondition', 'Training schedule state is unavailable.');
+    const directSnapshots = await Promise.all(desiredWorkoutIds.map(id => transaction.get(workoutsRef.doc(id))));
+    const plans = new Map<string, TrainingPlanV1>();
+    plansSnapshot.docs.forEach((snapshot) => {
+        const parsed = parseTrainingPlanV1(documentData(snapshot));
+        plans.set(parsed.id, parsed);
+    });
+    const workouts = new Map<string, ScheduledWorkoutV1>();
+    [...workoutsSnapshot.docs, ...directSnapshots].forEach((snapshot) => {
+        if (!snapshot.exists) return;
+        const parsed = parseScheduledWorkoutV1(documentData(snapshot));
+        workouts.set(parsed.id, parsed);
+    });
+    return { state: parseTrainingPlanStateV1(documentData(stateSnapshot)), plans, workouts };
+}
+
+function parseStoredRestoreResponse(value: unknown): RestoreTrainingScheduleRevisionResponseV1 {
+    const record = asRecord(value, '$receipt.response');
+    const mutation = asRecord(record.mutation, '$receipt.response.mutation');
+    if (!Array.isArray(record.skippedWorkoutIds) || typeof mutation.mutationId !== 'string') {
+        throw new Error('Invalid restore receipt.');
+    }
+    return {
+        mutation: {
+            mutationId: mutation.mutationId,
+            state: parseTrainingPlanStateV1(mutation.state),
+            plans: Array.isArray(mutation.plans) ? mutation.plans.map(parseTrainingPlanV1) : [],
+            workouts: Array.isArray(mutation.workouts) ? mutation.workouts.map(parseScheduledWorkoutV1) : [],
+            removedPlanIds: Array.isArray(mutation.removedPlanIds) ? mutation.removedPlanIds as string[] : [],
+            permanentlyDeletedWorkoutIds: Array.isArray(mutation.permanentlyDeletedWorkoutIds)
+                ? mutation.permanentlyDeletedWorkoutIds as string[] : [],
+        },
+        skippedWorkoutIds: record.skippedWorkoutIds as string[],
+    };
+}
+
+export async function restoreTrainingScheduleRevisionForUser(
+    uid: string,
+    request: RestoreTrainingScheduleRevisionRequestV1,
+    options: { db?: admin.firestore.Firestore; nowMs?: number } = {},
+): Promise<RestoreTrainingScheduleRevisionResponseV1> {
+    const db = options.db ?? admin.firestore();
+    const nowMs = options.nowMs ?? Date.now();
+    const desiredPlan = request.scope.kind === 'plan'
+        ? await readPlanSnapshotAtRevision(db, uid, request.scope.id, request.targetRevision)
+        : null;
+    const desiredWorkout = request.scope.kind === 'workout'
+        ? await readStandaloneWorkoutAtRevision(db, uid, request.scope.id, request.targetRevision)
+        : null;
+    const desiredWorkoutIds = desiredPlan ? [...desiredPlan.workouts.keys()] : [request.scope.id];
+    const requestHash = hashTrainingScheduleRequestPayload(request);
+    const userRef = db.collection('users').doc(uid);
+    const stateRef = userRef.collection('trainingPlanState').doc('current');
+    const receiptRef = stateRef.collection(TRAINING_PLAN_MUTATION_RECEIPTS_COLLECTION_ID).doc(request.mutationId);
+
+    return db.runTransaction(async (transaction) => {
+        const guard = await getUserDeletionGuardStateInTransaction(db, transaction, uid, nowMs);
+        if (guard.shouldSkip) {
+            throw new TrainingScheduleMutationError('failed-precondition', 'This account is being deleted or is no longer available.');
+        }
+        const receiptSnapshot = await transaction.get(receiptRef);
+        if (receiptSnapshot.exists) {
+            const receipt = documentData(receiptSnapshot);
+            if (receipt.requestHash !== requestHash) {
+                throw new TrainingScheduleMutationError('failed-precondition', 'This mutation ID was already used differently.');
+            }
+            return parseStoredRestoreResponse(receipt.response);
+        }
+        await assertNoTrainingPlanDeletionInProgress(transaction, stateRef);
+        const snapshot = await readCurrentScheduleForRestore(transaction, userRef, desiredWorkoutIds);
+        const restored = desiredPlan
+            ? applyPlanRevisionRestore(snapshot, desiredPlan, request, nowMs)
+            : applyStandaloneRevisionRestore(snapshot, desiredWorkout!, request, nowMs);
+        const revisionRequest = {
+            mutationId: request.mutationId,
+            operation: { kind: request.scope.kind === 'plan' ? 'restore-plan-revision' : 'restore-workout-revision' },
+        };
+        const revisions = buildTrainingScheduleRevisionWrites(restored.applied, revisionRequest, nowMs);
+        transaction.set(stateRef, restored.applied.after.state);
+        restored.applied.affectedPlanIds.forEach((planId) => {
+            const planRef = userRef.collection(TRAINING_PLANS_COLLECTION_ID).doc(planId);
+            const plan = restored.applied.after.plans.get(planId)!;
+            transaction.set(planRef, plan);
+            const revision = revisions.planRevisions.get(planId);
+            if (revision) {
+                const revisionRef = planRef.collection(TRAINING_PLAN_REVISIONS_COLLECTION_ID)
+                    .doc(trainingScheduleRevisionDocumentId(revision.revision));
+                transaction.create(revisionRef, revision);
+                for (const chunk of revisions.planRevisionChunks.get(planId) ?? []) {
+                    transaction.create(
+                        revisionRef.collection(TRAINING_PLAN_REVISION_CHUNKS_COLLECTION_ID)
+                            .doc(trainingPlanRevisionChunkDocumentId(chunk.kind, chunk.chunkIndex)),
+                        chunk,
+                    );
+                }
+            }
+        });
+        restored.applied.changedWorkoutIds.forEach((workoutId) => {
+            const workoutRef = userRef.collection(SCHEDULED_WORKOUTS_COLLECTION_ID).doc(workoutId);
+            const workout = restored.applied.after.workouts.get(workoutId)!;
+            transaction.set(workoutRef, workout);
+            const revision = revisions.standaloneWorkoutRevisions.get(workoutId);
+            if (revision) transaction.create(
+                workoutRef.collection(TRAINING_PLAN_REVISIONS_COLLECTION_ID)
+                    .doc(trainingScheduleRevisionDocumentId(revision.revision)),
+                revision,
+            );
+        });
+        transaction.create(receiptRef, {
+            schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+            requestHash,
+            response: restored.response,
+            createdAtMs: nowMs,
+            expireAt: Timestamp.fromMillis(nowMs + RESTORE_RECEIPT_RETENTION_MS),
+        });
+        return restored.response;
+    });
+}

--- a/functions/src/training-plans/restore.ts
+++ b/functions/src/training-plans/restore.ts
@@ -374,21 +374,62 @@ async function readCurrentScheduleForRestore(
 function parseStoredRestoreResponse(value: unknown): RestoreTrainingScheduleRevisionResponseV1 {
     const record = asRecord(value, '$receipt.response');
     const mutation = asRecord(record.mutation, '$receipt.response.mutation');
-    if (!Array.isArray(record.skippedWorkoutIds) || typeof mutation.mutationId !== 'string') {
+    if (
+        !Array.isArray(record.skippedWorkoutIds)
+        || typeof mutation.mutationId !== 'string'
+        || !Array.isArray(mutation.plans)
+        || !Array.isArray(mutation.workouts)
+    ) {
         throw new Error('Invalid restore receipt.');
     }
+    const readStringArray = (candidate: unknown, path: string): string[] => {
+        if (!Array.isArray(candidate) || candidate.some(item => typeof item !== 'string')) {
+            throw new Error(`Invalid restore receipt field ${path}.`);
+        }
+        return candidate as string[];
+    };
     return {
         mutation: {
             mutationId: mutation.mutationId,
             state: parseTrainingPlanStateV1(mutation.state),
-            plans: Array.isArray(mutation.plans) ? mutation.plans.map(parseTrainingPlanV1) : [],
-            workouts: Array.isArray(mutation.workouts) ? mutation.workouts.map(parseScheduledWorkoutV1) : [],
-            removedPlanIds: Array.isArray(mutation.removedPlanIds) ? mutation.removedPlanIds as string[] : [],
-            permanentlyDeletedWorkoutIds: Array.isArray(mutation.permanentlyDeletedWorkoutIds)
-                ? mutation.permanentlyDeletedWorkoutIds as string[] : [],
+            plans: mutation.plans.map(parseTrainingPlanV1),
+            workouts: mutation.workouts.map(parseScheduledWorkoutV1),
+            removedPlanIds: readStringArray(mutation.removedPlanIds, 'mutation.removedPlanIds'),
+            permanentlyDeletedWorkoutIds: readStringArray(
+                mutation.permanentlyDeletedWorkoutIds,
+                'mutation.permanentlyDeletedWorkoutIds',
+            ),
         },
-        skippedWorkoutIds: record.skippedWorkoutIds as string[],
+        skippedWorkoutIds: readStringArray(record.skippedWorkoutIds, 'skippedWorkoutIds'),
     };
+}
+
+async function readCompletedRestoreReceiptBeforeHistory(
+    db: admin.firestore.Firestore,
+    uid: string,
+    receiptRef: admin.firestore.DocumentReference,
+    requestHash: string,
+    nowMs: number,
+): Promise<RestoreTrainingScheduleRevisionResponseV1 | null> {
+    return db.runTransaction(async (transaction) => {
+        const guard = await getUserDeletionGuardStateInTransaction(db, transaction, uid, nowMs);
+        if (guard.shouldSkip) {
+            throw new TrainingScheduleMutationError(
+                'failed-precondition',
+                'This account is being deleted or is no longer available.',
+            );
+        }
+        const receiptSnapshot = await transaction.get(receiptRef);
+        if (!receiptSnapshot.exists) return null;
+        const receipt = documentData(receiptSnapshot);
+        if (receipt.requestHash !== requestHash) {
+            throw new TrainingScheduleMutationError(
+                'failed-precondition',
+                'This mutation ID was already used differently.',
+            );
+        }
+        return parseStoredRestoreResponse(receipt.response);
+    });
 }
 
 export async function restoreTrainingScheduleRevisionForUser(
@@ -398,6 +439,19 @@ export async function restoreTrainingScheduleRevisionForUser(
 ): Promise<RestoreTrainingScheduleRevisionResponseV1> {
     const db = options.db ?? admin.firestore();
     const nowMs = options.nowMs ?? Date.now();
+    const requestHash = hashTrainingScheduleRequestPayload(request);
+    const userRef = db.collection('users').doc(uid);
+    const stateRef = userRef.collection('trainingPlanState').doc('current');
+    const receiptRef = stateRef.collection(TRAINING_PLAN_MUTATION_RECEIPTS_COLLECTION_ID).doc(request.mutationId);
+    const completed = await readCompletedRestoreReceiptBeforeHistory(
+        db,
+        uid,
+        receiptRef,
+        requestHash,
+        nowMs,
+    );
+    if (completed) return completed;
+
     const desiredPlan = request.scope.kind === 'plan'
         ? await readPlanSnapshotAtRevision(db, uid, request.scope.id, request.targetRevision)
         : null;
@@ -405,10 +459,6 @@ export async function restoreTrainingScheduleRevisionForUser(
         ? await readStandaloneWorkoutAtRevision(db, uid, request.scope.id, request.targetRevision)
         : null;
     const desiredWorkoutIds = desiredPlan ? [...desiredPlan.workouts.keys()] : [request.scope.id];
-    const requestHash = hashTrainingScheduleRequestPayload(request);
-    const userRef = db.collection('users').doc(uid);
-    const stateRef = userRef.collection('trainingPlanState').doc('current');
-    const receiptRef = stateRef.collection(TRAINING_PLAN_MUTATION_RECEIPTS_COLLECTION_ID).doc(request.mutationId);
 
     return db.runTransaction(async (transaction) => {
         const guard = await getUserDeletionGuardStateInTransaction(db, transaction, uid, nowMs);

--- a/functions/src/users/cleanup.spec.ts
+++ b/functions/src/users/cleanup.spec.ts
@@ -587,13 +587,16 @@ describe('cleanupUserAccounts', () => {
         expect(recursiveDeleteMock).toHaveBeenCalledWith(docRef);
     });
 
-    it('should recursively delete generated derived metrics subtree', async () => {
+    it('should recursively delete generated metrics and training-planning subtrees', async () => {
         const wrapped = cleanupUserAccounts;
         const user = testEnv.auth.makeUserRecord({ uid: 'testUser123' });
 
         await wrapped(user, { eventId: 'eventId' } as unknown as functions.EventContext);
 
         expect(recursiveDeleteMock).toHaveBeenCalledWith(expect.objectContaining({ path: 'subcollection/derivedMetrics' }));
+        expect(recursiveDeleteMock).toHaveBeenCalledWith(expect.objectContaining({ path: 'subcollection/trainingPlanState' }));
+        expect(recursiveDeleteMock).toHaveBeenCalledWith(expect.objectContaining({ path: 'subcollection/trainingPlans' }));
+        expect(recursiveDeleteMock).toHaveBeenCalledWith(expect.objectContaining({ path: 'subcollection/scheduledWorkouts' }));
     });
 
     it('should handle subcollection deletion error and continue', async () => {

--- a/functions/src/users/cleanup.ts
+++ b/functions/src/users/cleanup.ts
@@ -6,6 +6,11 @@ import { GARMIN_API_TOKENS_COLLECTION_NAME, GARMIN_API_WORKOUT_QUEUE_COLLECTION_
 
 import { ServiceNames } from '@sports-alliance/sports-lib';
 import { DERIVED_METRICS_COLLECTION_ID } from '../../../shared/derived-metrics';
+import {
+    SCHEDULED_WORKOUTS_COLLECTION_ID,
+    TRAINING_PLANS_COLLECTION_ID,
+    TRAINING_PLAN_STATE_COLLECTION_ID,
+} from '../../../shared/training-plans';
 import { ACTIVITY_SYNC_QUEUE_COLLECTION_NAME } from '../activity-sync/constants';
 import { ROUTE_DELIVERY_SYNC_QUEUE_COLLECTION_NAME } from '../route-delivery-sync/constants';
 import { ROUTE_SYNC_QUEUE_COLLECTION_NAME } from '../routes/route-sync.constants';
@@ -312,6 +317,9 @@ async function cleanupUserScopedGeneratedState(uid: string): Promise<void> {
     const userRef = db.collection('users').doc(uid);
     const cleanupTargets = [
         { label: 'derived metrics', ref: userRef.collection(DERIVED_METRICS_COLLECTION_ID) },
+        { label: 'training plan state', ref: userRef.collection(TRAINING_PLAN_STATE_COLLECTION_ID) },
+        { label: 'training plans', ref: userRef.collection(TRAINING_PLANS_COLLECTION_ID) },
+        { label: 'scheduled workouts', ref: userRef.collection(SCHEDULED_WORKOUTS_COLLECTION_ID) },
     ];
 
     for (const target of cleanupTargets) {

--- a/ngsw-config.json
+++ b/ngsw-config.json
@@ -53,6 +53,7 @@
     "/dashboard",
     "/health",
     "/calendar",
+    "/plans",
     "/training",
     "/mytracks",
     "/routes",

--- a/shared/functions-manifest.ts
+++ b/shared/functions-manifest.ts
@@ -127,6 +127,11 @@ export const FUNCTIONS_MANIFEST = {
     resetAssistantConversation: { name: 'resetAssistantConversation', region: 'europe-west2' },
     ensureDerivedMetrics: { name: 'ensureDerivedMetrics', region: 'europe-west2' },
     setTrainingBuildBenchmark: { name: 'setTrainingBuildBenchmark', region: 'europe-west2' },
+    mutateTrainingSchedule: { name: 'mutateTrainingSchedule', region: 'europe-west2' },
+    getTrainingScheduleHistory: { name: 'getTrainingScheduleHistory', region: 'europe-west2' },
+    previewTrainingScheduleRestore: { name: 'previewTrainingScheduleRestore', region: 'europe-west2' },
+    restoreTrainingScheduleRevision: { name: 'restoreTrainingScheduleRevision', region: 'europe-west2' },
+    deleteTrainingPlan: { name: 'deleteTrainingPlan', region: 'europe-west2' },
     processDerivedMetricsIngressTask: { name: 'processDerivedMetricsIngressTask', region: 'europe-west2' },
 } as const;
 

--- a/shared/planned-workout-providers.ts
+++ b/shared/planned-workout-providers.ts
@@ -45,10 +45,12 @@ export interface PlannedWorkoutProviderMappingIssueV1 {
     | 'provider_contract_unavailable'
     | 'unsupported_sport'
     | 'unsupported_ending'
+    | 'unsupported_target'
     | 'purpose_degraded'
     | 'multiple_targets_degraded'
     | 'relative_target_degraded'
-    | 'relative_reference_conflict';
+    | 'relative_reference_conflict'
+    | 'relative_target_device_support_limited';
   path: string;
   message: string;
 }
@@ -69,19 +71,35 @@ export const PLANNED_WORKOUT_PROVIDER_CAPABILITIES_V1: Readonly<
   garmin: {
     id: 'garmin',
     label: 'Garmin',
-    implementationState: 'blocked-contract',
+    implementationState: 'fixture-only',
     deliveryEnabled: false,
     deliveryModel: 'native-workout-and-schedule',
     requiredScopes: ['WORKOUT_IMPORT'],
-    profile: null,
+    profile: {
+      sports: [ActivityTypes.Running, ActivityTypes.Cycling],
+      endingKinds: ['time', 'distance', 'manual'],
+      targetKinds: ['heart-rate', 'power', 'speed', 'cadence'],
+      supportsRepeats: true,
+      supportsRelativeTargets: false,
+      maxNodes: 100,
+      maxRepeatCount: 100,
+      maxTargetsPerStep: 2,
+    },
     scheduling: 'Workout content and Garmin Connect calendar scheduling have separate lifecycles.',
-    limits: ['Current private Training API contract is not present in this repository.'],
-    completionCorrelation: 'Pending confirmation from the current Garmin Training API contract.',
+    limits: [
+      'Single-sport workouts allow at most 100 total steps.',
+      'Descriptions allow 1024 characters per workout and 512 characters per step.',
+      'A secondary target is documented only for cycling and depends on device support.',
+      'Evaluation access is limited to 100 partner requests per minute and 200 requests per user per rolling day.',
+    ],
+    completionCorrelation: 'Training API V2 does not document a completed-activity workout identifier.',
     unresolvedGates: [
-      'Obtain the current private Training API schema, endpoints, limits, update/delete semantics, and test access.',
+      'Confirm evaluation credentials, app entitlement, and representative test-device access.',
+      'Confirm completion-correlation behavior outside the Training API contract.',
       'Pass sandbox create, update, reschedule, delete, reconnect, and duplicate tests.',
     ],
     evidence: [
+      'Garmin Connect Developer Program Training API V2, version 1.0 (private partner document, May 2025)',
       'https://developer.garmin.com/gc-developer-program/training-api/',
       'https://developer.garmin.com/gc-developer-program/program-faq/',
     ],
@@ -89,11 +107,18 @@ export const PLANNED_WORKOUT_PROVIDER_CAPABILITIES_V1: Readonly<
   coros: {
     id: 'coros',
     label: 'COROS',
-    implementationState: 'blocked-contract',
+    implementationState: 'fixture-only',
     deliveryEnabled: false,
     deliveryModel: 'native-plan-workout-batches',
     requiredScopes: ['training-plan partner entitlement'],
-    profile: null,
+    profile: {
+      sports: [ActivityTypes.Running, ActivityTypes.Cycling],
+      endingKinds: ['time', 'distance', 'manual'],
+      targetKinds: ['heart-rate', 'power', 'speed', 'cadence'],
+      supportsRepeats: true,
+      supportsRelativeTargets: true,
+      maxTargetsPerStep: 1,
+    },
     scheduling: 'Partner workout IDs are pushed in dated batches through the Training Plan API.',
     limits: ['At most 30 workouts per push.', 'Dates from today through one year ahead.'],
     completionCorrelation: 'Completed workout payloads may carry planWorkoutId.',
@@ -123,6 +148,7 @@ export const PLANNED_WORKOUT_PROVIDER_CAPABILITIES_V1: Readonly<
     limits: [
       'The public plan.json schema is version 1.0.0 and supports running and cycling.',
       'Bike computers use only the first target in an interval.',
+      'Relative heart-rate and threshold-speed targets are documented for treadmill workouts in the Wahoo app, not ELEMNT computers or RIVAL.',
       'Device-visible scheduling is documented as the current day plus six days.',
     ],
     completionCorrelation: 'workout_token identifies the app workout, but third-party-origin completions are not shared.',
@@ -147,7 +173,7 @@ export const PLANNED_WORKOUT_PROVIDER_CAPABILITIES_V1: Readonly<
       endingKinds: ['time', 'distance', 'manual'],
       targetKinds: ['heart-rate', 'power', 'speed', 'cadence'],
       supportsRepeats: true,
-      supportsRelativeTargets: true,
+      supportsRelativeTargets: false,
       maxNodes: 100,
       maxRepeatCount: 100,
       maxTargetsPerStep: 2,
@@ -217,16 +243,6 @@ export function assessPlannedWorkoutProviderMappingV1(
   const structure = parseWorkoutStructureV1(value);
   const issues: PlannedWorkoutProviderMappingIssueV1[] = [];
 
-  if (provider === 'garmin' || provider === 'coros') {
-    issues.push({
-      severity: 'unsupported',
-      code: 'provider_contract_unavailable',
-      path: '$',
-      message: `${PLANNED_WORKOUT_PROVIDER_CAPABILITIES_V1[provider].label} mapping is blocked until the current partner contract is available.`,
-    });
-    return { provider, level: 'unsupported', issues };
-  }
-
   if (![ActivityTypes.Running, ActivityTypes.Cycling].includes(structure.sport)) {
     issues.push({
       severity: 'unsupported',
@@ -250,21 +266,73 @@ export function assessPlannedWorkoutProviderMappingV1(
       });
     }
 
-    if (provider === 'wahoo' && step.purpose === 'other') {
+    if (
+      (provider === 'garmin' || provider === 'coros' || provider === 'wahoo')
+      && step.purpose === 'other'
+    ) {
       issues.push({
         severity: 'degraded',
         code: 'purpose_degraded',
         path: `${path}.purpose`,
-        message: 'Wahoo has no generic other intensity, so this step is delivered as active.',
+        message: `${PLANNED_WORKOUT_PROVIDER_CAPABILITIES_V1[provider].label} has no generic other intensity, so this step is delivered as active.`,
       });
     }
 
-    if (provider === 'wahoo' && step.targets.length > 1) {
+    if (provider === 'coros' && step.purpose === 'recovery') {
+      issues.push({
+        severity: 'degraded',
+        code: 'purpose_degraded',
+        path: `${path}.purpose`,
+        message: 'COROS has no recovery intensity, so this step is delivered as rest.',
+      });
+    }
+
+    if ((provider === 'wahoo' || provider === 'coros') && step.targets.length > 1) {
       issues.push({
         severity: 'degraded',
         code: 'multiple_targets_degraded',
         path: `${path}.targets`,
-        message: 'The plan file preserves both targets, but ELEMNT bike computers use only the first target.',
+        message: provider === 'wahoo'
+          ? 'The plan file preserves both targets, but ELEMNT bike computers use only the first target.'
+          : 'COROS accepts one intensity target per step, so only the first target can be delivered.',
+      });
+    }
+
+    if (provider === 'garmin' && step.targets.length > 1) {
+      if (structure.sport !== ActivityTypes.Cycling) {
+        issues.push({
+          severity: 'unsupported',
+          code: 'unsupported_target',
+          path: `${path}.targets`,
+          message: 'Garmin documents secondary targets only for cycling and lap swimming.',
+        });
+      } else if (step.targets[0]?.kind === step.targets[1]?.kind) {
+        issues.push({
+          severity: 'unsupported',
+          code: 'unsupported_target',
+          path: `${path}.targets[1]`,
+          message: 'Garmin requires the secondary target type to differ from the primary target type.',
+        });
+      } else {
+        issues.push({
+          severity: 'degraded',
+          code: 'multiple_targets_degraded',
+          path: `${path}.targets`,
+          message: 'Garmin cycling secondary targets are supported only on a documented subset of devices.',
+        });
+      }
+    }
+
+    if (
+      provider === 'coros'
+      && structure.sport === ActivityTypes.Cycling
+      && step.targets.some(target => target.kind === 'cadence')
+    ) {
+      issues.push({
+        severity: 'unsupported',
+        code: 'unsupported_target',
+        path: `${path}.targets`,
+        message: 'The COROS partner contract documents cadence targets for running and trail running, not cycling.',
       });
     }
 
@@ -275,7 +343,11 @@ export function assessPlannedWorkoutProviderMappingV1(
       const referenceValue = relativeReferenceValue(target);
 
       if (
-        provider === 'suunto'
+        provider === 'garmin'
+        || provider === 'suunto'
+        || (provider === 'coros' && target.kind === 'cadence')
+        || (provider === 'coros' && target.kind === 'heart-rate' && target.reference.kind === 'max-heart-rate')
+        || (provider === 'coros' && target.kind === 'power' && target.reference.kind === 'critical-power')
         || (provider === 'wahoo' && target.kind === 'cadence')
         || (provider === 'wahoo' && target.kind === 'power' && target.reference.kind === 'critical-power')
       ) {
@@ -288,7 +360,16 @@ export function assessPlannedWorkoutProviderMappingV1(
         return;
       }
 
-      if (referenceKey === null || referenceValue === null) return;
+      if (provider === 'wahoo' && (target.kind === 'heart-rate' || target.kind === 'speed')) {
+        issues.push({
+          severity: 'degraded',
+          code: 'relative_target_device_support_limited',
+          path: targetPath,
+          message: 'Wahoo documents relative heart-rate and threshold-speed targets for treadmill workouts in the Wahoo app, not ELEMNT computers or RIVAL.',
+        });
+      }
+
+      if (provider !== 'wahoo' || referenceKey === null || referenceValue === null) return;
       const priorValue = referenceSnapshots.get(referenceKey);
       if (priorValue !== undefined && priorValue !== referenceValue) {
         issues.push({

--- a/shared/planned-workout-providers.ts
+++ b/shared/planned-workout-providers.ts
@@ -1,0 +1,312 @@
+import { ActivityTypes } from '@sports-alliance/sports-lib';
+import {
+  parseWorkoutStructureV1,
+  type WorkoutCompatibilityProfileV1,
+  type WorkoutStepV1,
+  type WorkoutStructureV1,
+  type WorkoutTargetV1,
+} from './planned-workout';
+
+export const PLANNED_WORKOUT_PROVIDER_IDS = ['garmin', 'coros', 'wahoo', 'suunto'] as const;
+export type PlannedWorkoutProviderId = typeof PLANNED_WORKOUT_PROVIDER_IDS[number];
+
+export type PlannedWorkoutProviderImplementationState =
+  | 'blocked-contract'
+  | 'fixture-only'
+  | 'sandbox-verified'
+  | 'enabled';
+
+export type PlannedWorkoutProviderDeliveryModel =
+  | 'native-workout-and-schedule'
+  | 'native-plan-workout-batches'
+  | 'plan-library-plus-dated-workout'
+  | 'dated-guide';
+
+export interface PlannedWorkoutProviderCapabilityV1 {
+  id: PlannedWorkoutProviderId;
+  label: string;
+  implementationState: PlannedWorkoutProviderImplementationState;
+  deliveryEnabled: boolean;
+  deliveryModel: PlannedWorkoutProviderDeliveryModel;
+  requiredScopes: readonly string[];
+  profile: WorkoutCompatibilityProfileV1 | null;
+  scheduling: string;
+  limits: readonly string[];
+  completionCorrelation: string;
+  unresolvedGates: readonly string[];
+  evidence: readonly string[];
+}
+
+export type PlannedWorkoutProviderMappingLevel = 'exact' | 'degraded' | 'unsupported';
+
+export interface PlannedWorkoutProviderMappingIssueV1 {
+  severity: Exclude<PlannedWorkoutProviderMappingLevel, 'exact'>;
+  code:
+    | 'provider_contract_unavailable'
+    | 'unsupported_sport'
+    | 'unsupported_ending'
+    | 'purpose_degraded'
+    | 'multiple_targets_degraded'
+    | 'relative_target_degraded'
+    | 'relative_reference_conflict';
+  path: string;
+  message: string;
+}
+
+export interface PlannedWorkoutProviderMappingAssessmentV1 {
+  provider: PlannedWorkoutProviderId;
+  level: PlannedWorkoutProviderMappingLevel;
+  issues: PlannedWorkoutProviderMappingIssueV1[];
+}
+
+/**
+ * Versioned provider research snapshot. Delivery remains disabled until each
+ * provider's fixture and sandbox CRUD/idempotency evidence is recorded.
+ */
+export const PLANNED_WORKOUT_PROVIDER_CAPABILITIES_V1: Readonly<
+  Record<PlannedWorkoutProviderId, PlannedWorkoutProviderCapabilityV1>
+> = {
+  garmin: {
+    id: 'garmin',
+    label: 'Garmin',
+    implementationState: 'blocked-contract',
+    deliveryEnabled: false,
+    deliveryModel: 'native-workout-and-schedule',
+    requiredScopes: ['WORKOUT_IMPORT'],
+    profile: null,
+    scheduling: 'Workout content and Garmin Connect calendar scheduling have separate lifecycles.',
+    limits: ['Current private Training API contract is not present in this repository.'],
+    completionCorrelation: 'Pending confirmation from the current Garmin Training API contract.',
+    unresolvedGates: [
+      'Obtain the current private Training API schema, endpoints, limits, update/delete semantics, and test access.',
+      'Pass sandbox create, update, reschedule, delete, reconnect, and duplicate tests.',
+    ],
+    evidence: [
+      'https://developer.garmin.com/gc-developer-program/training-api/',
+      'https://developer.garmin.com/gc-developer-program/program-faq/',
+    ],
+  },
+  coros: {
+    id: 'coros',
+    label: 'COROS',
+    implementationState: 'blocked-contract',
+    deliveryEnabled: false,
+    deliveryModel: 'native-plan-workout-batches',
+    requiredScopes: ['training-plan partner entitlement'],
+    profile: null,
+    scheduling: 'Partner workout IDs are pushed in dated batches through the Training Plan API.',
+    limits: ['At most 30 workouts per push.', 'Dates from today through one year ahead.'],
+    completionCorrelation: 'Completed workout payloads may carry planWorkoutId.',
+    unresolvedGates: [
+      'Confirm Training Plan entitlement; provider code 30009 means access is unavailable.',
+      'Confirm repeated-ID replacement and overlapping-window semantics with COROS.',
+      'Pass sandbox create, update, reschedule, eligible-delete, and duplicate tests.',
+    ],
+    evidence: ['COROS API Reference V2.0.6 (partner document, February 2026)'],
+  },
+  wahoo: {
+    id: 'wahoo',
+    label: 'Wahoo',
+    implementationState: 'fixture-only',
+    deliveryEnabled: false,
+    deliveryModel: 'plan-library-plus-dated-workout',
+    requiredScopes: ['plans_read', 'plans_write', 'workouts_read', 'workouts_write'],
+    profile: {
+      sports: [ActivityTypes.Running, ActivityTypes.Cycling],
+      endingKinds: ['time', 'distance', 'kilojoules'],
+      targetKinds: ['heart-rate', 'power', 'speed', 'cadence'],
+      supportsRepeats: true,
+      supportsRelativeTargets: true,
+      maxTargetsPerStep: 2,
+    },
+    scheduling: 'Create an app-owned Plan record, then attach it to a dated Workout record.',
+    limits: [
+      'The public plan.json schema is version 1.0.0 and supports running and cycling.',
+      'Bike computers use only the first target in an interval.',
+      'Device-visible scheduling is documented as the current day plus six days.',
+    ],
+    completionCorrelation: 'workout_token identifies the app workout, but third-party-origin completions are not shared.',
+    unresolvedGates: [
+      'Confirm Plans entitlement, scopes, same-app ownership, and date-only starts/day_code behavior.',
+      'Pass sandbox CRUD, reconnect, duplicate, and current-day-plus-six device tests.',
+    ],
+    evidence: [
+      'https://cloud-api.wahooligan.com/',
+      'https://cloud-api.wahooligan.com/docs/plan-json-format.pdf',
+    ],
+  },
+  suunto: {
+    id: 'suunto',
+    label: 'Suunto',
+    implementationState: 'fixture-only',
+    deliveryEnabled: false,
+    deliveryModel: 'dated-guide',
+    requiredScopes: ['SuuntoPlus Guides entitlement', 'Suunto subscription key'],
+    profile: {
+      sports: [ActivityTypes.Running, ActivityTypes.Cycling],
+      endingKinds: ['time', 'distance', 'manual'],
+      targetKinds: ['heart-rate', 'power', 'speed', 'cadence'],
+      supportsRepeats: true,
+      supportsRelativeTargets: true,
+      maxNodes: 100,
+      maxRepeatCount: 100,
+      maxTargetsPerStep: 2,
+    },
+    scheduling: 'Each scheduled workout becomes an app-owned SuuntoPlus Guide with a user-local localDate.',
+    limits: [
+      'A Guide has 1–1000 steps; repeats allow 1–100 iterations and cannot nest.',
+      'Guide availability and watch storage/pinning are device-dependent.',
+      'This is individual Guide delivery, not native training-plan/calendar parity.',
+    ],
+    completionCorrelation: 'The Guide externalId can be recovered from matching SuuntoPlus FIT session arrays.',
+    unresolvedGates: [
+      'Confirm Guides entitlement, supported-watch workflow, storage, and pin/select behavior.',
+      'Pass sandbox create, update, reschedule, delete, duplicate, and FIT-correlation tests.',
+    ],
+    evidence: [
+      'https://apizone.suunto.com/how-to-use-suuntoplus-guides-api',
+      'https://apizone.suunto.com/suuntoplus-guide-description',
+      'https://apizone.suunto.com/fit-description',
+    ],
+  },
+};
+
+export function isPlannedWorkoutProviderDeliveryEnabled(provider: PlannedWorkoutProviderId): boolean {
+  return PLANNED_WORKOUT_PROVIDER_CAPABILITIES_V1[provider].deliveryEnabled;
+}
+
+function relativeReferenceKey(target: WorkoutTargetV1): string | null {
+  if (target.mode !== 'relative') return null;
+  return `${target.kind}:${target.reference.kind}`;
+}
+
+function relativeReferenceValue(target: WorkoutTargetV1): number | null {
+  if (target.mode !== 'relative') return null;
+  switch (target.kind) {
+    case 'heart-rate': return target.reference.bpm;
+    case 'power': return target.reference.watts;
+    case 'speed': return target.reference.metersPerSecond;
+    case 'cadence': return target.reference.rpm;
+  }
+}
+
+function structureSteps(structure: WorkoutStructureV1): Array<{
+  path: string;
+  step: WorkoutStepV1;
+}> {
+  const steps: Array<{ path: string; step: WorkoutStepV1 }> = [];
+  structure.nodes.forEach((node, nodeIndex) => {
+    const path = `$.nodes[${nodeIndex}]`;
+    if (node.kind === 'step') {
+      steps.push({ path, step: node });
+      return;
+    }
+    node.steps.forEach((step, stepIndex) => steps.push({ path: `${path}.steps[${stepIndex}]`, step }));
+  });
+  return steps;
+}
+
+/**
+ * Assesses mapping fidelity independently from provider access or delivery.
+ * A result can be exact while delivery remains disabled pending sandbox proof.
+ */
+export function assessPlannedWorkoutProviderMappingV1(
+  provider: PlannedWorkoutProviderId,
+  value: unknown,
+): PlannedWorkoutProviderMappingAssessmentV1 {
+  const structure = parseWorkoutStructureV1(value);
+  const issues: PlannedWorkoutProviderMappingIssueV1[] = [];
+
+  if (provider === 'garmin' || provider === 'coros') {
+    issues.push({
+      severity: 'unsupported',
+      code: 'provider_contract_unavailable',
+      path: '$',
+      message: `${PLANNED_WORKOUT_PROVIDER_CAPABILITIES_V1[provider].label} mapping is blocked until the current partner contract is available.`,
+    });
+    return { provider, level: 'unsupported', issues };
+  }
+
+  if (![ActivityTypes.Running, ActivityTypes.Cycling].includes(structure.sport)) {
+    issues.push({
+      severity: 'unsupported',
+      code: 'unsupported_sport',
+      path: '$.sport',
+      message: `${structure.sport} cannot be represented by the ${PLANNED_WORKOUT_PROVIDER_CAPABILITIES_V1[provider].label} fixture mapper.`,
+    });
+  }
+
+  const referenceSnapshots = new Map<string, number>();
+  for (const { path, step } of structureSteps(structure)) {
+    const supportedEndings = provider === 'wahoo'
+      ? ['time', 'distance', 'kilojoules']
+      : ['time', 'distance', 'manual'];
+    if (!supportedEndings.includes(step.ending.kind)) {
+      issues.push({
+        severity: 'unsupported',
+        code: 'unsupported_ending',
+        path: `${path}.ending`,
+        message: `${step.ending.kind} endings are not supported by ${PLANNED_WORKOUT_PROVIDER_CAPABILITIES_V1[provider].label}.`,
+      });
+    }
+
+    if (provider === 'wahoo' && step.purpose === 'other') {
+      issues.push({
+        severity: 'degraded',
+        code: 'purpose_degraded',
+        path: `${path}.purpose`,
+        message: 'Wahoo has no generic other intensity, so this step is delivered as active.',
+      });
+    }
+
+    if (provider === 'wahoo' && step.targets.length > 1) {
+      issues.push({
+        severity: 'degraded',
+        code: 'multiple_targets_degraded',
+        path: `${path}.targets`,
+        message: 'The plan file preserves both targets, but ELEMNT bike computers use only the first target.',
+      });
+    }
+
+    step.targets.forEach((target, targetIndex) => {
+      if (target.mode !== 'relative') return;
+      const targetPath = `${path}.targets[${targetIndex}]`;
+      const referenceKey = relativeReferenceKey(target);
+      const referenceValue = relativeReferenceValue(target);
+
+      if (
+        provider === 'suunto'
+        || (provider === 'wahoo' && target.kind === 'cadence')
+        || (provider === 'wahoo' && target.kind === 'power' && target.reference.kind === 'critical-power')
+      ) {
+        issues.push({
+          severity: 'degraded',
+          code: 'relative_target_degraded',
+          path: targetPath,
+          message: `${PLANNED_WORKOUT_PROVIDER_CAPABILITIES_V1[provider].label} cannot encode this relative reference; the stored reference snapshot must be frozen to an absolute range.`,
+        });
+        return;
+      }
+
+      if (referenceKey === null || referenceValue === null) return;
+      const priorValue = referenceSnapshots.get(referenceKey);
+      if (priorValue !== undefined && priorValue !== referenceValue) {
+        issues.push({
+          severity: 'degraded',
+          code: 'relative_reference_conflict',
+          path: targetPath,
+          message: 'Wahoo stores one header value for this reference; this conflicting snapshot must be frozen to an absolute range.',
+        });
+        return;
+      }
+      referenceSnapshots.set(referenceKey, referenceValue);
+    });
+  }
+
+  const level: PlannedWorkoutProviderMappingLevel = issues.some(issue => issue.severity === 'unsupported')
+    ? 'unsupported'
+    : issues.some(issue => issue.severity === 'degraded')
+      ? 'degraded'
+      : 'exact';
+  return { provider, level, issues };
+}

--- a/shared/planned-workout.ts
+++ b/shared/planned-workout.ts
@@ -260,6 +260,7 @@ interface ParseContext {
   issues: WorkoutStructureValidationIssue[];
   ids: Set<string>;
   nodeCount: number;
+  nodeLimitExceeded: boolean;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -273,6 +274,17 @@ function pushIssue(
   message: string,
 ): void {
   context.issues.push({ code, path, message });
+}
+
+function pushNodeLimitIssue(context: ParseContext, path: string): void {
+  if (context.nodeLimitExceeded) return;
+  context.nodeLimitExceeded = true;
+  pushIssue(
+    context,
+    'limit_exceeded',
+    path,
+    `Workout structures may contain at most ${WORKOUT_STRUCTURE_MAX_NODES} nodes including repeated steps.`,
+  );
 }
 
 function readRecord(value: unknown, path: string, context: ParseContext): Record<string, unknown> | null {
@@ -681,6 +693,8 @@ function parseNode(value: unknown, path: string, context: ParseContext): Workout
   let expectedStepCount: number | null = null;
   if (!Array.isArray(record.steps) || record.steps.length === 0) {
     pushIssue(context, 'invalid_type', `${path}.steps`, 'Expected a non-empty array of steps.');
+  } else if (context.nodeCount + record.steps.length > WORKOUT_STRUCTURE_MAX_NODES) {
+    pushNodeLimitIssue(context, `${path}.steps`);
   } else {
     expectedStepCount = record.steps.length;
     steps = record.steps
@@ -694,7 +708,7 @@ function parseNode(value: unknown, path: string, context: ParseContext): Workout
 }
 
 export function parseWorkoutStructureV1(value: unknown): WorkoutStructureV1 {
-  const context: ParseContext = { issues: [], ids: new Set(), nodeCount: 0 };
+  const context: ParseContext = { issues: [], ids: new Set(), nodeCount: 0, nodeLimitExceeded: false };
   const record = readRecord(value, '$', context);
   if (!record) throw new WorkoutStructureValidationError(context.issues);
   rejectUnknownFields(record, ['version', 'sport', 'nodes'], '$', context);
@@ -717,6 +731,9 @@ export function parseWorkoutStructureV1(value: unknown): WorkoutStructureV1 {
   let expectedNodeCount: number | null = null;
   if (!Array.isArray(record.nodes) || record.nodes.length === 0) {
     pushIssue(context, 'invalid_type', '$.nodes', 'Expected a non-empty array.');
+  } else if (record.nodes.length > WORKOUT_STRUCTURE_MAX_NODES) {
+    expectedNodeCount = record.nodes.length;
+    pushNodeLimitIssue(context, '$.nodes');
   } else {
     expectedNodeCount = record.nodes.length;
     nodes = record.nodes
@@ -725,12 +742,7 @@ export function parseWorkoutStructureV1(value: unknown): WorkoutStructureV1 {
   }
 
   if (context.nodeCount > WORKOUT_STRUCTURE_MAX_NODES) {
-    pushIssue(
-      context,
-      'limit_exceeded',
-      '$.nodes',
-      `Workout structures may contain at most ${WORKOUT_STRUCTURE_MAX_NODES} nodes including repeated steps.`,
-    );
+    pushNodeLimitIssue(context, '$.nodes');
   }
 
   if (context.issues.length > 0 || !sport || nodes.length !== expectedNodeCount) {

--- a/shared/planned-workout.ts
+++ b/shared/planned-workout.ts
@@ -1,0 +1,981 @@
+import {
+  ActivityTypes,
+  ActivityTypesHelper,
+  DataCadence,
+  DataDistance,
+  DataDuration,
+  DataHeartRate,
+  DataPace,
+  DataPower,
+  DataPowerWork,
+  DataSpeed,
+  type UserUnitSettingsInterface,
+} from '@sports-alliance/sports-lib';
+import {
+  resolveUnitAwareDisplayFromValue,
+  type UnitAwareStatDisplay,
+} from './unit-aware-display';
+
+export const WORKOUT_STRUCTURE_VERSION = 1 as const;
+export const WORKOUT_STRUCTURE_MAX_NODES = 100;
+export const WORKOUT_STRUCTURE_MAX_REPEAT_COUNT = 100;
+export const WORKOUT_STRUCTURE_MAX_TARGETS_PER_STEP = 2;
+
+const WORKOUT_NODE_ID_MAX_LENGTH = 128;
+const WORKOUT_NOTE_MAX_LENGTH = 500;
+const WORKOUT_NODE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+
+export const WORKOUT_STEP_PURPOSES = [
+  'warmup',
+  'work',
+  'recovery',
+  'cooldown',
+  'rest',
+  'other',
+] as const;
+export type WorkoutStepPurposeV1 = typeof WORKOUT_STEP_PURPOSES[number];
+
+export const WORKOUT_ENDING_KINDS = [
+  'time',
+  'distance',
+  'kilojoules',
+  'repetitions',
+  'manual',
+] as const;
+export type WorkoutEndingKindV1 = typeof WORKOUT_ENDING_KINDS[number];
+
+export const WORKOUT_TARGET_KINDS = [
+  'heart-rate',
+  'power',
+  'speed',
+  'cadence',
+] as const;
+export type WorkoutTargetKindV1 = typeof WORKOUT_TARGET_KINDS[number];
+export type WorkoutTargetModeV1 = 'absolute' | 'relative';
+export type WorkoutSpeedPresentationV1 = 'pace' | 'speed';
+
+export interface WorkoutTimeEndingV1 {
+  kind: 'time';
+  seconds: number;
+}
+
+export interface WorkoutDistanceEndingV1 {
+  kind: 'distance';
+  meters: number;
+}
+
+export interface WorkoutKilojoulesEndingV1 {
+  kind: 'kilojoules';
+  kilojoules: number;
+}
+
+export interface WorkoutRepetitionsEndingV1 {
+  kind: 'repetitions';
+  repetitions: number;
+}
+
+export interface WorkoutManualEndingV1 {
+  kind: 'manual';
+}
+
+export type WorkoutEndingV1 =
+  | WorkoutTimeEndingV1
+  | WorkoutDistanceEndingV1
+  | WorkoutKilojoulesEndingV1
+  | WorkoutRepetitionsEndingV1
+  | WorkoutManualEndingV1;
+
+export interface WorkoutAbsoluteHeartRateTargetV1 {
+  kind: 'heart-rate';
+  mode: 'absolute';
+  minimumBpm: number;
+  maximumBpm: number;
+}
+
+export interface WorkoutRelativeHeartRateTargetV1 {
+  kind: 'heart-rate';
+  mode: 'relative';
+  minimumPercent: number;
+  maximumPercent: number;
+  reference: {
+    kind: 'max-heart-rate' | 'threshold-heart-rate';
+    bpm: number;
+  };
+}
+
+export interface WorkoutAbsolutePowerTargetV1 {
+  kind: 'power';
+  mode: 'absolute';
+  minimumWatts: number;
+  maximumWatts: number;
+}
+
+export interface WorkoutRelativePowerTargetV1 {
+  kind: 'power';
+  mode: 'relative';
+  minimumPercent: number;
+  maximumPercent: number;
+  reference: {
+    kind: 'functional-threshold-power' | 'critical-power';
+    watts: number;
+  };
+}
+
+export interface WorkoutAbsoluteSpeedTargetV1 {
+  kind: 'speed';
+  mode: 'absolute';
+  minimumMetersPerSecond: number;
+  maximumMetersPerSecond: number;
+  presentation: WorkoutSpeedPresentationV1;
+}
+
+export interface WorkoutRelativeSpeedTargetV1 {
+  kind: 'speed';
+  mode: 'relative';
+  minimumPercent: number;
+  maximumPercent: number;
+  presentation: WorkoutSpeedPresentationV1;
+  reference: {
+    kind: 'threshold-speed';
+    metersPerSecond: number;
+  };
+}
+
+export interface WorkoutAbsoluteCadenceTargetV1 {
+  kind: 'cadence';
+  mode: 'absolute';
+  minimumRpm: number;
+  maximumRpm: number;
+}
+
+export interface WorkoutRelativeCadenceTargetV1 {
+  kind: 'cadence';
+  mode: 'relative';
+  minimumPercent: number;
+  maximumPercent: number;
+  reference: {
+    kind: 'preferred-cadence';
+    rpm: number;
+  };
+}
+
+export type WorkoutTargetV1 =
+  | WorkoutAbsoluteHeartRateTargetV1
+  | WorkoutRelativeHeartRateTargetV1
+  | WorkoutAbsolutePowerTargetV1
+  | WorkoutRelativePowerTargetV1
+  | WorkoutAbsoluteSpeedTargetV1
+  | WorkoutRelativeSpeedTargetV1
+  | WorkoutAbsoluteCadenceTargetV1
+  | WorkoutRelativeCadenceTargetV1;
+
+export interface WorkoutStepV1 {
+  kind: 'step';
+  id: string;
+  purpose: WorkoutStepPurposeV1;
+  ending: WorkoutEndingV1;
+  targets: WorkoutTargetV1[];
+  note?: string;
+}
+
+export interface WorkoutRepeatV1 {
+  kind: 'repeat';
+  id: string;
+  count: number;
+  steps: WorkoutStepV1[];
+}
+
+export type WorkoutNodeV1 = WorkoutStepV1 | WorkoutRepeatV1;
+
+export interface WorkoutStructureV1 {
+  version: typeof WORKOUT_STRUCTURE_VERSION;
+  sport: ActivityTypes;
+  nodes: WorkoutNodeV1[];
+}
+
+export interface WorkoutStructureValidationIssue {
+  code:
+    | 'invalid_type'
+    | 'invalid_value'
+    | 'unsupported_version'
+    | 'unknown_field'
+    | 'unknown_discriminant'
+    | 'duplicate_id'
+    | 'limit_exceeded'
+    | 'inverted_range';
+  path: string;
+  message: string;
+}
+
+export class WorkoutStructureValidationError extends Error {
+  readonly issues: WorkoutStructureValidationIssue[];
+
+  constructor(issues: WorkoutStructureValidationIssue[]) {
+    super(issues.map(issue => `${issue.path}: ${issue.message}`).join('; '));
+    this.name = 'WorkoutStructureValidationError';
+    this.issues = issues;
+  }
+}
+
+export interface WorkoutCompatibilityProfileV1 {
+  sports?: readonly ActivityTypes[];
+  endingKinds: readonly WorkoutEndingKindV1[];
+  targetKinds: readonly WorkoutTargetKindV1[];
+  supportsRepeats: boolean;
+  supportsRelativeTargets: boolean;
+  maxNodes?: number;
+  maxRepeatCount?: number;
+  maxTargetsPerStep?: number;
+}
+
+export interface WorkoutCompatibilityIssueV1 {
+  code:
+    | 'unsupported_sport'
+    | 'unsupported_repeat'
+    | 'unsupported_ending'
+    | 'unsupported_target'
+    | 'unsupported_relative_target'
+    | 'provider_limit_exceeded';
+  path: string;
+  message: string;
+}
+
+export interface WorkoutCompatibilityResultV1 {
+  compatible: boolean;
+  issues: WorkoutCompatibilityIssueV1[];
+}
+
+export const INITIAL_MANUAL_WORKOUT_EDITOR_PROFILE_V1: WorkoutCompatibilityProfileV1 = {
+  sports: [ActivityTypes.Running, ActivityTypes.Cycling],
+  endingKinds: ['time', 'distance'],
+  targetKinds: ['heart-rate', 'power', 'speed'],
+  supportsRepeats: true,
+  supportsRelativeTargets: false,
+  maxNodes: WORKOUT_STRUCTURE_MAX_NODES,
+  maxRepeatCount: WORKOUT_STRUCTURE_MAX_REPEAT_COUNT,
+  maxTargetsPerStep: 1,
+};
+
+interface ParseContext {
+  issues: WorkoutStructureValidationIssue[];
+  ids: Set<string>;
+  nodeCount: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function pushIssue(
+  context: ParseContext,
+  code: WorkoutStructureValidationIssue['code'],
+  path: string,
+  message: string,
+): void {
+  context.issues.push({ code, path, message });
+}
+
+function readRecord(value: unknown, path: string, context: ParseContext): Record<string, unknown> | null {
+  if (!isRecord(value)) {
+    pushIssue(context, 'invalid_type', path, 'Expected an object.');
+    return null;
+  }
+  return value;
+}
+
+function rejectUnknownFields(
+  value: Record<string, unknown>,
+  allowedFields: readonly string[],
+  path: string,
+  context: ParseContext,
+): void {
+  for (const field of Object.keys(value)) {
+    if (!allowedFields.includes(field)) {
+      pushIssue(context, 'unknown_field', `${path}.${field}`, 'Unknown field.');
+    }
+  }
+}
+
+function readEnum<T extends string>(
+  value: unknown,
+  allowedValues: readonly T[],
+  path: string,
+  context: ParseContext,
+): T | null {
+  if (typeof value !== 'string' || !allowedValues.includes(value as T)) {
+    pushIssue(context, 'unknown_discriminant', path, `Expected one of: ${allowedValues.join(', ')}.`);
+    return null;
+  }
+  return value as T;
+}
+
+function readPositiveNumber(
+  value: unknown,
+  path: string,
+  context: ParseContext,
+  validate?: (candidate: number) => boolean,
+): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0 || validate?.(value) === false) {
+    pushIssue(context, 'invalid_value', path, 'Expected a finite positive number.');
+    return null;
+  }
+  return value;
+}
+
+function readNonNegativeNumber(
+  value: unknown,
+  path: string,
+  context: ParseContext,
+  validate?: (candidate: number) => boolean,
+): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || validate?.(value) === false) {
+    pushIssue(context, 'invalid_value', path, 'Expected a finite non-negative number.');
+    return null;
+  }
+  return value;
+}
+
+function readPositiveInteger(
+  value: unknown,
+  path: string,
+  context: ParseContext,
+  maximum?: number,
+): number | null {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+    pushIssue(context, 'invalid_value', path, 'Expected a positive integer.');
+    return null;
+  }
+  if (maximum !== undefined && value > maximum) {
+    pushIssue(context, 'limit_exceeded', path, `Must be at most ${maximum}.`);
+    return null;
+  }
+  return value;
+}
+
+function sportsLibScalarValidator<T extends { isValueTypeValid(value: unknown): boolean }>(
+  DataType: new (value: number) => T,
+): (candidate: number) => boolean {
+  return candidate => {
+    try {
+      const instance = new DataType(candidate);
+      return instance.isValueTypeValid(candidate);
+    } catch {
+      return false;
+    }
+  };
+}
+
+const validDuration = sportsLibScalarValidator(DataDuration);
+const validDistance = sportsLibScalarValidator(DataDistance);
+const validHeartRate = sportsLibScalarValidator(DataHeartRate);
+const validPower = sportsLibScalarValidator(DataPower);
+const validSpeed = sportsLibScalarValidator(DataSpeed);
+const validCadence = sportsLibScalarValidator(DataCadence);
+const validPowerWork = sportsLibScalarValidator(DataPowerWork);
+
+function readNodeId(value: unknown, path: string, context: ParseContext): string | null {
+  if (
+    typeof value !== 'string'
+    || value.length > WORKOUT_NODE_ID_MAX_LENGTH
+    || !WORKOUT_NODE_ID_PATTERN.test(value)
+  ) {
+    pushIssue(
+      context,
+      'invalid_value',
+      path,
+      `Expected ${WORKOUT_NODE_ID_PATTERN.source} and at most ${WORKOUT_NODE_ID_MAX_LENGTH} characters.`,
+    );
+    return null;
+  }
+
+  if (context.ids.has(value)) {
+    pushIssue(context, 'duplicate_id', path, `Duplicate node ID "${value}".`);
+    return null;
+  }
+
+  context.ids.add(value);
+  return value;
+}
+
+function readRange(
+  minimum: number | null,
+  maximum: number | null,
+  minimumPath: string,
+  maximumPath: string,
+  context: ParseContext,
+): boolean {
+  if (minimum === null || maximum === null) {
+    return false;
+  }
+  if (minimum > maximum) {
+    pushIssue(
+      context,
+      'inverted_range',
+      maximumPath,
+      `Must be greater than or equal to ${minimumPath}.`,
+    );
+    return false;
+  }
+  return true;
+}
+
+function parseEnding(value: unknown, path: string, context: ParseContext): WorkoutEndingV1 | null {
+  const record = readRecord(value, path, context);
+  if (!record) return null;
+  const kind = readEnum(record.kind, WORKOUT_ENDING_KINDS, `${path}.kind`, context);
+  if (!kind) return null;
+
+  switch (kind) {
+    case 'time': {
+      rejectUnknownFields(record, ['kind', 'seconds'], path, context);
+      const seconds = readPositiveNumber(record.seconds, `${path}.seconds`, context, validDuration);
+      return seconds === null ? null : { kind, seconds };
+    }
+    case 'distance': {
+      rejectUnknownFields(record, ['kind', 'meters'], path, context);
+      const meters = readPositiveNumber(record.meters, `${path}.meters`, context, validDistance);
+      return meters === null ? null : { kind, meters };
+    }
+    case 'kilojoules': {
+      rejectUnknownFields(record, ['kind', 'kilojoules'], path, context);
+      const kilojoules = readPositiveNumber(record.kilojoules, `${path}.kilojoules`, context, validPowerWork);
+      return kilojoules === null ? null : { kind, kilojoules };
+    }
+    case 'repetitions': {
+      rejectUnknownFields(record, ['kind', 'repetitions'], path, context);
+      const repetitions = readPositiveInteger(record.repetitions, `${path}.repetitions`, context);
+      return repetitions === null ? null : { kind, repetitions };
+    }
+    case 'manual':
+      rejectUnknownFields(record, ['kind'], path, context);
+      return { kind };
+  }
+}
+
+function parseRelativeRange(
+  record: Record<string, unknown>,
+  path: string,
+  context: ParseContext,
+): { minimumPercent: number; maximumPercent: number } | null {
+  const minimumPercent = readNonNegativeNumber(record.minimumPercent, `${path}.minimumPercent`, context);
+  const maximumPercent = readNonNegativeNumber(record.maximumPercent, `${path}.maximumPercent`, context);
+  return readRange(
+    minimumPercent,
+    maximumPercent,
+    `${path}.minimumPercent`,
+    `${path}.maximumPercent`,
+    context,
+  ) ? { minimumPercent: minimumPercent!, maximumPercent: maximumPercent! } : null;
+}
+
+function parseTarget(value: unknown, path: string, context: ParseContext): WorkoutTargetV1 | null {
+  const record = readRecord(value, path, context);
+  if (!record) return null;
+  const kind = readEnum(record.kind, WORKOUT_TARGET_KINDS, `${path}.kind`, context);
+  const mode = readEnum(record.mode, ['absolute', 'relative'], `${path}.mode`, context);
+  if (!kind || !mode) return null;
+
+  if (kind === 'heart-rate' && mode === 'absolute') {
+    rejectUnknownFields(record, ['kind', 'mode', 'minimumBpm', 'maximumBpm'], path, context);
+    const minimumBpm = readNonNegativeNumber(record.minimumBpm, `${path}.minimumBpm`, context, validHeartRate);
+    const maximumBpm = readNonNegativeNumber(record.maximumBpm, `${path}.maximumBpm`, context, validHeartRate);
+    return readRange(minimumBpm, maximumBpm, `${path}.minimumBpm`, `${path}.maximumBpm`, context)
+      ? { kind, mode, minimumBpm: minimumBpm!, maximumBpm: maximumBpm! }
+      : null;
+  }
+
+  if (kind === 'power' && mode === 'absolute') {
+    rejectUnknownFields(record, ['kind', 'mode', 'minimumWatts', 'maximumWatts'], path, context);
+    const minimumWatts = readNonNegativeNumber(record.minimumWatts, `${path}.minimumWatts`, context, validPower);
+    const maximumWatts = readNonNegativeNumber(record.maximumWatts, `${path}.maximumWatts`, context, validPower);
+    return readRange(minimumWatts, maximumWatts, `${path}.minimumWatts`, `${path}.maximumWatts`, context)
+      ? { kind, mode, minimumWatts: minimumWatts!, maximumWatts: maximumWatts! }
+      : null;
+  }
+
+  if (kind === 'speed' && mode === 'absolute') {
+    rejectUnknownFields(
+      record,
+      ['kind', 'mode', 'minimumMetersPerSecond', 'maximumMetersPerSecond', 'presentation'],
+      path,
+      context,
+    );
+    const minimumMetersPerSecond = readNonNegativeNumber(
+      record.minimumMetersPerSecond,
+      `${path}.minimumMetersPerSecond`,
+      context,
+      validSpeed,
+    );
+    const maximumMetersPerSecond = readNonNegativeNumber(
+      record.maximumMetersPerSecond,
+      `${path}.maximumMetersPerSecond`,
+      context,
+      validSpeed,
+    );
+    const presentation = readEnum(record.presentation, ['pace', 'speed'], `${path}.presentation`, context);
+    const rangeIsValid = readRange(
+      minimumMetersPerSecond,
+      maximumMetersPerSecond,
+      `${path}.minimumMetersPerSecond`,
+      `${path}.maximumMetersPerSecond`,
+      context,
+    );
+    if (presentation === 'pace' && (minimumMetersPerSecond === 0 || maximumMetersPerSecond === 0)) {
+      pushIssue(context, 'invalid_value', path, 'Pace targets require positive speed bounds.');
+      return null;
+    }
+    return presentation && rangeIsValid
+      ? { kind, mode, minimumMetersPerSecond: minimumMetersPerSecond!, maximumMetersPerSecond: maximumMetersPerSecond!, presentation }
+      : null;
+  }
+
+  if (kind === 'cadence' && mode === 'absolute') {
+    rejectUnknownFields(record, ['kind', 'mode', 'minimumRpm', 'maximumRpm'], path, context);
+    const minimumRpm = readNonNegativeNumber(record.minimumRpm, `${path}.minimumRpm`, context, validCadence);
+    const maximumRpm = readNonNegativeNumber(record.maximumRpm, `${path}.maximumRpm`, context, validCadence);
+    return readRange(minimumRpm, maximumRpm, `${path}.minimumRpm`, `${path}.maximumRpm`, context)
+      ? { kind, mode, minimumRpm: minimumRpm!, maximumRpm: maximumRpm! }
+      : null;
+  }
+
+  const relativeRange = parseRelativeRange(record, path, context);
+  const reference = readRecord(record.reference, `${path}.reference`, context);
+  if (mode !== 'relative' || !relativeRange || !reference) return null;
+
+  if (kind === 'heart-rate') {
+    rejectUnknownFields(record, ['kind', 'mode', 'minimumPercent', 'maximumPercent', 'reference'], path, context);
+    rejectUnknownFields(reference, ['kind', 'bpm'], `${path}.reference`, context);
+    const referenceKind = readEnum(
+      reference.kind,
+      ['max-heart-rate', 'threshold-heart-rate'],
+      `${path}.reference.kind`,
+      context,
+    );
+    const bpm = readPositiveNumber(reference.bpm, `${path}.reference.bpm`, context, validHeartRate);
+    return referenceKind && bpm !== null
+      ? { kind, mode: 'relative', ...relativeRange, reference: { kind: referenceKind, bpm } }
+      : null;
+  }
+
+  if (kind === 'power') {
+    rejectUnknownFields(record, ['kind', 'mode', 'minimumPercent', 'maximumPercent', 'reference'], path, context);
+    rejectUnknownFields(reference, ['kind', 'watts'], `${path}.reference`, context);
+    const referenceKind = readEnum(
+      reference.kind,
+      ['functional-threshold-power', 'critical-power'],
+      `${path}.reference.kind`,
+      context,
+    );
+    const watts = readPositiveNumber(reference.watts, `${path}.reference.watts`, context, validPower);
+    return referenceKind && watts !== null
+      ? { kind, mode: 'relative', ...relativeRange, reference: { kind: referenceKind, watts } }
+      : null;
+  }
+
+  if (kind === 'speed') {
+    rejectUnknownFields(
+      record,
+      ['kind', 'mode', 'minimumPercent', 'maximumPercent', 'presentation', 'reference'],
+      path,
+      context,
+    );
+    rejectUnknownFields(reference, ['kind', 'metersPerSecond'], `${path}.reference`, context);
+    const presentation = readEnum(record.presentation, ['pace', 'speed'], `${path}.presentation`, context);
+    const referenceKind = readEnum(reference.kind, ['threshold-speed'], `${path}.reference.kind`, context);
+    const metersPerSecond = readPositiveNumber(
+      reference.metersPerSecond,
+      `${path}.reference.metersPerSecond`,
+      context,
+      validSpeed,
+    );
+    return presentation && referenceKind && metersPerSecond !== null
+      ? { kind, mode: 'relative', ...relativeRange, presentation, reference: { kind: referenceKind, metersPerSecond } }
+      : null;
+  }
+
+  rejectUnknownFields(record, ['kind', 'mode', 'minimumPercent', 'maximumPercent', 'reference'], path, context);
+  rejectUnknownFields(reference, ['kind', 'rpm'], `${path}.reference`, context);
+  const referenceKind = readEnum(reference.kind, ['preferred-cadence'], `${path}.reference.kind`, context);
+  const rpm = readPositiveNumber(reference.rpm, `${path}.reference.rpm`, context, validCadence);
+  return referenceKind && rpm !== null
+    ? { kind, mode: 'relative', ...relativeRange, reference: { kind: referenceKind, rpm } }
+    : null;
+}
+
+function parseStep(value: unknown, path: string, context: ParseContext): WorkoutStepV1 | null {
+  const record = readRecord(value, path, context);
+  if (!record) return null;
+  rejectUnknownFields(record, ['kind', 'id', 'purpose', 'ending', 'targets', 'note'], path, context);
+  if (record.kind !== 'step') {
+    pushIssue(context, 'unknown_discriminant', `${path}.kind`, 'Expected step. Nested repeats are not supported.');
+    return null;
+  }
+
+  context.nodeCount += 1;
+  const id = readNodeId(record.id, `${path}.id`, context);
+  const purpose = readEnum(record.purpose, WORKOUT_STEP_PURPOSES, `${path}.purpose`, context);
+  const ending = parseEnding(record.ending, `${path}.ending`, context);
+
+  let targets: WorkoutTargetV1[] | null = null;
+  let expectedTargetCount: number | null = null;
+  if (!Array.isArray(record.targets)) {
+    pushIssue(context, 'invalid_type', `${path}.targets`, 'Expected an array.');
+  } else if (record.targets.length > WORKOUT_STRUCTURE_MAX_TARGETS_PER_STEP) {
+    pushIssue(
+      context,
+      'limit_exceeded',
+      `${path}.targets`,
+      `A step may contain at most ${WORKOUT_STRUCTURE_MAX_TARGETS_PER_STEP} targets.`,
+    );
+  } else {
+    expectedTargetCount = record.targets.length;
+    targets = record.targets
+      .map((target, index) => parseTarget(target, `${path}.targets[${index}]`, context))
+      .filter((target): target is WorkoutTargetV1 => target !== null);
+    const uniqueKinds = new Set(targets.map(target => target.kind));
+    if (uniqueKinds.size !== targets.length) {
+      pushIssue(context, 'invalid_value', `${path}.targets`, 'Target kinds must be unique within a step.');
+    }
+  }
+
+  let note: string | undefined;
+  if (record.note !== undefined) {
+    if (typeof record.note !== 'string' || record.note.trim().length === 0 || record.note.length > WORKOUT_NOTE_MAX_LENGTH) {
+      pushIssue(
+        context,
+        'invalid_value',
+        `${path}.note`,
+        `Expected a non-empty string of at most ${WORKOUT_NOTE_MAX_LENGTH} characters.`,
+      );
+    } else {
+      note = record.note.trim();
+    }
+  }
+
+  if (!id || !purpose || !ending || !targets || targets.length !== expectedTargetCount) {
+    return null;
+  }
+
+  return note === undefined
+    ? { kind: 'step', id, purpose, ending, targets }
+    : { kind: 'step', id, purpose, ending, targets, note };
+}
+
+function parseNode(value: unknown, path: string, context: ParseContext): WorkoutNodeV1 | null {
+  const record = readRecord(value, path, context);
+  if (!record) return null;
+
+  if (record.kind === 'step') {
+    return parseStep(record, path, context);
+  }
+  if (record.kind !== 'repeat') {
+    pushIssue(context, 'unknown_discriminant', `${path}.kind`, 'Expected step or repeat.');
+    return null;
+  }
+
+  rejectUnknownFields(record, ['kind', 'id', 'count', 'steps'], path, context);
+  context.nodeCount += 1;
+  const id = readNodeId(record.id, `${path}.id`, context);
+  const count = readPositiveInteger(record.count, `${path}.count`, context, WORKOUT_STRUCTURE_MAX_REPEAT_COUNT);
+  let steps: WorkoutStepV1[] | null = null;
+  let expectedStepCount: number | null = null;
+  if (!Array.isArray(record.steps) || record.steps.length === 0) {
+    pushIssue(context, 'invalid_type', `${path}.steps`, 'Expected a non-empty array of steps.');
+  } else {
+    expectedStepCount = record.steps.length;
+    steps = record.steps
+      .map((step, index) => parseStep(step, `${path}.steps[${index}]`, context))
+      .filter((step): step is WorkoutStepV1 => step !== null);
+  }
+
+  return id && count !== null && steps && steps.length === expectedStepCount
+    ? { kind: 'repeat', id, count, steps }
+    : null;
+}
+
+export function parseWorkoutStructureV1(value: unknown): WorkoutStructureV1 {
+  const context: ParseContext = { issues: [], ids: new Set(), nodeCount: 0 };
+  const record = readRecord(value, '$', context);
+  if (!record) throw new WorkoutStructureValidationError(context.issues);
+  rejectUnknownFields(record, ['version', 'sport', 'nodes'], '$', context);
+
+  if (record.version !== WORKOUT_STRUCTURE_VERSION) {
+    pushIssue(
+      context,
+      'unsupported_version',
+      '$.version',
+      `Only workout structure version ${WORKOUT_STRUCTURE_VERSION} is supported.`,
+    );
+  }
+
+  const sport = ActivityTypesHelper.resolveActivityType(record.sport);
+  if (!sport || sport === ActivityTypes.unknown) {
+    pushIssue(context, 'invalid_value', '$.sport', 'Expected a supported canonical activity type or alias.');
+  }
+
+  let nodes: WorkoutNodeV1[] = [];
+  let expectedNodeCount: number | null = null;
+  if (!Array.isArray(record.nodes) || record.nodes.length === 0) {
+    pushIssue(context, 'invalid_type', '$.nodes', 'Expected a non-empty array.');
+  } else {
+    expectedNodeCount = record.nodes.length;
+    nodes = record.nodes
+      .map((node, index) => parseNode(node, `$.nodes[${index}]`, context))
+      .filter((node): node is WorkoutNodeV1 => node !== null);
+  }
+
+  if (context.nodeCount > WORKOUT_STRUCTURE_MAX_NODES) {
+    pushIssue(
+      context,
+      'limit_exceeded',
+      '$.nodes',
+      `Workout structures may contain at most ${WORKOUT_STRUCTURE_MAX_NODES} nodes including repeated steps.`,
+    );
+  }
+
+  if (context.issues.length > 0 || !sport || nodes.length !== expectedNodeCount) {
+    throw new WorkoutStructureValidationError(context.issues);
+  }
+
+  return { version: WORKOUT_STRUCTURE_VERSION, sport, nodes };
+}
+
+export function normalizeWorkoutStructureV1(value: unknown): WorkoutStructureV1 {
+  return parseWorkoutStructureV1(value);
+}
+
+export function serializeWorkoutStructureV1(value: unknown): string {
+  return JSON.stringify(parseWorkoutStructureV1(value));
+}
+
+export function deserializeWorkoutStructureV1(value: string): WorkoutStructureV1 {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value) as unknown;
+  } catch {
+    throw new WorkoutStructureValidationError([{
+      code: 'invalid_type',
+      path: '$',
+      message: 'Expected valid JSON.',
+    }]);
+  }
+  return parseWorkoutStructureV1(parsed);
+}
+
+export function toFirestoreWorkoutStructureV1(value: unknown): WorkoutStructureV1 {
+  return JSON.parse(serializeWorkoutStructureV1(value)) as WorkoutStructureV1;
+}
+
+export function countWorkoutStructureNodesV1(structure: WorkoutStructureV1): number {
+  return structure.nodes.reduce((total, node) => total + (node.kind === 'repeat' ? 1 + node.steps.length : 1), 0);
+}
+
+export function evaluateWorkoutCompatibilityV1(
+  value: unknown,
+  profile: WorkoutCompatibilityProfileV1,
+): WorkoutCompatibilityResultV1 {
+  const structure = parseWorkoutStructureV1(value);
+  const issues: WorkoutCompatibilityIssueV1[] = [];
+  const maxNodes = profile.maxNodes ?? WORKOUT_STRUCTURE_MAX_NODES;
+  const maxRepeatCount = profile.maxRepeatCount ?? WORKOUT_STRUCTURE_MAX_REPEAT_COUNT;
+  const maxTargetsPerStep = profile.maxTargetsPerStep ?? WORKOUT_STRUCTURE_MAX_TARGETS_PER_STEP;
+
+  if (profile.sports && !profile.sports.includes(structure.sport)) {
+    issues.push({
+      code: 'unsupported_sport',
+      path: '$.sport',
+      message: `${structure.sport} is not supported by this capability profile.`,
+    });
+  }
+
+  if (countWorkoutStructureNodesV1(structure) > maxNodes) {
+    issues.push({
+      code: 'provider_limit_exceeded',
+      path: '$.nodes',
+      message: `This capability profile supports at most ${maxNodes} nodes.`,
+    });
+  }
+
+  const checkStep = (step: WorkoutStepV1, path: string): void => {
+    if (!profile.endingKinds.includes(step.ending.kind)) {
+      issues.push({
+        code: 'unsupported_ending',
+        path: `${path}.ending`,
+        message: `${step.ending.kind} endings are not supported by this capability profile.`,
+      });
+    }
+    if (step.targets.length > maxTargetsPerStep) {
+      issues.push({
+        code: 'provider_limit_exceeded',
+        path: `${path}.targets`,
+        message: `This capability profile supports at most ${maxTargetsPerStep} targets per step.`,
+      });
+    }
+    step.targets.forEach((target, targetIndex) => {
+      if (!profile.targetKinds.includes(target.kind)) {
+        issues.push({
+          code: 'unsupported_target',
+          path: `${path}.targets[${targetIndex}]`,
+          message: `${target.kind} targets are not supported by this capability profile.`,
+        });
+      }
+      if (target.mode === 'relative' && !profile.supportsRelativeTargets) {
+        issues.push({
+          code: 'unsupported_relative_target',
+          path: `${path}.targets[${targetIndex}]`,
+          message: 'Relative targets are not supported by this capability profile.',
+        });
+      }
+    });
+  };
+
+  structure.nodes.forEach((node, nodeIndex) => {
+    const path = `$.nodes[${nodeIndex}]`;
+    if (node.kind === 'step') {
+      checkStep(node, path);
+      return;
+    }
+    if (!profile.supportsRepeats) {
+      issues.push({ code: 'unsupported_repeat', path, message: 'Repeats are not supported by this capability profile.' });
+    }
+    if (node.count > maxRepeatCount) {
+      issues.push({
+        code: 'provider_limit_exceeded',
+        path: `${path}.count`,
+        message: `This capability profile supports repeat counts up to ${maxRepeatCount}.`,
+      });
+    }
+    node.steps.forEach((step, stepIndex) => checkStep(step, `${path}.steps[${stepIndex}]`));
+  });
+
+  return { compatible: issues.length === 0, issues };
+}
+
+function formatRange(minimum: string, maximum: string): string {
+  return minimum === maximum ? minimum : `${minimum}–${maximum}`;
+}
+
+function formatDisplayRange(
+  minimum: UnitAwareStatDisplay | null,
+  maximum: UnitAwareStatDisplay | null,
+): string | null {
+  if (!minimum || !maximum) return null;
+  if (minimum.unit === maximum.unit) {
+    return `${formatRange(minimum.value, maximum.value)}${minimum.unit ? ` ${minimum.unit}` : ''}`;
+  }
+  return formatRange(minimum.text, maximum.text);
+}
+
+function formatSpeedValue(
+  metersPerSecond: number,
+  presentation: WorkoutSpeedPresentationV1,
+  unitSettings?: UserUnitSettingsInterface | null,
+): UnitAwareStatDisplay | null {
+  const paceSecondsPerKilometer = Math.round((1000 / metersPerSecond) * 1000) / 1000;
+  return presentation === 'pace'
+    ? resolveUnitAwareDisplayFromValue(DataPace.type, paceSecondsPerKilometer, unitSettings)
+    : resolveUnitAwareDisplayFromValue(DataSpeed.type, metersPerSecond, unitSettings);
+}
+
+export function formatWorkoutEndingV1(
+  ending: WorkoutEndingV1,
+  unitSettings?: UserUnitSettingsInterface | null,
+  locale?: string,
+): string {
+  switch (ending.kind) {
+    case 'time':
+      return resolveUnitAwareDisplayFromValue(DataDuration.type, ending.seconds, unitSettings)?.text ?? `${ending.seconds} s`;
+    case 'distance':
+      return resolveUnitAwareDisplayFromValue(DataDistance.type, ending.meters, unitSettings)?.text ?? `${ending.meters} m`;
+    case 'kilojoules':
+      return resolveUnitAwareDisplayFromValue(DataPowerWork.type, ending.kilojoules, unitSettings)?.text
+        ?? `${ending.kilojoules} kJ`;
+    case 'repetitions':
+      return `${new Intl.NumberFormat(locale).format(ending.repetitions)} rep${ending.repetitions === 1 ? '' : 's'}`;
+    case 'manual':
+      return 'Manual transition';
+  }
+}
+
+function formatPercentRange(minimum: number, maximum: number, locale?: string): string {
+  const formatter = new Intl.NumberFormat(locale, { maximumFractionDigits: 2 });
+  return `${formatRange(formatter.format(minimum), formatter.format(maximum))}%`;
+}
+
+export function formatWorkoutTargetV1(
+  target: WorkoutTargetV1,
+  unitSettings?: UserUnitSettingsInterface | null,
+  locale?: string,
+): string {
+  if (target.mode === 'absolute') {
+    switch (target.kind) {
+      case 'heart-rate':
+        return formatDisplayRange(
+          resolveUnitAwareDisplayFromValue(DataHeartRate.type, target.minimumBpm, unitSettings),
+          resolveUnitAwareDisplayFromValue(DataHeartRate.type, target.maximumBpm, unitSettings),
+        ) ?? `${target.minimumBpm}–${target.maximumBpm} bpm`;
+      case 'power':
+        return formatDisplayRange(
+          resolveUnitAwareDisplayFromValue(DataPower.type, target.minimumWatts, unitSettings),
+          resolveUnitAwareDisplayFromValue(DataPower.type, target.maximumWatts, unitSettings),
+        ) ?? `${target.minimumWatts}–${target.maximumWatts} W`;
+      case 'speed':
+        return formatDisplayRange(
+          formatSpeedValue(
+            target.presentation === 'pace' ? target.maximumMetersPerSecond : target.minimumMetersPerSecond,
+            target.presentation,
+            unitSettings,
+          ),
+          formatSpeedValue(
+            target.presentation === 'pace' ? target.minimumMetersPerSecond : target.maximumMetersPerSecond,
+            target.presentation,
+            unitSettings,
+          ),
+        ) ?? `${target.minimumMetersPerSecond}–${target.maximumMetersPerSecond} m/s`;
+      case 'cadence':
+        return formatDisplayRange(
+          resolveUnitAwareDisplayFromValue(DataCadence.type, target.minimumRpm, unitSettings),
+          resolveUnitAwareDisplayFromValue(DataCadence.type, target.maximumRpm, unitSettings),
+        ) ?? `${target.minimumRpm}–${target.maximumRpm} rpm`;
+    }
+  }
+
+  const percent = formatPercentRange(target.minimumPercent, target.maximumPercent, locale);
+  switch (target.kind) {
+    case 'heart-rate': {
+      const reference = resolveUnitAwareDisplayFromValue(DataHeartRate.type, target.reference.bpm, unitSettings)?.text
+        ?? `${target.reference.bpm} bpm`;
+      const label = target.reference.kind === 'max-heart-rate' ? 'max HR' : 'threshold HR';
+      return `${percent} of ${reference} ${label}`;
+    }
+    case 'power': {
+      const reference = resolveUnitAwareDisplayFromValue(DataPower.type, target.reference.watts, unitSettings)?.text
+        ?? `${target.reference.watts} W`;
+      const label = target.reference.kind === 'functional-threshold-power' ? 'FTP' : 'critical power';
+      return `${percent} of ${reference} ${label}`;
+    }
+    case 'speed': {
+      const reference = formatSpeedValue(target.reference.metersPerSecond, target.presentation, unitSettings)?.text
+        ?? `${target.reference.metersPerSecond} m/s`;
+      return `${percent} of ${reference} threshold ${target.presentation}`;
+    }
+    case 'cadence': {
+      const reference = resolveUnitAwareDisplayFromValue(DataCadence.type, target.reference.rpm, unitSettings)?.text
+        ?? `${target.reference.rpm} rpm`;
+      return `${percent} of ${reference} preferred cadence`;
+    }
+  }
+}
+
+export function formatWorkoutStepV1(
+  step: WorkoutStepV1,
+  unitSettings?: UserUnitSettingsInterface | null,
+  locale?: string,
+): string {
+  const purpose = step.purpose === 'other'
+    ? 'Step'
+    : `${step.purpose.charAt(0).toUpperCase()}${step.purpose.slice(1)}`;
+  const ending = formatWorkoutEndingV1(step.ending, unitSettings, locale);
+  const targets = step.targets.map(target => formatWorkoutTargetV1(target, unitSettings, locale));
+  return [purpose, ending, ...targets].join(' · ');
+}

--- a/shared/training-planning-rollout.ts
+++ b/shared/training-planning-rollout.ts
@@ -1,0 +1,15 @@
+/**
+ * Presentation-only rollout for the authenticated Training Planning navigation
+ * entry. This is not an authorization boundary: owner-scoped APIs and the
+ * `/plans` route remain available when opened directly. Broader rollout is
+ * tracked by #655.
+ */
+export const TRAINING_PLANNING_NAVIGATION_ALLOWED_UIDS: readonly string[] = [
+  'xcsAolLDDTWTgtRN9eYF3lW2YKL2',
+];
+
+export function isTrainingPlanningNavigationUIDAllowed(uid: string | null | undefined): boolean {
+  const normalizedUID = typeof uid === 'string' ? uid.trim() : '';
+  return normalizedUID.length > 0
+    && TRAINING_PLANNING_NAVIGATION_ALLOWED_UIDS.includes(normalizedUID);
+}

--- a/shared/training-plans.ts
+++ b/shared/training-plans.ts
@@ -114,8 +114,11 @@ export interface CreateScheduledWorkoutMutationV1 {
 export interface UpdateScheduledWorkoutMutationV1 {
   kind: 'update-workout';
   workoutId: string;
+  planId: string | null;
+  localDate: string;
   title: string;
   structure: WorkoutStructureV1;
+  confirmPlanRangeExtension: boolean;
 }
 
 export interface MoveScheduledWorkoutMutationV1 {
@@ -293,6 +296,17 @@ function readInteger(value: unknown, path: string, minimum = 0): number {
   return value as number;
 }
 
+function readCurrentWorkoutCount(value: unknown, path: string): number {
+  const count = readInteger(value, path);
+  if (count > TRAINING_PLAN_MAX_CURRENT_WORKOUTS) {
+    throw new TrainingPlanContractError(
+      path,
+      `Expected at most ${TRAINING_PLAN_MAX_CURRENT_WORKOUTS} current workouts.`,
+    );
+  }
+  return count;
+}
+
 function readTimestampMs(value: unknown, path: string): number {
   if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
     throw new TrainingPlanContractError(path, 'Expected a non-negative millisecond timestamp.');
@@ -384,7 +398,7 @@ export function parseTrainingPlanStateV1(value: unknown): TrainingPlanStateV1 {
     schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
     activePlanId: readNullableEntityId(record.activePlanId, '$.activePlanId'),
     revision: readInteger(record.revision, '$.revision'),
-    currentWorkoutCount: readInteger(record.currentWorkoutCount, '$.currentWorkoutCount'),
+    currentWorkoutCount: readCurrentWorkoutCount(record.currentWorkoutCount, '$.currentWorkoutCount'),
     updatedAtMs: readTimestampMs(record.updatedAtMs, '$.updatedAtMs'),
   };
 }
@@ -415,7 +429,7 @@ export function parseTrainingPlanV1(value: unknown): TrainingPlanV1 {
     endLocalDate,
     revision,
     lastCheckpointRevision,
-    workoutCount: readInteger(record.workoutCount, '$.workoutCount'),
+    workoutCount: readCurrentWorkoutCount(record.workoutCount, '$.workoutCount'),
     createdAtMs: readTimestampMs(record.createdAtMs, '$.createdAtMs'),
     updatedAtMs: readTimestampMs(record.updatedAtMs, '$.updatedAtMs'),
   };
@@ -567,10 +581,15 @@ export function parseMutateTrainingScheduleRequestV1(value: unknown): MutateTrai
       break;
     }
     case 'update-workout':
-      rejectUnknownFields(operationRecord, ['kind', 'workoutId', 'title', 'structure'], '$.operation');
+      rejectUnknownFields(
+        operationRecord,
+        ['kind', 'workoutId', 'planId', 'localDate', 'title', 'structure', 'confirmPlanRangeExtension'],
+        '$.operation',
+      );
       operation = {
         kind,
         workoutId: readEntityId(operationRecord.workoutId, '$.operation.workoutId'),
+        ...parseWorkoutDestinationFields(operationRecord),
         title: readString(operationRecord.title, '$.operation.title', 120),
         structure: parseWorkoutStructureV1(operationRecord.structure),
       };

--- a/shared/training-plans.ts
+++ b/shared/training-plans.ts
@@ -1,0 +1,662 @@
+import {
+  parseWorkoutStructureV1,
+  type WorkoutStructureV1,
+} from './planned-workout';
+
+export const TRAINING_PLAN_SCHEMA_VERSION = 1 as const;
+export const TRAINING_PLAN_MAX_DAYS = 366;
+export const TRAINING_PLAN_MAX_CURRENT_WORKOUTS = 400;
+export const TRAINING_PLAN_CHECKPOINT_INTERVAL = 20;
+
+export const TRAINING_PLAN_STATE_COLLECTION_ID = 'trainingPlanState';
+export const TRAINING_PLAN_STATE_DOCUMENT_ID = 'current';
+export const TRAINING_PLAN_STATE_DOCUMENT_PATH = `${TRAINING_PLAN_STATE_COLLECTION_ID}/${TRAINING_PLAN_STATE_DOCUMENT_ID}`;
+export const TRAINING_PLANS_COLLECTION_ID = 'trainingPlans';
+export const SCHEDULED_WORKOUTS_COLLECTION_ID = 'scheduledWorkouts';
+export const TRAINING_PLAN_REVISIONS_COLLECTION_ID = 'revisions';
+export const TRAINING_PLAN_MUTATION_RECEIPTS_COLLECTION_ID = 'mutationReceipts';
+export const TRAINING_PLAN_DELETION_LOCKS_COLLECTION_ID = 'planDeletionLocks';
+export const TRAINING_SCHEDULE_DELETION_TOMBSTONES_COLLECTION_ID = 'deletionTombstones';
+
+const ENTITY_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
+const MUTATION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9:_-]{0,127}$/;
+const LOCAL_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+export const TRAINING_PLAN_LIFECYCLES = ['active', 'paused', 'archived'] as const;
+export type TrainingPlanLifecycle = typeof TRAINING_PLAN_LIFECYCLES[number];
+
+export const SCHEDULED_WORKOUT_LIFECYCLES = ['planned', 'skipped', 'deleted'] as const;
+export type ScheduledWorkoutLifecycle = typeof SCHEDULED_WORKOUT_LIFECYCLES[number];
+
+export interface TrainingPlanStateV1 {
+  schemaVersion: typeof TRAINING_PLAN_SCHEMA_VERSION;
+  activePlanId: string | null;
+  revision: number;
+  currentWorkoutCount: number;
+  updatedAtMs: number;
+}
+
+export interface TrainingPlanV1 {
+  schemaVersion: typeof TRAINING_PLAN_SCHEMA_VERSION;
+  id: string;
+  name: string;
+  lifecycle: TrainingPlanLifecycle;
+  startLocalDate: string;
+  endLocalDate: string;
+  revision: number;
+  lastCheckpointRevision: number;
+  workoutCount: number;
+  createdAtMs: number;
+  updatedAtMs: number;
+}
+
+export interface ScheduledWorkoutV1 {
+  schemaVersion: typeof TRAINING_PLAN_SCHEMA_VERSION;
+  id: string;
+  planId: string | null;
+  localDate: string;
+  lifecycle: ScheduledWorkoutLifecycle;
+  title: string;
+  structure: WorkoutStructureV1;
+  revision: number;
+  createdAtMs: number;
+  updatedAtMs: number;
+  deletedAtMs?: number;
+}
+
+export type TrainingScheduleRevisionScope =
+  | { kind: 'plan'; id: string }
+  | { kind: 'workout'; id: string };
+
+export interface ExpectedTrainingScheduleRevision {
+  scope: 'state' | 'plan' | 'workout';
+  id: string;
+  revision: number;
+}
+
+export interface CreateTrainingPlanMutationV1 {
+  kind: 'create-plan';
+  planId: string;
+  name: string;
+  startLocalDate: string;
+  endLocalDate: string;
+  activate: boolean;
+}
+
+export interface RenameTrainingPlanMutationV1 {
+  kind: 'rename-plan';
+  planId: string;
+  name: string;
+}
+
+export interface SetTrainingPlanLifecycleMutationV1 {
+  kind: 'set-plan-lifecycle';
+  planId: string;
+  lifecycle: TrainingPlanLifecycle;
+}
+
+export interface ShiftTrainingPlanMutationV1 {
+  kind: 'shift-plan';
+  planId: string;
+  days: number;
+}
+
+export interface CreateScheduledWorkoutMutationV1 {
+  kind: 'create-workout';
+  workoutId: string;
+  planId: string | null;
+  localDate: string;
+  title: string;
+  structure: WorkoutStructureV1;
+  confirmPlanRangeExtension: boolean;
+}
+
+export interface UpdateScheduledWorkoutMutationV1 {
+  kind: 'update-workout';
+  workoutId: string;
+  title: string;
+  structure: WorkoutStructureV1;
+}
+
+export interface MoveScheduledWorkoutMutationV1 {
+  kind: 'move-workout';
+  workoutId: string;
+  planId: string | null;
+  localDate: string;
+  confirmPlanRangeExtension: boolean;
+}
+
+export interface CopyScheduledWorkoutMutationV1 {
+  kind: 'copy-workout';
+  sourceWorkoutId: string;
+  workoutId: string;
+  planId: string | null;
+  localDate: string;
+  confirmPlanRangeExtension: boolean;
+}
+
+export interface SetScheduledWorkoutLifecycleMutationV1 {
+  kind: 'set-workout-lifecycle';
+  workoutId: string;
+  lifecycle: Exclude<ScheduledWorkoutLifecycle, 'deleted'>;
+}
+
+export interface DeleteScheduledWorkoutMutationV1 {
+  kind: 'delete-workout';
+  workoutId: string;
+}
+
+export interface PermanentlyDeleteScheduledWorkoutMutationV1 {
+  kind: 'permanently-delete-workout';
+  workoutId: string;
+  confirmPermanentDeletion: true;
+}
+
+export type TrainingScheduleMutationOperationV1 =
+  | CreateTrainingPlanMutationV1
+  | RenameTrainingPlanMutationV1
+  | SetTrainingPlanLifecycleMutationV1
+  | ShiftTrainingPlanMutationV1
+  | CreateScheduledWorkoutMutationV1
+  | UpdateScheduledWorkoutMutationV1
+  | MoveScheduledWorkoutMutationV1
+  | CopyScheduledWorkoutMutationV1
+  | SetScheduledWorkoutLifecycleMutationV1
+  | DeleteScheduledWorkoutMutationV1
+  | PermanentlyDeleteScheduledWorkoutMutationV1;
+
+export interface MutateTrainingScheduleRequestV1 {
+  mutationId: string;
+  expectedRevisions: ExpectedTrainingScheduleRevision[];
+  operation: TrainingScheduleMutationOperationV1;
+}
+
+export interface MutateTrainingScheduleResponseV1 {
+  mutationId: string;
+  state: TrainingPlanStateV1;
+  plans: TrainingPlanV1[];
+  workouts: ScheduledWorkoutV1[];
+  removedPlanIds: string[];
+  permanentlyDeletedWorkoutIds: string[];
+}
+
+export interface TrainingScheduleHistoryRequestV1 {
+  scope: TrainingScheduleRevisionScope;
+  beforeRevision?: number;
+  limit?: number;
+}
+
+export interface TrainingScheduleHistoryEntryV1 {
+  revision: number;
+  operationKind: string;
+  createdAtMs: number;
+  mutationId: string;
+  isCheckpoint: boolean;
+}
+
+export interface TrainingScheduleHistoryResponseV1 {
+  scope: TrainingScheduleRevisionScope;
+  entries: TrainingScheduleHistoryEntryV1[];
+  nextBeforeRevision: number | null;
+}
+
+export interface PreviewTrainingScheduleRestoreRequestV1 {
+  scope: TrainingScheduleRevisionScope;
+  targetRevision: number;
+}
+
+export interface TrainingScheduleRestorePreviewV1 {
+  scope: TrainingScheduleRevisionScope;
+  targetRevision: number;
+  changedPlanIds: string[];
+  changedWorkoutIds: string[];
+  skippedWorkoutIds: string[];
+  warnings: string[];
+}
+
+export interface RestoreTrainingScheduleRevisionRequestV1 extends PreviewTrainingScheduleRestoreRequestV1 {
+  mutationId: string;
+  expectedRevisions: ExpectedTrainingScheduleRevision[];
+}
+
+export interface RestoreTrainingScheduleRevisionResponseV1 {
+  mutation: MutateTrainingScheduleResponseV1;
+  skippedWorkoutIds: string[];
+}
+
+export interface DeleteTrainingPlanRequestV1 {
+  mutationId: string;
+  planId: string;
+  expectedRevisions: ExpectedTrainingScheduleRevision[];
+  workoutDisposition: 'convert-to-standalone' | 'delete-workouts';
+  confirmPlanDeletion: true;
+}
+
+export interface DeleteTrainingPlanResponseV1 {
+  mutationId: string;
+  state: TrainingPlanStateV1;
+  removedPlanId: string;
+  workoutDisposition: DeleteTrainingPlanRequestV1['workoutDisposition'];
+  convertedWorkoutIds: string[];
+  permanentlyDeletedWorkoutIds: string[];
+}
+
+export class TrainingPlanContractError extends Error {
+  constructor(
+    public readonly path: string,
+    message: string,
+  ) {
+    super(`${path}: ${message}`);
+    this.name = 'TrainingPlanContractError';
+  }
+}
+
+function asRecord(value: unknown, path: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TrainingPlanContractError(path, 'Expected an object.');
+  }
+  return value as Record<string, unknown>;
+}
+
+function rejectUnknownFields(record: Record<string, unknown>, fields: readonly string[], path: string): void {
+  const unknown = Object.keys(record).find(field => !fields.includes(field));
+  if (unknown) throw new TrainingPlanContractError(`${path}.${unknown}`, 'Unknown field.');
+}
+
+function readEntityId(value: unknown, path: string): string {
+  if (typeof value !== 'string' || !ENTITY_ID_PATTERN.test(value)) {
+    throw new TrainingPlanContractError(path, 'Expected a Firestore-safe ID of at most 128 characters.');
+  }
+  return value;
+}
+
+export function normalizeTrainingScheduleMutationId(value: unknown): string {
+  if (typeof value !== 'string' || !MUTATION_ID_PATTERN.test(value)) {
+    throw new TrainingPlanContractError('$.mutationId', 'Expected a stable mutation ID of at most 128 characters.');
+  }
+  return value;
+}
+
+function readString(value: unknown, path: string, maximum: number): string {
+  if (typeof value !== 'string') throw new TrainingPlanContractError(path, 'Expected a string.');
+  const normalized = value.trim();
+  if (!normalized || normalized.length > maximum) {
+    throw new TrainingPlanContractError(path, `Expected 1 to ${maximum} characters.`);
+  }
+  return normalized;
+}
+
+function readInteger(value: unknown, path: string, minimum = 0): number {
+  if (!Number.isSafeInteger(value) || (value as number) < minimum) {
+    throw new TrainingPlanContractError(path, `Expected an integer greater than or equal to ${minimum}.`);
+  }
+  return value as number;
+}
+
+function readTimestampMs(value: unknown, path: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw new TrainingPlanContractError(path, 'Expected a non-negative millisecond timestamp.');
+  }
+  return value;
+}
+
+export function normalizeTrainingLocalDate(value: unknown, path = '$.localDate'): string {
+  if (typeof value !== 'string') throw new TrainingPlanContractError(path, 'Expected YYYY-MM-DD.');
+  const match = LOCAL_DATE_PATTERN.exec(value);
+  if (!match) throw new TrainingPlanContractError(path, 'Expected YYYY-MM-DD.');
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const time = Date.UTC(year, month - 1, day);
+  const date = new Date(time);
+  if (
+    date.getUTCFullYear() !== year
+    || date.getUTCMonth() !== month - 1
+    || date.getUTCDate() !== day
+  ) {
+    throw new TrainingPlanContractError(path, 'Expected a real calendar date.');
+  }
+  return value;
+}
+
+export function addDaysToTrainingLocalDate(localDate: string, days: number): string {
+  const normalized = normalizeTrainingLocalDate(localDate);
+  if (!Number.isSafeInteger(days)) throw new TrainingPlanContractError('$.days', 'Expected an integer.');
+  const [year, month, day] = normalized.split('-').map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day + days));
+  return [
+    `${date.getUTCFullYear()}`.padStart(4, '0'),
+    `${date.getUTCMonth() + 1}`.padStart(2, '0'),
+    `${date.getUTCDate()}`.padStart(2, '0'),
+  ].join('-');
+}
+
+export function countTrainingPlanDays(startLocalDate: string, endLocalDate: string): number {
+  const start = normalizeTrainingLocalDate(startLocalDate, '$.startLocalDate');
+  const end = normalizeTrainingLocalDate(endLocalDate, '$.endLocalDate');
+  const startMs = Date.parse(`${start}T00:00:00.000Z`);
+  const endMs = Date.parse(`${end}T00:00:00.000Z`);
+  if (endMs < startMs) throw new TrainingPlanContractError('$.endLocalDate', 'Must not precede the start date.');
+  return Math.round((endMs - startMs) / 86_400_000) + 1;
+}
+
+export function validateTrainingPlanDateRange(startLocalDate: string, endLocalDate: string): void {
+  const days = countTrainingPlanDays(startLocalDate, endLocalDate);
+  if (days > TRAINING_PLAN_MAX_DAYS) {
+    throw new TrainingPlanContractError('$.endLocalDate', `A plan may contain at most ${TRAINING_PLAN_MAX_DAYS} days.`);
+  }
+}
+
+export function isTrainingLocalDateWithinPlan(localDate: string, plan: Pick<TrainingPlanV1, 'startLocalDate' | 'endLocalDate'>): boolean {
+  const normalized = normalizeTrainingLocalDate(localDate);
+  return normalized >= plan.startLocalDate && normalized <= plan.endLocalDate;
+}
+
+export function extendTrainingPlanRangeToDate(
+  plan: TrainingPlanV1,
+  localDate: string,
+): Pick<TrainingPlanV1, 'startLocalDate' | 'endLocalDate'> {
+  const normalized = normalizeTrainingLocalDate(localDate);
+  const startLocalDate = normalized < plan.startLocalDate ? normalized : plan.startLocalDate;
+  const endLocalDate = normalized > plan.endLocalDate ? normalized : plan.endLocalDate;
+  validateTrainingPlanDateRange(startLocalDate, endLocalDate);
+  return { startLocalDate, endLocalDate };
+}
+
+function readNullableEntityId(value: unknown, path: string): string | null {
+  return value === null ? null : readEntityId(value, path);
+}
+
+function readLifecycle<T extends string>(value: unknown, values: readonly T[], path: string): T {
+  if (typeof value !== 'string' || !values.includes(value as T)) {
+    throw new TrainingPlanContractError(path, `Expected one of: ${values.join(', ')}.`);
+  }
+  return value as T;
+}
+
+export function parseTrainingPlanStateV1(value: unknown): TrainingPlanStateV1 {
+  const record = asRecord(value, '$');
+  rejectUnknownFields(record, ['schemaVersion', 'activePlanId', 'revision', 'currentWorkoutCount', 'updatedAtMs'], '$');
+  if (record.schemaVersion !== TRAINING_PLAN_SCHEMA_VERSION) {
+    throw new TrainingPlanContractError('$.schemaVersion', 'Unsupported training-plan state version.');
+  }
+  return {
+    schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+    activePlanId: readNullableEntityId(record.activePlanId, '$.activePlanId'),
+    revision: readInteger(record.revision, '$.revision'),
+    currentWorkoutCount: readInteger(record.currentWorkoutCount, '$.currentWorkoutCount'),
+    updatedAtMs: readTimestampMs(record.updatedAtMs, '$.updatedAtMs'),
+  };
+}
+
+export function parseTrainingPlanV1(value: unknown): TrainingPlanV1 {
+  const record = asRecord(value, '$');
+  rejectUnknownFields(record, [
+    'schemaVersion', 'id', 'name', 'lifecycle', 'startLocalDate', 'endLocalDate',
+    'revision', 'lastCheckpointRevision', 'workoutCount', 'createdAtMs', 'updatedAtMs',
+  ], '$');
+  if (record.schemaVersion !== TRAINING_PLAN_SCHEMA_VERSION) {
+    throw new TrainingPlanContractError('$.schemaVersion', 'Unsupported training-plan version.');
+  }
+  const startLocalDate = normalizeTrainingLocalDate(record.startLocalDate, '$.startLocalDate');
+  const endLocalDate = normalizeTrainingLocalDate(record.endLocalDate, '$.endLocalDate');
+  validateTrainingPlanDateRange(startLocalDate, endLocalDate);
+  const revision = readInteger(record.revision, '$.revision', 1);
+  const lastCheckpointRevision = readInteger(record.lastCheckpointRevision, '$.lastCheckpointRevision', 1);
+  if (lastCheckpointRevision > revision) {
+    throw new TrainingPlanContractError('$.lastCheckpointRevision', 'Must not exceed revision.');
+  }
+  return {
+    schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+    id: readEntityId(record.id, '$.id'),
+    name: readString(record.name, '$.name', 120),
+    lifecycle: readLifecycle(record.lifecycle, TRAINING_PLAN_LIFECYCLES, '$.lifecycle'),
+    startLocalDate,
+    endLocalDate,
+    revision,
+    lastCheckpointRevision,
+    workoutCount: readInteger(record.workoutCount, '$.workoutCount'),
+    createdAtMs: readTimestampMs(record.createdAtMs, '$.createdAtMs'),
+    updatedAtMs: readTimestampMs(record.updatedAtMs, '$.updatedAtMs'),
+  };
+}
+
+export function parseScheduledWorkoutV1(value: unknown): ScheduledWorkoutV1 {
+  const record = asRecord(value, '$');
+  rejectUnknownFields(record, [
+    'schemaVersion', 'id', 'planId', 'localDate', 'lifecycle', 'title', 'structure',
+    'revision', 'createdAtMs', 'updatedAtMs', 'deletedAtMs',
+  ], '$');
+  if (record.schemaVersion !== TRAINING_PLAN_SCHEMA_VERSION) {
+    throw new TrainingPlanContractError('$.schemaVersion', 'Unsupported scheduled-workout version.');
+  }
+  const deletedAtMs = record.deletedAtMs === undefined
+    ? undefined
+    : readTimestampMs(record.deletedAtMs, '$.deletedAtMs');
+  const lifecycle = readLifecycle(record.lifecycle, SCHEDULED_WORKOUT_LIFECYCLES, '$.lifecycle');
+  if ((lifecycle === 'deleted') !== (deletedAtMs !== undefined)) {
+    throw new TrainingPlanContractError('$.deletedAtMs', 'Deleted workouts require deletedAtMs and current workouts must omit it.');
+  }
+  const parsed: ScheduledWorkoutV1 = {
+    schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+    id: readEntityId(record.id, '$.id'),
+    planId: readNullableEntityId(record.planId, '$.planId'),
+    localDate: normalizeTrainingLocalDate(record.localDate),
+    lifecycle,
+    title: readString(record.title, '$.title', 120),
+    structure: parseWorkoutStructureV1(record.structure),
+    revision: readInteger(record.revision, '$.revision', 1),
+    createdAtMs: readTimestampMs(record.createdAtMs, '$.createdAtMs'),
+    updatedAtMs: readTimestampMs(record.updatedAtMs, '$.updatedAtMs'),
+  };
+  return deletedAtMs === undefined ? parsed : { ...parsed, deletedAtMs };
+}
+
+function parseExpectedRevisions(value: unknown): ExpectedTrainingScheduleRevision[] {
+  if (!Array.isArray(value) || value.length > 4) {
+    throw new TrainingPlanContractError('$.expectedRevisions', 'Expected an array of at most four revisions.');
+  }
+  const seen = new Set<string>();
+  return value.map((entry, index) => {
+    const path = `$.expectedRevisions[${index}]`;
+    const record = asRecord(entry, path);
+    rejectUnknownFields(record, ['scope', 'id', 'revision'], path);
+    const scope = readLifecycle(record.scope, ['state', 'plan', 'workout'], `${path}.scope`);
+    const id = scope === 'state'
+      ? (record.id === 'current' ? 'current' : (() => { throw new TrainingPlanContractError(`${path}.id`, 'State ID must be current.'); })())
+      : readEntityId(record.id, `${path}.id`);
+    const key = `${scope}:${id}`;
+    if (seen.has(key)) throw new TrainingPlanContractError(path, 'Duplicate expected revision.');
+    seen.add(key);
+    return { scope, id, revision: readInteger(record.revision, `${path}.revision`) };
+  });
+}
+
+function parsePlanFields(record: Record<string, unknown>, path = '$.operation'): {
+  planId: string;
+  name: string;
+  startLocalDate: string;
+  endLocalDate: string;
+} {
+  const startLocalDate = normalizeTrainingLocalDate(record.startLocalDate, `${path}.startLocalDate`);
+  const endLocalDate = normalizeTrainingLocalDate(record.endLocalDate, `${path}.endLocalDate`);
+  validateTrainingPlanDateRange(startLocalDate, endLocalDate);
+  return {
+    planId: readEntityId(record.planId, `${path}.planId`),
+    name: readString(record.name, `${path}.name`, 120),
+    startLocalDate,
+    endLocalDate,
+  };
+}
+
+function parseWorkoutDestinationFields(record: Record<string, unknown>, path = '$.operation'): {
+  planId: string | null;
+  localDate: string;
+  confirmPlanRangeExtension: boolean;
+} {
+  if (typeof record.confirmPlanRangeExtension !== 'boolean') {
+    throw new TrainingPlanContractError(`${path}.confirmPlanRangeExtension`, 'Expected a boolean.');
+  }
+  return {
+    planId: readNullableEntityId(record.planId, `${path}.planId`),
+    localDate: normalizeTrainingLocalDate(record.localDate, `${path}.localDate`),
+    confirmPlanRangeExtension: record.confirmPlanRangeExtension,
+  };
+}
+
+export function parseMutateTrainingScheduleRequestV1(value: unknown): MutateTrainingScheduleRequestV1 {
+  const record = asRecord(value, '$');
+  rejectUnknownFields(record, ['mutationId', 'expectedRevisions', 'operation'], '$');
+  const operationRecord = asRecord(record.operation, '$.operation');
+  const kind = readLifecycle(operationRecord.kind, [
+    'create-plan', 'rename-plan', 'set-plan-lifecycle', 'shift-plan', 'create-workout',
+    'update-workout', 'move-workout', 'copy-workout', 'set-workout-lifecycle',
+    'delete-workout', 'permanently-delete-workout',
+  ] as const, '$.operation.kind');
+
+  let operation: TrainingScheduleMutationOperationV1;
+  switch (kind) {
+    case 'create-plan': {
+      rejectUnknownFields(operationRecord, ['kind', 'planId', 'name', 'startLocalDate', 'endLocalDate', 'activate'], '$.operation');
+      if (typeof operationRecord.activate !== 'boolean') {
+        throw new TrainingPlanContractError('$.operation.activate', 'Expected a boolean.');
+      }
+      operation = { kind, ...parsePlanFields(operationRecord), activate: operationRecord.activate };
+      break;
+    }
+    case 'rename-plan':
+      rejectUnknownFields(operationRecord, ['kind', 'planId', 'name'], '$.operation');
+      operation = {
+        kind,
+        planId: readEntityId(operationRecord.planId, '$.operation.planId'),
+        name: readString(operationRecord.name, '$.operation.name', 120),
+      };
+      break;
+    case 'set-plan-lifecycle':
+      rejectUnknownFields(operationRecord, ['kind', 'planId', 'lifecycle'], '$.operation');
+      operation = {
+        kind,
+        planId: readEntityId(operationRecord.planId, '$.operation.planId'),
+        lifecycle: readLifecycle(operationRecord.lifecycle, TRAINING_PLAN_LIFECYCLES, '$.operation.lifecycle'),
+      };
+      break;
+    case 'shift-plan':
+      rejectUnknownFields(operationRecord, ['kind', 'planId', 'days'], '$.operation');
+      operation = {
+        kind,
+        planId: readEntityId(operationRecord.planId, '$.operation.planId'),
+        days: readInteger(operationRecord.days, '$.operation.days', -366),
+      };
+      if (operation.days === 0 || operation.days > 366) {
+        throw new TrainingPlanContractError('$.operation.days', 'Expected a non-zero shift between -366 and 366 days.');
+      }
+      break;
+    case 'create-workout': {
+      rejectUnknownFields(
+        operationRecord,
+        ['kind', 'workoutId', 'planId', 'localDate', 'title', 'structure', 'confirmPlanRangeExtension'],
+        '$.operation',
+      );
+      operation = {
+        kind,
+        workoutId: readEntityId(operationRecord.workoutId, '$.operation.workoutId'),
+        ...parseWorkoutDestinationFields(operationRecord),
+        title: readString(operationRecord.title, '$.operation.title', 120),
+        structure: parseWorkoutStructureV1(operationRecord.structure),
+      };
+      break;
+    }
+    case 'update-workout':
+      rejectUnknownFields(operationRecord, ['kind', 'workoutId', 'title', 'structure'], '$.operation');
+      operation = {
+        kind,
+        workoutId: readEntityId(operationRecord.workoutId, '$.operation.workoutId'),
+        title: readString(operationRecord.title, '$.operation.title', 120),
+        structure: parseWorkoutStructureV1(operationRecord.structure),
+      };
+      break;
+    case 'move-workout':
+      rejectUnknownFields(
+        operationRecord,
+        ['kind', 'workoutId', 'planId', 'localDate', 'confirmPlanRangeExtension'],
+        '$.operation',
+      );
+      operation = {
+        kind,
+        workoutId: readEntityId(operationRecord.workoutId, '$.operation.workoutId'),
+        ...parseWorkoutDestinationFields(operationRecord),
+      };
+      break;
+    case 'copy-workout':
+      rejectUnknownFields(
+        operationRecord,
+        ['kind', 'sourceWorkoutId', 'workoutId', 'planId', 'localDate', 'confirmPlanRangeExtension'],
+        '$.operation',
+      );
+      operation = {
+        kind,
+        sourceWorkoutId: readEntityId(operationRecord.sourceWorkoutId, '$.operation.sourceWorkoutId'),
+        workoutId: readEntityId(operationRecord.workoutId, '$.operation.workoutId'),
+        ...parseWorkoutDestinationFields(operationRecord),
+      };
+      if (operation.sourceWorkoutId === operation.workoutId) {
+        throw new TrainingPlanContractError('$.operation.workoutId', 'Copy destination must use a new workout ID.');
+      }
+      break;
+    case 'set-workout-lifecycle':
+      rejectUnknownFields(operationRecord, ['kind', 'workoutId', 'lifecycle'], '$.operation');
+      operation = {
+        kind,
+        workoutId: readEntityId(operationRecord.workoutId, '$.operation.workoutId'),
+        lifecycle: readLifecycle(operationRecord.lifecycle, ['planned', 'skipped'], '$.operation.lifecycle'),
+      };
+      break;
+    case 'delete-workout':
+      rejectUnknownFields(operationRecord, ['kind', 'workoutId'], '$.operation');
+      operation = { kind, workoutId: readEntityId(operationRecord.workoutId, '$.operation.workoutId') };
+      break;
+    case 'permanently-delete-workout':
+      rejectUnknownFields(operationRecord, ['kind', 'workoutId', 'confirmPermanentDeletion'], '$.operation');
+      if (operationRecord.confirmPermanentDeletion !== true) {
+        throw new TrainingPlanContractError('$.operation.confirmPermanentDeletion', 'Explicit confirmation is required.');
+      }
+      operation = {
+        kind,
+        workoutId: readEntityId(operationRecord.workoutId, '$.operation.workoutId'),
+        confirmPermanentDeletion: true,
+      };
+      break;
+  }
+
+  return {
+    mutationId: normalizeTrainingScheduleMutationId(record.mutationId),
+    expectedRevisions: parseExpectedRevisions(record.expectedRevisions),
+    operation,
+  };
+}
+
+export function parseDeleteTrainingPlanRequestV1(value: unknown): DeleteTrainingPlanRequestV1 {
+  const record = asRecord(value, '$');
+  rejectUnknownFields(record, [
+    'mutationId', 'planId', 'expectedRevisions', 'workoutDisposition', 'confirmPlanDeletion',
+  ], '$');
+  const workoutDisposition = readLifecycle(
+    record.workoutDisposition,
+    ['convert-to-standalone', 'delete-workouts'] as const,
+    '$.workoutDisposition',
+  );
+  if (record.confirmPlanDeletion !== true) {
+    throw new TrainingPlanContractError('$.confirmPlanDeletion', 'Explicit plan-deletion confirmation is required.');
+  }
+  return {
+    mutationId: normalizeTrainingScheduleMutationId(record.mutationId),
+    planId: readEntityId(record.planId, '$.planId'),
+    expectedRevisions: parseExpectedRevisions(record.expectedRevisions),
+    workoutDisposition,
+    confirmPlanDeletion: true,
+  };
+}
+
+export function shouldCheckpointTrainingPlanRevision(revision: number, bulkOperation = false): boolean {
+  return revision === 1 || bulkOperation || revision % TRAINING_PLAN_CHECKPOINT_INTERVAL === 0;
+}

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -89,6 +89,7 @@ export const CLIENT_RENDERED_APP_ROUTES = [
   'dashboard',
   'health',
   'calendar',
+  'plans',
   'training',
   'mytracks',
   'routes',

--- a/src/app/app.routing.module.spec.ts
+++ b/src/app/app.routing.module.spec.ts
@@ -177,6 +177,20 @@ describe('AppRoutingModule routes', () => {
     expect(calendarRoute?.data?.['robots']).toBe('noindex, follow');
   });
 
+  it('keeps manual training plans authenticated, client-rendered, and noindexed', () => {
+    const plansRoute = routes.find(route => route.path === 'plans');
+
+    expect(plansRoute).toBeTruthy();
+    expect(plansRoute?.canMatch).toEqual([authGuard, onboardingGuard]);
+    expect(plansRoute?.loadComponent).toBeTypeOf('function');
+    expect(plansRoute?.data).toMatchObject({
+      title: 'Plans',
+      preload: true,
+      robots: 'noindex, follow',
+    });
+    expect(plansRoute?.data?.['description']).toContain('standalone workouts');
+  });
+
   it('should keep the private routes library authenticated and noindexed', () => {
     const routesRoute = routes.find(route => route.path === 'routes');
 

--- a/src/app/app.routing.module.ts
+++ b/src/app/app.routing.module.ts
@@ -567,6 +567,19 @@ const topLevelRoutes: Routes = [
     canMatch: [authGuard, onboardingGuard]
   },
   {
+    path: 'plans',
+    loadComponent: () => import('./components/plans/plans-workspace.component')
+      .then(module => module.PlansWorkspaceComponent),
+    data: {
+      title: 'Plans',
+      animation: 'Plans',
+      preload: true,
+      description: 'Create standalone workouts and organize date-based running and cycling training plans.',
+      robots: 'noindex, follow',
+    },
+    canMatch: [authGuard, onboardingGuard]
+  },
+  {
     path: 'training',
     loadChildren: () => import('./modules/training.module').then(module => module.TrainingModule),
     data: {

--- a/src/app/components/calendar/activity-calendar-grid/activity-calendar-grid.component.html
+++ b/src/app/components/calendar/activity-calendar-grid/activity-calendar-grid.component.html
@@ -23,18 +23,18 @@
         @for (day of month.days; track day.dateKey) {
         @let dayNotes = timelineNotesByDate.get(day.dateKey);
         @if (day.inPrimaryPeriod || (!hideOutsideDays && model.view !== 'year')) {
-          @if (day.eventCount || dayNotes) {
           <button type="button" class="activity-calendar-day activity-calendar-day-button"
             [class.activity-calendar-day--outside]="!day.inPrimaryPeriod"
             [class.activity-calendar-day--today]="day.isToday"
             [class.activity-calendar-day--weekend]="day.isWeekend"
-            [attr.aria-label]="dayNotes?.ariaLabel ?? day.ariaLabel"
+            [attr.aria-label]="(dayNotes?.ariaLabel ?? day.ariaLabel) + (plannedWorkoutsByDate[day.dateKey] ? ' ' + plannedWorkoutsByDate[day.dateKey].ariaLabel + '.' : ' No planned workouts.')"
             matRipple
             (click)="selectDay(day)">
             <span class="activity-calendar-day-number"><span class="activity-calendar-day-number-value">{{ day.dayNumber }}</span></span>
             @if (dayNotes) {
             <mat-icon class="activity-calendar-note-indicator" [style.color]="dayNotes.color" aria-hidden="true">{{ dayNotes.icon }}</mat-icon>
             }
+            @if (day.eventCount) {
             <span class="activity-calendar-marker-stage"
               [class.activity-calendar-marker-stage--concentric]="compact || model.view === 'year'">
               @for (family of day.visibleFamilies; track family.id) {
@@ -48,16 +48,19 @@
               <span class="activity-calendar-marker-overflow">+{{ day.overflowFamilyCount }}</span>
               }
             </span>
+            }
+            @if (plannedWorkoutsByDate[day.dateKey]; as plannedDay) {
+              <span class="planned-workout-markers" aria-hidden="true"
+                [class.planned-workout-markers--skipped]="plannedDay.hasSkipped">
+                @for (entry of plannedDay.visibleEntries; track entry.workout.id) {
+                  <mat-icon>{{ entry.workout.lifecycle === 'skipped' ? 'event_busy' : 'event_note' }}</mat-icon>
+                }
+                @if (plannedDay.overflowCount) {
+                  <span>+{{ plannedDay.overflowCount }}</span>
+                }
+              </span>
+            }
           </button>
-          } @else {
-          <div class="activity-calendar-day"
-            [class.activity-calendar-day--outside]="!day.inPrimaryPeriod"
-            [class.activity-calendar-day--today]="day.isToday"
-            [class.activity-calendar-day--weekend]="day.isWeekend"
-            [attr.aria-label]="day.ariaLabel">
-            <span class="activity-calendar-day-number"><span class="activity-calendar-day-number-value">{{ day.dayNumber }}</span></span>
-          </div>
-          }
         } @else {
         <div class="activity-calendar-day activity-calendar-day--blank"
           [class.activity-calendar-day--weekend]="day.isWeekend"

--- a/src/app/components/calendar/activity-calendar-grid/activity-calendar-grid.component.scss
+++ b/src/app/components/calendar/activity-calendar-grid/activity-calendar-grid.component.scss
@@ -239,6 +239,32 @@
   letter-spacing: 0;
 }
 
+.planned-workout-markers {
+  position: absolute;
+  right: 3px;
+  bottom: 3px;
+  display: inline-flex;
+  max-width: calc(100% - 6px);
+  align-items: center;
+  gap: 1px;
+  padding: 1px 3px;
+  border-radius: var(--mat-sys-corner-extra-small);
+  background: var(--mat-sys-secondary-container);
+  color: var(--mat-sys-on-secondary-container);
+  font: var(--mat-sys-label-small);
+}
+
+.planned-workout-markers--skipped {
+  background: var(--mat-sys-surface-container-highest);
+  color: var(--mat-sys-on-surface-variant);
+}
+
+.planned-workout-markers mat-icon {
+  width: 13px;
+  height: 13px;
+  font-size: 13px;
+}
+
 .activity-calendar--year .activity-calendar-weekdays {
   min-height: 22px;
 }
@@ -254,6 +280,27 @@
   padding: 2px 1px;
   border-right-color: transparent;
   border-bottom-color: transparent;
+}
+
+.activity-calendar--year .planned-workout-markers,
+.activity-calendar--compact .planned-workout-markers {
+  top: 0;
+  right: 0;
+  bottom: auto;
+  padding: 0;
+  background: transparent;
+}
+
+.activity-calendar--year .planned-workout-markers mat-icon,
+.activity-calendar--compact .planned-workout-markers mat-icon {
+  width: 10px;
+  height: 10px;
+  font-size: 10px;
+}
+
+.activity-calendar--year .planned-workout-markers mat-icon:nth-of-type(n + 2),
+.activity-calendar--compact .planned-workout-markers mat-icon:nth-of-type(n + 2) {
+  display: none;
 }
 
 .activity-calendar--year .activity-calendar-day-number,

--- a/src/app/components/calendar/activity-calendar-grid/activity-calendar-grid.component.spec.ts
+++ b/src/app/components/calendar/activity-calendar-grid/activity-calendar-grid.component.spec.ts
@@ -7,16 +7,16 @@ import { ActivityCalendarGridComponent } from './activity-calendar-grid.componen
 import { AppHapticsService } from '../../../services/app.haptics.service';
 import type { TimelineNote } from '@shared/timeline-notes';
 import { calendarTimelineNotesByDate } from '../../../helpers/calendar-timeline-notes.helper';
+import type { PlannedWorkoutCalendarOverlay } from '../../../helpers/planned-workout-calendar.helper';
 
 describe('ActivityCalendarGridComponent', () => {
-  it.each(['week', 'month', 'year'] as const)('makes note-only days accessible in %s view without activity markers', async view => {
+  it.each(['week', 'month', 'year'] as const)('marks note-only days without activity markers in %s view', async view => {
     const fixture = await renderGrid(view, false, []);
     const note: TimelineNote = { id: 'a'.repeat(64), category: 'vacation', title: 'Vacation', startDate: '2026-08-03', endDate: '2026-08-03', timeZone: 'UTC', revision: 1, createdAtMs: 1, updatedAtMs: 1 };
-    expect(fixture.nativeElement.querySelectorAll('.activity-calendar-day-button')).toHaveLength(0);
+    expect(fixture.nativeElement.querySelectorAll('.activity-calendar-day-button').length).toBeGreaterThan(0);
     fixture.componentRef.setInput('timelineNotesByDate', calendarTimelineNotesByDate(fixture.componentInstance.model, [note]));
     fixture.detectChanges();
-    const button = fixture.nativeElement.querySelector('.activity-calendar-day-button') as HTMLButtonElement;
-    expect(button.getAttribute('aria-label')).toContain('1 Timeline note');
+    const button = fixture.nativeElement.querySelector('[aria-label*="1 Timeline note"]') as HTMLButtonElement;
     expect(button.querySelector('.activity-calendar-note-indicator')?.textContent).toBe('beach_access');
     expect(fixture.nativeElement.querySelectorAll('.activity-calendar-note-indicator')).toHaveLength(1);
     expect(button.querySelector('.activity-calendar-marker')).toBeNull();
@@ -27,7 +27,7 @@ describe('ActivityCalendarGridComponent', () => {
     expect(selected.mock.calls[0][0].eventCount).toBe(0);
     expect(fixture.componentRef.injector.get(AppHapticsService).selection).toHaveBeenCalledOnce();
     fixture.componentRef.setInput('timelineNotesByDate', new Map()); fixture.detectChanges();
-    expect(fixture.nativeElement.querySelectorAll('.activity-calendar-day-button')).toHaveLength(0);
+    expect(fixture.nativeElement.querySelectorAll('.activity-calendar-note-indicator')).toHaveLength(0);
   });
   it('shows the selected color/category, keeping mixed-note days neutral and grouped', async () => {
     const fixture = await renderGrid('month', false, []);
@@ -42,20 +42,55 @@ describe('ActivityCalendarGridComponent', () => {
     expect(icon().textContent).toBe('event_note');
     expect(icon().style.color).toBe('');
   });
-  it('renders activity days as buttons and emits the selected day', async () => {
+
+  it('renders every visible day as a button and emits activity and empty days', async () => {
     const fixture = await renderGrid('month', false, [
       createEvent('run-1', new Date(2026, 7, 3, 8), ActivityTypes.Running, 3600),
     ]);
     const selected = vi.fn();
     fixture.componentInstance.daySelected.subscribe(selected);
-    const activeDay = fixture.debugElement.query(By.css('.activity-calendar-day-button'));
+    const buttons = fixture.debugElement.queryAll(By.css('.activity-calendar-day-button'));
+    const activityDayIndex = fixture.componentInstance.model.months[0].days
+      .findIndex(day => day.dateKey === '2026-08-03');
+    const emptyDayIndex = fixture.componentInstance.model.months[0].days
+      .findIndex(day => day.dateKey === '2026-08-04');
 
-    activeDay.triggerEventHandler('click');
+    buttons[activityDayIndex].triggerEventHandler('click');
+    buttons[emptyDayIndex].triggerEventHandler('click');
 
-    expect(selected).toHaveBeenCalledOnce();
+    expect(selected).toHaveBeenCalledTimes(2);
     expect(selected.mock.calls[0][0].dateKey).toBe('2026-08-03');
-    expect(fixture.componentRef.injector.get(AppHapticsService).selection).toHaveBeenCalledOnce();
-    expect(fixture.nativeElement.querySelectorAll('.activity-calendar-day-button')).toHaveLength(1);
+    expect(selected.mock.calls[1][0].dateKey).toBe('2026-08-04');
+    expect(fixture.componentRef.injector.get(AppHapticsService).selection).toHaveBeenCalledTimes(2);
+    expect(buttons).toHaveLength(42);
+  });
+
+  it('renders planned and skipped workout markers without changing activity markers', async () => {
+    const plannedWorkoutsByDate: PlannedWorkoutCalendarOverlay = {
+      '2026-08-03': {
+        entries: [],
+        visibleEntries: [
+          { workout: createWorkout('tempo', 'planned'), planName: 'Autumn build' },
+          { workout: createWorkout('rest', 'skipped'), planName: null },
+        ],
+        overflowCount: 1,
+        hasSkipped: true,
+        ariaLabel: '2 planned workouts, 1 skipped workout',
+      },
+    };
+    const fixture = await renderGrid('month', false, [
+      createEvent('run-1', new Date(2026, 7, 3, 8), ActivityTypes.Running, 3600),
+    ], DaysOfTheWeek.Monday, plannedWorkoutsByDate);
+    const plannedMarkers = fixture.nativeElement.querySelector('.planned-workout-markers');
+    const activityMarkers = fixture.nativeElement.querySelectorAll('.activity-calendar-marker');
+
+    expect(plannedMarkers.classList).toContain('planned-workout-markers--skipped');
+    expect([...plannedMarkers.querySelectorAll('mat-icon')].map((icon: Element) => icon.textContent?.trim()))
+      .toEqual(['event_note', 'event_busy']);
+    expect(plannedMarkers.textContent).toContain('+1');
+    expect(activityMarkers).toHaveLength(1);
+    expect(fixture.nativeElement.querySelector('[aria-label*="2 planned workouts, 1 skipped workout"]'))
+      .toBeTruthy();
   });
 
   it('renders same-center markers for compact calendars', async () => {
@@ -207,6 +242,7 @@ async function renderGrid(
   compact: boolean,
   events: EventInterface[],
   startOfWeek: DaysOfTheWeek | number = DaysOfTheWeek.Monday,
+  plannedWorkoutsByDate: PlannedWorkoutCalendarOverlay = {},
 ) {
   const fixture = await import('@angular/core/testing').then(async ({ TestBed }) => {
     await TestBed.configureTestingModule({
@@ -231,8 +267,34 @@ async function renderGrid(
     now: new Date(2026, 7, 3),
   }));
   fixture.componentRef.setInput('compact', compact);
+  fixture.componentRef.setInput('plannedWorkoutsByDate', plannedWorkoutsByDate);
   fixture.detectChanges();
   return fixture;
+}
+
+function createWorkout(id: string, lifecycle: 'planned' | 'skipped') {
+  return {
+    schemaVersion: 1 as const,
+    id,
+    planId: id === 'tempo' ? 'plan-1' : null,
+    localDate: '2026-08-03',
+    lifecycle,
+    title: id,
+    structure: {
+      version: 1 as const,
+      sport: ActivityTypes.Running,
+      nodes: [{
+        kind: 'step' as const,
+        id: 'steady',
+        purpose: 'work' as const,
+        ending: { kind: 'time' as const, seconds: 1800 },
+        targets: [],
+      }],
+    },
+    revision: 1,
+    createdAtMs: 1,
+    updatedAtMs: 1,
+  };
 }
 
 function createEvent(

--- a/src/app/components/calendar/activity-calendar-grid/activity-calendar-grid.component.ts
+++ b/src/app/components/calendar/activity-calendar-grid/activity-calendar-grid.component.ts
@@ -6,6 +6,7 @@ import type {
 import { SharedModule } from '../../../modules/shared.module';
 import { AppHapticsService } from '../../../services/app.haptics.service';
 import type { CalendarDayTimelineNotes } from '../../../helpers/calendar-timeline-notes.helper';
+import type { PlannedWorkoutCalendarOverlay } from '../../../helpers/planned-workout-calendar.helper';
 
 @Component({
   selector: 'app-activity-calendar-grid',
@@ -21,13 +22,11 @@ export class ActivityCalendarGridComponent {
   @Input() hideOutsideDays = false;
   // Private notes are opt-in; dashboard/shared calendar instances do not fetch or receive them.
   @Input() timelineNotesByDate: ReadonlyMap<string, CalendarDayTimelineNotes> = new Map();
+  @Input() plannedWorkoutsByDate: PlannedWorkoutCalendarOverlay = {};
   @Output() daySelected = new EventEmitter<ActivityCalendarDayViewModel>();
   private readonly hapticsService = inject(AppHapticsService);
 
   selectDay(day: ActivityCalendarDayViewModel): void {
-    if (!day.eventCount && !this.timelineNotesByDate.has(day.dateKey)) {
-      return;
-    }
     this.hapticsService.selection();
     this.daySelected.emit(day);
   }

--- a/src/app/components/calendar/activity-calendar-tile/activity-calendar-tile.component.html
+++ b/src/app/components/calendar/activity-calendar-tile/activity-calendar-tile.component.html
@@ -43,10 +43,14 @@
     [model]="calendarModel()"
     [compact]="true"
     [hideOutsideDays]="true"
+    [plannedWorkoutsByDate]="plannedWorkoutsByDate()"
     (daySelected)="openDay($event)">
   </app-activity-calendar-grid>
   @if (!isLoading() && !hasEvents()) {
-  <div class="activity-calendar-tile-status" role="status">No activities this month</div>
+  <div class="activity-calendar-tile-status" role="status">No completed activities this month</div>
+  }
+  @if (plansState().status === 'error') {
+  <div class="activity-calendar-tile-status" role="status">Planned workouts unavailable</div>
   }
   }
 </section>

--- a/src/app/components/calendar/activity-calendar-tile/activity-calendar-tile.component.html
+++ b/src/app/components/calendar/activity-calendar-tile/activity-calendar-tile.component.html
@@ -38,7 +38,7 @@
       <mat-icon>refresh</mat-icon>
     </button>
   </div>
-  } @else {
+  }
   <app-activity-calendar-grid
     [model]="calendarModel()"
     [compact]="true"
@@ -46,11 +46,10 @@
     [plannedWorkoutsByDate]="plannedWorkoutsByDate()"
     (daySelected)="openDay($event)">
   </app-activity-calendar-grid>
-  @if (!isLoading() && !hasEvents()) {
+  @if (eventState().status === 'ready' && !hasEvents()) {
   <div class="activity-calendar-tile-status" role="status">No completed activities this month</div>
   }
   @if (plansState().status === 'error') {
   <div class="activity-calendar-tile-status" role="status">Planned workouts unavailable</div>
-  }
   }
 </section>

--- a/src/app/components/calendar/activity-calendar-tile/activity-calendar-tile.component.spec.ts
+++ b/src/app/components/calendar/activity-calendar-tile/activity-calendar-tile.component.spec.ts
@@ -125,6 +125,7 @@ describe('ActivityCalendarTileComponent', () => {
 
   it('shows a retry action when the month query fails', async () => {
     watchEvents.mockReturnValue(throwError(() => new Error('offline')));
+    watchSchedule.mockReturnValue(of(scheduleForDate(currentLocalDate(2))));
     const fixture = TestBed.createComponent(ActivityCalendarTileComponent);
     fixture.componentRef.setInput('user', user);
     fixture.detectChanges();
@@ -132,6 +133,9 @@ describe('ActivityCalendarTileComponent', () => {
     fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelector('[role="alert"]')?.textContent).toContain('Calendar unavailable');
+    expect(fixture.nativeElement.querySelector('.activity-calendar-day-button')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('.planned-workout-markers')).toBeTruthy();
+    expect(fixture.nativeElement.textContent).not.toContain('No completed activities this month');
   });
 
   it('shows the empty state when query results only belong to an adjacent month', async () => {

--- a/src/app/components/calendar/activity-calendar-tile/activity-calendar-tile.component.spec.ts
+++ b/src/app/components/calendar/activity-calendar-tile/activity-calendar-tile.component.spec.ts
@@ -5,8 +5,10 @@ import { MatBottomSheet } from '@angular/material/bottom-sheet';
 import { provideRouter } from '@angular/router';
 import { ActivityTypes, DataDuration, DaysOfTheWeek, type EventInterface } from '@sports-alliance/sports-lib';
 import { BehaviorSubject, of, throwError } from 'rxjs';
+import type { WorkoutStructureV1 } from '@shared/planned-workout';
 import { ActivityCalendarService } from '../../../services/activity-calendar.service';
 import { CalendarDayDetailsNavigationService } from '../../../services/calendar-day-details-navigation.service';
+import { TrainingPlansService, type CurrentTrainingScheduleV1 } from '../../../services/training-plans.service';
 import { ActivityCalendarTileComponent } from './activity-calendar-tile.component';
 
 describe('ActivityCalendarTileComponent', () => {
@@ -16,6 +18,7 @@ describe('ActivityCalendarTileComponent', () => {
   };
   let watchEvents: ReturnType<typeof vi.fn>;
   let openBottomSheet: ReturnType<typeof vi.fn>;
+  let watchSchedule: ReturnType<typeof vi.fn>;
   let dayDetailsNavigation: {
     restorationFor: ReturnType<typeof vi.fn>;
     consumeRestoration: ReturnType<typeof vi.fn>;
@@ -23,6 +26,7 @@ describe('ActivityCalendarTileComponent', () => {
 
   beforeEach(async () => {
     watchEvents = vi.fn().mockReturnValue(of([createEvent()]));
+    watchSchedule = vi.fn().mockReturnValue(of(emptySchedule()));
     openBottomSheet = vi.fn();
     dayDetailsNavigation = {
       restorationFor: vi.fn().mockReturnValue(null),
@@ -33,6 +37,7 @@ describe('ActivityCalendarTileComponent', () => {
       providers: [
         provideRouter([]),
         { provide: ActivityCalendarService, useValue: { watchEvents } },
+        { provide: TrainingPlansService, useValue: { watchSchedule } },
         { provide: CalendarDayDetailsNavigationService, useValue: dayDetailsNavigation },
       ],
     }).compileComponents();
@@ -70,6 +75,31 @@ describe('ActivityCalendarTileComponent', () => {
         unitSettings: user.settings.unitSettings,
       }),
     }));
+  });
+
+  it('shows active-plan and standalone workouts and passes them to empty-day details', async () => {
+    const plannedDate = currentLocalDate(2);
+    watchSchedule.mockReturnValue(of(scheduleForDate(plannedDate)));
+    watchEvents.mockReturnValue(of([]));
+    const fixture = TestBed.createComponent(ActivityCalendarTileComponent);
+    fixture.componentRef.setInput('user', user);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const componentBottomSheet = (fixture.componentInstance as unknown as {
+      bottomSheet: MatBottomSheet;
+    }).bottomSheet;
+    const componentOpen = vi.spyOn(componentBottomSheet, 'open').mockImplementation(openBottomSheet);
+    const day = fixture.componentInstance.calendarModel().months[0].days
+      .find(candidate => candidate.dateKey === plannedDate)!;
+
+    expect(fixture.nativeElement.querySelector('.planned-workout-markers')).toBeTruthy();
+    fixture.componentInstance.openDay(day);
+
+    const plannedWorkouts = (componentOpen.mock.calls[0][1] as {
+      data: { plannedWorkouts: Array<{ workout: { id: string } }> };
+    }).data.plannedWorkouts;
+    expect(plannedWorkouts.map(entry => entry.workout.id)).toEqual(['active-workout', 'standalone-workout']);
   });
 
   it('pages the compact month picker without rendering the tile heading', async () => {
@@ -113,8 +143,8 @@ describe('ActivityCalendarTileComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    expect(fixture.nativeElement.textContent).toContain('No activities this month');
-    expect(fixture.nativeElement.querySelector('.activity-calendar-day-button')).toBeNull();
+    expect(fixture.nativeElement.textContent).toContain('No completed activities this month');
+    expect(fixture.nativeElement.querySelector('.activity-calendar-day-button')).toBeTruthy();
   });
 
   it('refreshes the today marker without re-querying during the same month', () => {
@@ -213,6 +243,91 @@ describe('ActivityCalendarTileComponent', () => {
     expect(gridRule).toContain('overflow: hidden;');
   });
 });
+
+function emptySchedule(): CurrentTrainingScheduleV1 {
+  return {
+    state: { schemaVersion: 1, activePlanId: null, revision: 0, currentWorkoutCount: 0, updatedAtMs: 0 },
+    plans: [],
+    workouts: [],
+  };
+}
+
+function scheduleForDate(localDate: string): CurrentTrainingScheduleV1 {
+  const rangeStart = currentLocalDate(1);
+  const rangeEnd = currentLocalDate(28);
+  const structure = {
+    version: 1 as const,
+    sport: ActivityTypes.Running,
+    nodes: [{
+      kind: 'step' as const,
+      id: 'steady',
+      purpose: 'work' as const,
+      ending: { kind: 'time' as const, seconds: 1800 },
+      targets: [],
+    }],
+  };
+  return {
+    state: { schemaVersion: 1, activePlanId: 'active-plan', revision: 1, currentWorkoutCount: 3, updatedAtMs: 1 },
+    plans: [
+      {
+        schemaVersion: 1,
+        id: 'active-plan',
+        name: 'Active build',
+        lifecycle: 'active',
+        startLocalDate: rangeStart,
+        endLocalDate: rangeEnd,
+        revision: 1,
+        lastCheckpointRevision: 1,
+        workoutCount: 1,
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      },
+      {
+        schemaVersion: 1,
+        id: 'inactive-plan',
+        name: 'Paused build',
+        lifecycle: 'paused',
+        startLocalDate: rangeStart,
+        endLocalDate: rangeEnd,
+        revision: 1,
+        lastCheckpointRevision: 1,
+        workoutCount: 1,
+        createdAtMs: 2,
+        updatedAtMs: 2,
+      },
+    ],
+    workouts: [
+      plannedWorkout('active-workout', 'active-plan', localDate, structure),
+      plannedWorkout('standalone-workout', null, localDate, structure),
+      plannedWorkout('inactive-workout', 'inactive-plan', localDate, structure),
+    ],
+  };
+}
+
+function plannedWorkout(
+  id: string,
+  planId: string | null,
+  localDate: string,
+  structure: WorkoutStructureV1,
+) {
+  return {
+    schemaVersion: 1 as const,
+    id,
+    planId,
+    localDate,
+    lifecycle: 'planned' as const,
+    title: id,
+    structure,
+    revision: 1,
+    createdAtMs: 1,
+    updatedAtMs: 1,
+  };
+}
+
+function currentLocalDate(day: number): string {
+  const now = new Date();
+  return [now.getFullYear(), `${now.getMonth() + 1}`.padStart(2, '0'), `${day}`.padStart(2, '0')].join('-');
+}
 
 function createEvent(startDate?: Date, eventId = 'event-1'): EventInterface {
   const now = new Date();

--- a/src/app/components/calendar/activity-calendar-tile/activity-calendar-tile.component.ts
+++ b/src/app/components/calendar/activity-calendar-tile/activity-calendar-tile.component.ts
@@ -24,15 +24,29 @@ import {
 import { SharedModule } from '../../../modules/shared.module';
 import { ActivityCalendarService } from '../../../services/activity-calendar.service';
 import { CalendarDayDetailsNavigationService } from '../../../services/calendar-day-details-navigation.service';
+import {
+  TrainingPlansService,
+  selectCalendarVisibleScheduledWorkouts,
+  type CurrentTrainingScheduleV1,
+} from '../../../services/training-plans.service';
 import { ActivityCalendarGridComponent } from '../activity-calendar-grid/activity-calendar-grid.component';
 import {
   CalendarDayDetailsComponent,
   type CalendarDayDetailsData,
 } from '../calendar-day-details/calendar-day-details.component';
+import {
+  buildPlannedWorkoutCalendarOverlay,
+  type PlannedWorkoutCalendarOverlay,
+} from '../../../helpers/planned-workout-calendar.helper';
 
 interface ActivityCalendarTileState {
   status: 'loading' | 'ready' | 'error';
   events: EventInterface[];
+}
+
+interface ActivityCalendarTilePlansState {
+  status: 'loading' | 'ready' | 'error';
+  schedule: CurrentTrainingScheduleV1 | null;
 }
 
 @Component({
@@ -45,6 +59,7 @@ interface ActivityCalendarTileState {
 })
 export class ActivityCalendarTileComponent {
   private readonly calendarService = inject(ActivityCalendarService);
+  private readonly plansService = inject(TrainingPlansService);
   private readonly bottomSheet = inject(MatBottomSheet);
   private readonly router = inject(Router);
   private readonly dayDetailsNavigation = inject(CalendarDayDetailsNavigationService);
@@ -78,6 +93,26 @@ export class ActivityCalendarTileComponent {
       );
     }),
   ), { initialValue: { status: 'loading', events: [] } as ActivityCalendarTileState });
+  readonly plansState = toSignal(toObservable(this.user).pipe(
+    switchMap(user => {
+      if (!user?.uid) {
+        return of({ status: 'ready', schedule: null } as ActivityCalendarTilePlansState);
+      }
+      return this.plansService.watchSchedule(user.uid).pipe(
+        map(schedule => ({ status: 'ready', schedule }) as ActivityCalendarTilePlansState),
+        startWith({ status: 'loading', schedule: null } as ActivityCalendarTilePlansState),
+        catchError(() => of({ status: 'error', schedule: null } as ActivityCalendarTilePlansState)),
+      );
+    }),
+  ), { initialValue: { status: 'loading', schedule: null } as ActivityCalendarTilePlansState });
+  readonly plannedWorkoutsByDate = computed<PlannedWorkoutCalendarOverlay>(() => {
+    const schedule = this.plansState().schedule;
+    if (!schedule) return {};
+    return buildPlannedWorkoutCalendarOverlay(
+      selectCalendarVisibleScheduledWorkouts(schedule),
+      schedule.plans,
+    );
+  });
   readonly calendarModel = computed(() => buildActivityCalendarViewModel(this.eventState().events, {
     view: 'month',
     anchorDate: this.anchorDate(),
@@ -115,7 +150,7 @@ export class ActivityCalendarTileComponent {
     if (!this.dayDetailsNavigation.consumeRestoration(restoration)) {
       return;
     }
-    if (day?.eventCount) {
+    if (day) {
       this.openDay(day);
     }
   });
@@ -144,7 +179,7 @@ export class ActivityCalendarTileComponent {
 
   openDay(day: ActivityCalendarDayViewModel): void {
     const userId = `${this.user()?.uid || ''}`.trim();
-    if (!day.eventCount || !userId) {
+    if (!userId) {
       return;
     }
     this.bottomSheet.open<CalendarDayDetailsComponent, CalendarDayDetailsData>(CalendarDayDetailsComponent, {
@@ -154,6 +189,7 @@ export class ActivityCalendarTileComponent {
         locale: this.locale,
         unitSettings: this.user()?.settings?.unitSettings ?? null,
         summariesSettings: this.user()?.settings?.summariesSettings ?? null,
+        plannedWorkouts: this.plannedWorkoutsByDate()[day.dateKey]?.entries ?? [],
       },
     });
   }

--- a/src/app/components/calendar/activity-calendar-tile/activity-calendar-tile.component.ts
+++ b/src/app/components/calendar/activity-calendar-tile/activity-calendar-tile.component.ts
@@ -190,6 +190,8 @@ export class ActivityCalendarTileComponent {
         unitSettings: this.user()?.settings?.unitSettings ?? null,
         summariesSettings: this.user()?.settings?.summariesSettings ?? null,
         plannedWorkouts: this.plannedWorkoutsByDate()[day.dateKey]?.entries ?? [],
+        plannedWorkoutsSource: () => this.plannedWorkoutsByDate()[day.dateKey]?.entries ?? [],
+        plannedWorkoutsStatusSource: () => this.plansState().status,
       },
     });
   }

--- a/src/app/components/calendar/activity-calendar-tile/activity-calendar-tile.component.ts
+++ b/src/app/components/calendar/activity-calendar-tile/activity-calendar-tile.component.ts
@@ -111,6 +111,7 @@ export class ActivityCalendarTileComponent {
     return buildPlannedWorkoutCalendarOverlay(
       selectCalendarVisibleScheduledWorkouts(schedule),
       schedule.plans,
+      schedule.state.activePlanId,
     );
   });
   readonly calendarModel = computed(() => buildActivityCalendarViewModel(this.eventState().events, {

--- a/src/app/components/calendar/calendar-day-details/calendar-day-details.component.html
+++ b/src/app/components/calendar/calendar-day-details/calendar-day-details.component.html
@@ -21,26 +21,71 @@
       </mat-action-list>
     </section>
     }
+
+    <section class="calendar-day-planned" aria-labelledby="calendar-day-planned-title">
+      <div class="calendar-day-section-heading">
+        <h3 id="calendar-day-planned-title">Planned workouts</h3>
+        <div class="calendar-day-plan-actions" aria-label="Add a workout">
+          <a mat-flat-button [routerLink]="['/plans']" [queryParams]="{ date: data.day.dateKey }"
+            (click)="prepareWorkoutNavigation()">
+            <mat-icon aria-hidden="true">add</mat-icon>
+            Add workout
+          </a>
+          <a mat-stroked-button [routerLink]="['/plans']"
+            [queryParams]="{ date: data.day.dateKey, scope: 'standalone' }"
+            (click)="prepareWorkoutNavigation()">
+            Standalone
+          </a>
+        </div>
+      </div>
+      @if (plannedWorkoutsStatus() === 'loading') {
+      <p class="calendar-day-empty" role="status">Loading planned workouts…</p>
+      } @else if (plannedWorkoutsStatus() === 'error') {
+      <p class="calendar-day-empty" role="status">Planned workouts could not be loaded.</p>
+      } @else if (plannedWorkoutRows().length) {
+      <mat-nav-list>
+        @for (planned of plannedWorkoutRows(); track planned.id) {
+        <a mat-list-item class="calendar-day-planned-item" [routerLink]="['/plans']"
+          [queryParams]="{ workout: planned.id }" (click)="prepareWorkoutNavigation()">
+          <app-activity-type-icon matListItemIcon [activityType]="planned.sport" size="24px"
+            aria-hidden="true"></app-activity-type-icon>
+          <span matListItemTitle>{{ planned.title }}</span>
+          <span matListItemLine>{{ planned.scopeLabel }} · {{ planned.lifecycleLabel }}</span>
+          <span matListItemLine class="calendar-day-planned-summary">{{ planned.summary.join(' · ') }}</span>
+          <mat-icon matListItemMeta aria-hidden="true">chevron_right</mat-icon>
+        </a>
+        }
+      </mat-nav-list>
+      } @else {
+      <p class="calendar-day-empty">No planned workouts for this day.</p>
+      }
+    </section>
+
+    <mat-divider></mat-divider>
+
     @if (activityState().status === 'loading') {
     <p role="status">Loading activities…</p>
     } @else if (activityState().status === 'error') {
     <p role="status">Activities could not be loaded. Close this sheet and retry the calendar.</p>
-    } @else if (day().eventCount) {
-    <div class="calendar-day-total" aria-label="Day total">
-      <span><span class="calendar-day-number">{{ day().eventCount }}</span> {{ day().eventCount === 1 ? 'activity' : 'activities' }}</span>
+    } @else {
+    <div class="calendar-day-total" aria-label="Completed activity total">
+      <span><span class="calendar-day-number">{{ day().eventCount }}</span> completed {{ day().eventCount === 1 ? 'activity' : 'activities' }}</span>
       <strong>{{ day().durationLabel }}</strong>
     </div>
 
+    @if (familyVolumeRows().length) {
     <section aria-labelledby="calendar-day-family-title">
-      <h3 id="calendar-day-family-title">Activities</h3>
+      <h3 id="calendar-day-family-title">Completed activities</h3>
       <app-activity-calendar-volume-list [rows]="familyVolumeRows()" [emphasizeNumericText]="true"
         (rowSelected)="prepareEventNavigation($event.route)"></app-activity-calendar-volume-list>
     </section>
 
     <mat-divider></mat-divider>
+    }
 
     <section aria-labelledby="calendar-day-activities-title">
-      <h3 id="calendar-day-activities-title">Activity details</h3>
+      <h3 id="calendar-day-activities-title">Completed activity details</h3>
+      @if (eventRows().length) {
       <mat-nav-list>
         @for (event of eventRows(); track event.id) {
           @if (event.route) {
@@ -90,9 +135,10 @@
           }
         }
       </mat-nav-list>
+      } @else {
+      <p class="calendar-day-empty">No completed activities for this day.</p>
+      }
     </section>
-    } @else {
-    <p>No activities on this day.</p>
     }
   </div>
 </section>

--- a/src/app/components/calendar/calendar-day-details/calendar-day-details.component.scss
+++ b/src/app/components/calendar/calendar-day-details/calendar-day-details.component.scss
@@ -73,6 +73,39 @@ h3 {
   letter-spacing: 0;
 }
 
+.calendar-day-section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.calendar-day-section-heading h3 {
+  margin-bottom: 0;
+}
+
+.calendar-day-plan-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.calendar-day-planned-item {
+  height: auto;
+  min-height: 72px;
+}
+
+.calendar-day-planned-summary {
+  white-space: normal;
+}
+
+.calendar-day-empty {
+  margin: 12px 0 0;
+  color: var(--mat-sys-on-surface-variant);
+  font: var(--mat-sys-body-medium);
+}
+
 mat-nav-list,
 mat-action-list {
   padding-top: 0;
@@ -114,5 +147,15 @@ mat-action-list {
 @media (max-width: 480px) {
   .calendar-day-details-content {
     padding: 12px;
+  }
+
+  .calendar-day-section-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .calendar-day-plan-actions {
+    width: 100%;
+    justify-content: flex-start;
   }
 }

--- a/src/app/components/calendar/calendar-day-details/calendar-day-details.component.spec.ts
+++ b/src/app/components/calendar/calendar-day-details/calendar-day-details.component.spec.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { TestBed } from '@angular/core/testing';
 import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import type { TimelineNote } from '@shared/timeline-notes';
 import { MAT_BOTTOM_SHEET_DATA, MatBottomSheetRef } from '@angular/material/bottom-sheet';
 import { provideRouter } from '@angular/router';
@@ -17,6 +17,7 @@ import {
 import { buildActivityCalendarViewModel } from '../../../helpers/activity-calendar.helper';
 import { AppEventColorService } from '../../../services/color/app.event.color.service';
 import { CalendarDayDetailsNavigationService } from '../../../services/calendar-day-details-navigation.service';
+import type { PlannedWorkoutCalendarEntry } from '../../../helpers/planned-workout-calendar.helper';
 import { CalendarDayDetailsComponent, type CalendarDayDetailsData } from './calendar-day-details.component';
 
 describe('CalendarDayDetailsComponent', () => {
@@ -83,6 +84,25 @@ describe('CalendarDayDetailsComponent', () => {
     ]);
     expect(fixture.nativeElement.textContent).toContain('No completed activities for this day.');
     expect(fixture.nativeElement.querySelector('[aria-labelledby="calendar-day-family-title"]')).toBeNull();
+  });
+
+  it('updates an already-open day when the planned-workout listener finishes', async () => {
+    const status = signal<'loading' | 'ready' | 'error'>('loading');
+    const planned = signal<PlannedWorkoutCalendarEntry[]>([]);
+    const fixture = await renderDayDetails([], {
+      plannedWorkoutsSource: () => planned(),
+      plannedWorkoutsStatusSource: () => status(),
+    });
+
+    expect(fixture.nativeElement.textContent).toContain('Loading planned workouts');
+
+    planned.set([{ workout: createPlannedWorkout(), planName: 'Autumn build' }]);
+    status.set('ready');
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.calendar-day-planned-item')?.textContent)
+      .toContain('Autumn build · Planned');
+    expect(fixture.nativeElement.textContent).not.toContain('Loading planned workouts');
   });
 
   it('uses Barlow Condensed only for numeric day-detail content, not the date title', () => {

--- a/src/app/components/calendar/calendar-day-details/calendar-day-details.component.spec.ts
+++ b/src/app/components/calendar/calendar-day-details/calendar-day-details.component.spec.ts
@@ -25,7 +25,7 @@ describe('CalendarDayDetailsComponent', () => {
     const notes = signal<readonly TimelineNote[]>([note]);
     const fixture = await renderDayDetails([], { timelineNotes: notes });
     expect(fixture.nativeElement.querySelector('#calendar-day-notes-title')?.textContent).toBe('Timeline notes');
-    expect(fixture.nativeElement.textContent).toContain('No activities on this day');
+    expect(fixture.nativeElement.textContent).toContain('No completed activities for this day');
     const button = fixture.nativeElement.querySelector('mat-action-list button') as HTMLButtonElement;
     expect(button.textContent).toContain('<b>Trip</b>');
     expect(button.textContent).toContain('Travel');
@@ -34,7 +34,8 @@ describe('CalendarDayDetailsComponent', () => {
     expect([...button.querySelectorAll('[matListItemLine]')].map(line => line.textContent?.trim()))
       .toEqual(['Travel', '2026-08-01 – ongoing']);
     expect(button.querySelector('b')).toBeNull();
-    expect(fixture.nativeElement.querySelector('#calendar-day-activities-title')).toBeNull();
+    expect(fixture.nativeElement.querySelector('#calendar-day-activities-title')?.textContent)
+      .toContain('Completed activity details');
     button.click();
     expect(TestBed.inject(MatBottomSheetRef).dismiss).toHaveBeenCalledExactlyOnceWith(note.id);
     notes.set([]); fixture.detectChanges();
@@ -47,7 +48,8 @@ describe('CalendarDayDetailsComponent', () => {
 
     expect(fixture.nativeElement.textContent).toContain('Running');
     expect(fixture.nativeElement.textContent).toContain('Morning run');
-    expect(fixture.nativeElement.querySelector('a')?.getAttribute('href')).toBe('/user/user-1/event/event-1');
+    expect(fixture.nativeElement.querySelector('.calendar-day-event-item')?.getAttribute('href'))
+      .toBe('/user/user-1/event/event-1');
     expect(fixture.nativeElement.querySelector('.calendar-family-volume-copy strong')?.textContent?.trim()).toBe('Running');
     expect(fixture.nativeElement.querySelector('.calendar-family-volume-value')?.textContent?.trim()).toBe('1h');
     expect(fixture.nativeElement.querySelector('.calendar-family-volume-row--link')?.getAttribute('href'))
@@ -60,7 +62,27 @@ describe('CalendarDayDetailsComponent', () => {
     expect([...fixture.nativeElement.querySelectorAll('.calendar-day-event-metric')]
       .map((part: HTMLElement) => part.textContent?.trim())).toEqual(['8:30 AM', '1h']);
     expect([...fixture.nativeElement.querySelectorAll('h3')].map((heading: HTMLElement) => heading.textContent?.trim()))
-      .toEqual(['Activities', 'Activity details']);
+      .toEqual(['Planned workouts', 'Completed activities', 'Completed activity details']);
+  });
+
+  it('keeps planned workouts separate and offers active-plan and standalone add paths', async () => {
+    const fixture = await renderDayDetails([], { plannedWorkouts: [{
+      workout: createPlannedWorkout(),
+      planName: 'Autumn build',
+    }] });
+    const actions = [...fixture.nativeElement.querySelectorAll('.calendar-day-plan-actions a')] as HTMLAnchorElement[];
+
+    expect(fixture.nativeElement.querySelector('.calendar-day-planned-item')?.getAttribute('href'))
+      .toBe('/plans?workout=workout-1');
+    expect(fixture.nativeElement.querySelector('.calendar-day-planned-item')?.textContent)
+      .toContain('Autumn build · Planned');
+    expect(fixture.nativeElement.querySelector('.calendar-day-planned-summary')?.textContent).toContain('30m 00s');
+    expect(actions.map(action => action.getAttribute('href'))).toEqual([
+      '/plans?date=2026-08-03',
+      '/plans?date=2026-08-03&scope=standalone',
+    ]);
+    expect(fixture.nativeElement.textContent).toContain('No completed activities for this day.');
+    expect(fixture.nativeElement.querySelector('[aria-labelledby="calendar-day-family-title"]')).toBeNull();
   });
 
   it('uses Barlow Condensed only for numeric day-detail content, not the date title', () => {
@@ -248,6 +270,31 @@ async function renderDayDetails(eventOrEvents: EventInterface | EventInterface[]
   const fixture = TestBed.createComponent(CalendarDayDetailsComponent);
   fixture.detectChanges();
   return fixture;
+}
+
+function createPlannedWorkout() {
+  return {
+    schemaVersion: 1 as const,
+    id: 'workout-1',
+    planId: 'plan-1',
+    localDate: '2026-08-03',
+    lifecycle: 'planned' as const,
+    title: 'Tempo intervals',
+    structure: {
+      version: 1 as const,
+      sport: ActivityTypes.Running,
+      nodes: [{
+        kind: 'step' as const,
+        id: 'steady',
+        purpose: 'work' as const,
+        ending: { kind: 'time' as const, seconds: 1800 },
+        targets: [],
+      }],
+    },
+    revision: 1,
+    createdAtMs: 1,
+    updatedAtMs: 1,
+  };
 }
 
 function createEvent(

--- a/src/app/components/calendar/calendar-day-details/calendar-day-details.component.ts
+++ b/src/app/components/calendar/calendar-day-details/calendar-day-details.component.ts
@@ -22,6 +22,8 @@ import { SharedModule } from '../../../modules/shared.module';
 import { CalendarDayDetailsNavigationService } from '../../../services/calendar-day-details-navigation.service';
 import { ActivityCalendarVolumeListComponent } from '../activity-calendar-volume-list/activity-calendar-volume-list.component';
 import { ActivityCalendarVolumeStatsComponent } from '../activity-calendar-volume-list/activity-calendar-volume-stats.component';
+import type { PlannedWorkoutCalendarEntry } from '../../../helpers/planned-workout-calendar.helper';
+import { formatManualWorkoutStructure } from '../../../helpers/planned-workout-editor.helper';
 
 export interface CalendarDayDetailsData {
   day: ActivityCalendarDayViewModel;
@@ -31,6 +33,18 @@ export interface CalendarDayDetailsData {
   summariesSettings?: SummaryStatsSettingsLike | null;
   timelineNotes?: Signal<readonly TimelineNote[]>;
   activities?: Signal<{ status: 'loading' | 'ready' | 'error'; day: ActivityCalendarDayViewModel }>;
+  plannedWorkouts?: PlannedWorkoutCalendarEntry[];
+  plannedWorkoutsSource?: () => readonly PlannedWorkoutCalendarEntry[];
+  plannedWorkoutsStatusSource?: () => 'loading' | 'ready' | 'error';
+}
+
+interface CalendarDayPlannedWorkoutRow {
+  id: string;
+  title: string;
+  sport: string;
+  scopeLabel: string;
+  lifecycleLabel: string;
+  summary: string[];
 }
 
 interface CalendarDayEventRow {
@@ -77,6 +91,17 @@ export class CalendarDayDetailsComponent {
     note, category: TIMELINE_NOTE_LABELS[note.category], dates: timelineNoteDates(note),
     icon: TIMELINE_NOTE_ICONS[note.category], color: timelineNoteColor(note),
   })));
+  readonly plannedWorkoutsStatus = computed(() => this.data.plannedWorkoutsStatusSource?.() ?? 'ready');
+  readonly plannedWorkoutRows = computed(() => (
+    this.data.plannedWorkoutsSource?.() ?? this.data.plannedWorkouts ?? []
+  ).map<CalendarDayPlannedWorkoutRow>(entry => ({
+    id: entry.workout.id,
+    title: entry.workout.title,
+    sport: entry.workout.structure.sport,
+    scopeLabel: entry.planName ?? 'Standalone',
+    lifecycleLabel: entry.workout.lifecycle === 'skipped' ? 'Skipped' : 'Planned',
+    summary: formatManualWorkoutStructure(entry.workout.structure, this.data.unitSettings, this.data.locale),
+  })));
 
   selectNote(noteId: string): void {
     if (this.noteRows().some(row => row.note.id === noteId)) this.bottomSheetRef.dismiss(noteId);
@@ -91,6 +116,10 @@ export class CalendarDayDetailsComponent {
       return;
     }
     this.navigation.prepareReturn(this.router.url, this.data.day.dateKey);
+    this.dismiss();
+  }
+
+  prepareWorkoutNavigation(): void {
     this.dismiss();
   }
 

--- a/src/app/components/calendar/calendar-month-picker-bottom-sheet/calendar-month-picker-bottom-sheet.component.spec.ts
+++ b/src/app/components/calendar/calendar-month-picker-bottom-sheet/calendar-month-picker-bottom-sheet.component.spec.ts
@@ -4,6 +4,7 @@ import { TestBed } from '@angular/core/testing';
 import { MAT_BOTTOM_SHEET_DATA, MatBottomSheet, MatBottomSheetRef } from '@angular/material/bottom-sheet';
 import { of } from 'rxjs';
 import { ActivityCalendarService } from '../../../services/activity-calendar.service';
+import { TrainingPlansService } from '../../../services/training-plans.service';
 import {
   CalendarMonthPickerBottomSheetComponent,
   type CalendarMonthPickerBottomSheetData,
@@ -23,6 +24,16 @@ describe('CalendarMonthPickerBottomSheetComponent', () => {
         { provide: MatBottomSheetRef, useValue: { dismiss } },
         { provide: MatBottomSheet, useValue: { open: vi.fn() } },
         { provide: ActivityCalendarService, useValue: { watchEvents: vi.fn().mockReturnValue(of([])) } },
+        {
+          provide: TrainingPlansService,
+          useValue: {
+            watchSchedule: vi.fn().mockReturnValue(of({
+              state: { schemaVersion: 1, activePlanId: null, revision: 0, currentWorkoutCount: 0, updatedAtMs: 0 },
+              plans: [],
+              workouts: [],
+            })),
+          },
+        },
       ],
     }).compileComponents();
     const fixture = TestBed.createComponent(CalendarMonthPickerBottomSheetComponent);

--- a/src/app/components/calendar/calendar-page/calendar-page.component.html
+++ b/src/app/components/calendar/calendar-page/calendar-page.component.html
@@ -73,7 +73,13 @@
     @if (!hasError() && !isLoading() && !hasEvents()) {
     <span class="calendar-status-announcement" role="status">{{ emptyStateLabel() }}</span>
     }
-    <app-activity-calendar-grid [model]="calendarModel()" [timelineNotesByDate]="notesByDate()" (daySelected)="openDay($event)">
+    @if (plansState().status === 'error') {
+    <span class="calendar-status-announcement" role="status">Planned workouts could not be loaded.</span>
+    }
+    <app-activity-calendar-grid [model]="calendarModel()"
+      [timelineNotesByDate]="notesByDate()"
+      [plannedWorkoutsByDate]="plannedWorkoutsByDate()"
+      (daySelected)="openDay($event)">
     </app-activity-calendar-grid>
 
     @if (!isLoading() && familyVolumeRows().length) {

--- a/src/app/components/calendar/calendar-page/calendar-page.component.html
+++ b/src/app/components/calendar/calendar-page/calendar-page.component.html
@@ -70,7 +70,7 @@
     </button>
   </section>
   }
-    @if (!hasError() && !isLoading() && !hasEvents()) {
+    @if (eventState().status === 'ready' && !hasEvents()) {
     <span class="calendar-status-announcement" role="status">{{ emptyStateLabel() }}</span>
     }
     @if (plansState().status === 'error') {

--- a/src/app/components/calendar/calendar-page/calendar-page.component.spec.ts
+++ b/src/app/components/calendar/calendar-page/calendar-page.component.spec.ts
@@ -16,12 +16,14 @@ import {
 } from '@sports-alliance/sports-lib';
 import { BehaviorSubject, Subject, of, throwError } from 'rxjs';
 import type { TimelineNote } from '@shared/timeline-notes';
+import type { WorkoutStructureV1 } from '@shared/planned-workout';
 import { AppTimelineNotesService } from '../../../services/app.timeline-notes.service';
 import { AppHapticsService } from '../../../services/app.haptics.service';
 import type { CalendarDayDetailsData } from '../calendar-day-details/calendar-day-details.component';
 import { AppUserService } from '../../../services/app.user.service';
 import { ActivityCalendarService } from '../../../services/activity-calendar.service';
 import { CalendarDayDetailsNavigationService } from '../../../services/calendar-day-details-navigation.service';
+import { TrainingPlansService, type CurrentTrainingScheduleV1 } from '../../../services/training-plans.service';
 import { ActivityRangeTableSectionComponent } from '../../event-table/activity-range-table-section.component';
 import { CalendarPageComponent } from './calendar-page.component';
 
@@ -57,6 +59,7 @@ describe('CalendarPageComponent', () => {
   const notesService = { uid: signal<string | null>('user-1'), showOnCharts: signal(true), changes$: new Subject<void>(), loadRange: vi.fn(), invalidate: vi.fn(), isOwner: (uid: string) => notesService.uid() === uid };
   const haptics = { selection: vi.fn() };
   const dialogs = { open: vi.fn() };
+  let watchSchedule: ReturnType<typeof vi.fn>;
   let dayDetailsNavigation: {
     restorationFor: ReturnType<typeof vi.fn>;
     consumeRestoration: ReturnType<typeof vi.fn>;
@@ -72,6 +75,7 @@ describe('CalendarPageComponent', () => {
     notesService.loadRange.mockReset().mockResolvedValue({ notes: [], incomplete: null });
     notesService.invalidate.mockImplementation(() => notesService.changes$.next());
     haptics.selection.mockClear(); dialogs.open.mockClear();
+    watchSchedule = vi.fn().mockReturnValue(of(emptySchedule()));
     dayDetailsNavigation = {
       restorationFor: vi.fn().mockReturnValue(null),
       consumeRestoration: vi.fn().mockReturnValue(true),
@@ -86,6 +90,7 @@ describe('CalendarPageComponent', () => {
         } },
         { provide: AppUserService, useValue: { user: signal(user), user$: of(user) } },
         { provide: ActivityCalendarService, useValue: { watchEvents } },
+        { provide: TrainingPlansService, useValue: { watchSchedule } },
         { provide: CalendarDayDetailsNavigationService, useValue: dayDetailsNavigation },
         { provide: AppTimelineNotesService, useValue: notesService },
         { provide: AppHapticsService, useValue: haptics },
@@ -111,7 +116,7 @@ describe('CalendarPageComponent', () => {
     expect(fixture.nativeElement.querySelector('.qs-page-header__leading-icon')?.textContent?.trim())
       .toBe('calendar_month');
     expect(fixture.nativeElement.querySelector('.calendar-progress-slot')).toBeTruthy();
-    expect(fixture.nativeElement.querySelectorAll('.activity-calendar-day-button')).toHaveLength(1);
+    expect(fixture.nativeElement.querySelectorAll('.activity-calendar-day-button')).toHaveLength(42);
     const summaryMetrics = [...fixture.nativeElement.querySelectorAll('.calendar-period-summary-metric')]
       .map((metric: HTMLElement) => ({
         label: metric.querySelector('.calendar-period-summary-label span')?.textContent?.trim(),
@@ -285,6 +290,35 @@ describe('CalendarPageComponent', () => {
     }));
   });
 
+  it('opens empty days and supplies standalone plus active-plan workouts separately', async () => {
+    watchSchedule.mockReturnValue(of(trainingSchedule()));
+    const fixture = TestBed.createComponent(CalendarPageComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const componentBottomSheet = (fixture.componentInstance as unknown as {
+      bottomSheet: MatBottomSheet;
+    }).bottomSheet;
+    const componentOpen = vi.spyOn(componentBottomSheet, 'open').mockImplementation(openBottomSheet);
+    const plannedDay = fixture.componentInstance.calendarModel().months[0].days
+      .find(day => day.dateKey === '2026-08-04')!;
+
+    fixture.componentInstance.openDay(plannedDay);
+
+    expect(fixture.nativeElement.querySelectorAll('[aria-label*="planned workout"]')).not.toHaveLength(0);
+    expect(componentOpen).toHaveBeenCalledWith(expect.any(Function), expect.objectContaining({
+      data: expect.objectContaining({
+        day: expect.objectContaining({ dateKey: '2026-08-04', eventCount: 0 }),
+        plannedWorkouts: [
+          expect.objectContaining({ workout: expect.objectContaining({ id: 'active-workout' }) }),
+          expect.objectContaining({ workout: expect.objectContaining({ id: 'standalone-workout' }) }),
+        ],
+      }),
+    }));
+    expect((componentOpen.mock.calls[0][1] as { data: { plannedWorkouts: Array<{ workout: { id: string } }> } })
+      .data.plannedWorkouts.map(entry => entry.workout.id)).not.toContain('inactive-workout');
+  });
+
   it('reopens day details after returning from an event route', async () => {
     const restoration = { sourceUrl: '/', dateKey: '2026-08-03' };
     dayDetailsNavigation.restorationFor.mockReturnValue(restoration);
@@ -356,7 +390,7 @@ describe('CalendarPageComponent', () => {
     fixture.componentInstance.retry(); notesService.changes$.next();
     fixture.detectChanges(); await fixture.whenStable(); fixture.detectChanges();
     expect(fixture.nativeElement.textContent).toContain('Retry notes');
-    expect(fixture.nativeElement.querySelectorAll('.activity-calendar-day-button')).toHaveLength(1);
+    expect(fixture.nativeElement.querySelectorAll('.activity-calendar-day-button')).toHaveLength(42);
   });
 
   it('shows the selected month empty state when only an adjacent grid day has an activity', async () => {
@@ -367,7 +401,7 @@ describe('CalendarPageComponent', () => {
     fixture.detectChanges();
 
     expect(fixture.componentInstance.hasEvents()).toBe(false);
-    expect(fixture.nativeElement.textContent).toContain('No activities in August 2026');
+    expect(fixture.nativeElement.textContent).toContain('No completed activities in August 2026');
     expect(fixture.nativeElement.querySelector('.calendar-status-announcement')).toBeTruthy();
     expect(fixture.nativeElement.querySelector('.calendar-status:not(.calendar-status--error)')).toBeNull();
   });
@@ -424,6 +458,83 @@ describe('CalendarPageComponent', () => {
     }
   });
 });
+
+function emptySchedule(): CurrentTrainingScheduleV1 {
+  return {
+    state: { schemaVersion: 1, activePlanId: null, revision: 0, currentWorkoutCount: 0, updatedAtMs: 0 },
+    plans: [],
+    workouts: [],
+  };
+}
+
+function trainingSchedule(): CurrentTrainingScheduleV1 {
+  const structure = {
+    version: 1 as const,
+    sport: ActivityTypes.Running,
+    nodes: [{
+      kind: 'step' as const,
+      id: 'steady',
+      purpose: 'work' as const,
+      ending: { kind: 'time' as const, seconds: 1800 },
+      targets: [],
+    }],
+  };
+  return {
+    state: { schemaVersion: 1, activePlanId: 'active-plan', revision: 1, currentWorkoutCount: 3, updatedAtMs: 1 },
+    plans: [
+      {
+        schemaVersion: 1,
+        id: 'active-plan',
+        name: 'Active build',
+        lifecycle: 'active',
+        startLocalDate: '2026-08-01',
+        endLocalDate: '2026-08-31',
+        revision: 1,
+        lastCheckpointRevision: 1,
+        workoutCount: 1,
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      },
+      {
+        schemaVersion: 1,
+        id: 'inactive-plan',
+        name: 'Paused build',
+        lifecycle: 'paused',
+        startLocalDate: '2026-08-01',
+        endLocalDate: '2026-08-31',
+        revision: 1,
+        lastCheckpointRevision: 1,
+        workoutCount: 1,
+        createdAtMs: 2,
+        updatedAtMs: 2,
+      },
+    ],
+    workouts: [
+      calendarWorkout('active-workout', 'active-plan', structure),
+      calendarWorkout('standalone-workout', null, structure),
+      calendarWorkout('inactive-workout', 'inactive-plan', structure),
+    ],
+  };
+}
+
+function calendarWorkout(
+  id: string,
+  planId: string | null,
+  structure: WorkoutStructureV1,
+) {
+  return {
+    schemaVersion: 1 as const,
+    id,
+    planId,
+    localDate: '2026-08-04',
+    lifecycle: 'planned' as const,
+    title: id,
+    structure,
+    revision: 1,
+    createdAtMs: 1,
+    updatedAtMs: 1,
+  };
+}
 
 function createEvent(
   startDate = new Date(2026, 7, 3, 8),

--- a/src/app/components/calendar/calendar-page/calendar-page.component.spec.ts
+++ b/src/app/components/calendar/calendar-page/calendar-page.component.spec.ts
@@ -339,12 +339,16 @@ describe('CalendarPageComponent', () => {
 
   it('shows a retryable error state', async () => {
     watchEvents.mockReturnValue(throwError(() => new Error('offline')));
+    watchSchedule.mockReturnValue(of(trainingSchedule()));
     const fixture = TestBed.createComponent(CalendarPageComponent);
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelector('[role="alert"]')?.textContent).toContain('could not be loaded');
+    expect(fixture.nativeElement.querySelectorAll('.activity-calendar-day-button')).toHaveLength(42);
+    expect(fixture.nativeElement.querySelector('.planned-workout-markers')).toBeTruthy();
+    expect(fixture.nativeElement.textContent).not.toContain('No completed activities in August 2026');
   });
   it('loads the visible grid and opens notes on days without activities using the shared manager', async () => {
     notesService.loadRange.mockResolvedValue({ notes: [note], incomplete: null });

--- a/src/app/components/calendar/calendar-page/calendar-page.component.ts
+++ b/src/app/components/calendar/calendar-page/calendar-page.component.ts
@@ -11,6 +11,11 @@ import { AppUserService } from '../../../services/app.user.service';
 import { ActivityCalendarService } from '../../../services/activity-calendar.service';
 import { CalendarDayDetailsNavigationService } from '../../../services/calendar-day-details-navigation.service';
 import {
+  TrainingPlansService,
+  selectCalendarVisibleScheduledWorkouts,
+  type CurrentTrainingScheduleV1,
+} from '../../../services/training-plans.service';
+import {
   type ActivityCalendarDayViewModel,
   type ActivityCalendarRouteState,
   type ActivityCalendarView,
@@ -36,10 +41,19 @@ import {
 import { ActivityRangeTableSectionComponent } from '../../event-table/activity-range-table-section.component';
 import { TimelineNotesWorkspaceComponent } from '../../timeline-notes/timeline-notes-workspace.component';
 import { calendarTimelineNoteRange, calendarTimelineNotesByDate } from '../../../helpers/calendar-timeline-notes.helper';
+import {
+  buildPlannedWorkoutCalendarOverlay,
+  type PlannedWorkoutCalendarOverlay,
+} from '../../../helpers/planned-workout-calendar.helper';
 
 interface CalendarEventsState {
   status: 'loading' | 'ready' | 'error';
   events: EventInterface[];
+}
+
+interface CalendarPlansState {
+  status: 'loading' | 'ready' | 'error';
+  schedule: CurrentTrainingScheduleV1 | null;
 }
 
 interface CalendarViewOption {
@@ -73,6 +87,7 @@ export class CalendarPageComponent {
   private readonly router = inject(Router);
   private readonly userService = inject(AppUserService);
   private readonly calendarService = inject(ActivityCalendarService);
+  private readonly plansService = inject(TrainingPlansService);
   private readonly bottomSheet = inject(MatBottomSheet);
   private readonly dayDetailsNavigation = inject(CalendarDayDetailsNavigationService);
   private readonly locale = inject(LOCALE_ID);
@@ -115,6 +130,22 @@ export class CalendarPageComponent {
       );
     }),
   ), { initialValue: { status: 'loading', events: [] } as CalendarEventsState });
+  readonly plansState = toSignal(this.userService.user$.pipe(
+    filter((user): user is AppUserInterface => !!user?.uid),
+    switchMap(user => this.plansService.watchSchedule(user.uid).pipe(
+      map(schedule => ({ status: 'ready', schedule }) as CalendarPlansState),
+      startWith({ status: 'loading', schedule: null } as CalendarPlansState),
+      catchError(() => of({ status: 'error', schedule: null } as CalendarPlansState)),
+    )),
+  ), { initialValue: { status: 'loading', schedule: null } as CalendarPlansState });
+  readonly plannedWorkoutsByDate = computed<PlannedWorkoutCalendarOverlay>(() => {
+    const schedule = this.plansState().schedule;
+    if (!schedule) return {};
+    return buildPlannedWorkoutCalendarOverlay(
+      selectCalendarVisibleScheduledWorkouts(schedule),
+      schedule.plans,
+    );
+  });
   readonly calendarModel = computed(() => {
     const state = this.routeState();
     return buildActivityCalendarViewModel(this.eventState().events, {
@@ -188,7 +219,7 @@ export class CalendarPageComponent {
   readonly hasEvents = computed(() => this.calendarModel().months.some(month => (
     month.days.some(day => day.inPrimaryPeriod && day.eventCount > 0)
   )));
-  readonly emptyStateLabel = computed(() => `No activities in ${this.calendarModel().periodLabel}`);
+  readonly emptyStateLabel = computed(() => `No completed activities in ${this.calendarModel().periodLabel}`);
   private readonly restoreDayDetailsEffect = effect(() => {
     const restoration = this.dayDetailsNavigation.restorationFor(this.router.url);
     if (!restoration || this.eventState().status !== 'ready') {
@@ -204,7 +235,7 @@ export class CalendarPageComponent {
     if (!this.dayDetailsNavigation.consumeRestoration(restoration)) {
       return;
     }
-    if (day?.eventCount) {
+    if (day) {
       this.openDay(day);
     }
   });
@@ -246,7 +277,7 @@ export class CalendarPageComponent {
 
   openDay(day: ActivityCalendarDayViewModel): void {
     const userId = `${this.currentUser()?.uid || ''}`.trim();
-    if ((!day.eventCount && !this.notesByDate().has(day.dateKey)) || !userId) {
+    if (!userId) {
       return;
     }
     // Keep an open sheet's notes live and owner-fenced through refreshes, edits, and account changes.
@@ -267,6 +298,9 @@ export class CalendarPageComponent {
             status: this.currentUser()?.uid === userId && currentDay ? this.eventState().status : 'error',
           };
         }),
+        plannedWorkouts: this.plannedWorkoutsByDate()[day.dateKey]?.entries ?? [],
+        plannedWorkoutsSource: () => this.plannedWorkoutsByDate()[day.dateKey]?.entries ?? [],
+        plannedWorkoutsStatusSource: () => this.plansState().status,
       },
     });
     sheet.afterDismissed().pipe(takeUntilDestroyed(this.destroy)).subscribe(noteId => {

--- a/src/app/components/calendar/calendar-page/calendar-page.component.ts
+++ b/src/app/components/calendar/calendar-page/calendar-page.component.ts
@@ -144,6 +144,7 @@ export class CalendarPageComponent {
     return buildPlannedWorkoutCalendarOverlay(
       selectCalendarVisibleScheduledWorkouts(schedule),
       schedule.plans,
+      schedule.state.activePlanId,
     );
   });
   readonly calendarModel = computed(() => {

--- a/src/app/components/calendar/calendar-page/calendar-page.component.ts
+++ b/src/app/components/calendar/calendar-page/calendar-page.component.ts
@@ -4,7 +4,7 @@ import { MatBottomSheet } from '@angular/material/bottom-sheet';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { DataAscent, DataDistance, type EventInterface } from '@sports-alliance/sports-lib';
 import { formatUnitAwareDataValue } from '@shared/unit-aware-display';
-import { catchError, combineLatest, distinctUntilChanged, filter, map, of, shareReplay, startWith, switchMap } from 'rxjs';
+import { catchError, combineLatest, distinctUntilChanged, map, of, shareReplay, startWith, switchMap } from 'rxjs';
 import type { AppUserInterface } from '../../../models/app-user.interface';
 import { SharedModule } from '../../../modules/shared.module';
 import { AppUserService } from '../../../services/app.user.service';
@@ -114,13 +114,12 @@ export class CalendarPageComponent {
   readonly routeState = toSignal(this.routeState$, { initialValue: this.initialRouteState });
   readonly currentUser = computed(() => this.userService.user() as AppUserInterface | null);
   readonly eventState = toSignal(combineLatest([
-    this.userService.user$.pipe(
-      filter((user): user is AppUserInterface => !!user?.uid),
-    ),
+    this.userService.user$,
     this.routeState$,
     toObservable(this.reloadSequence),
   ]).pipe(
     switchMap(([user, state]) => {
+      if (!user?.uid) return of({ status: 'ready', events: [] } as CalendarEventsState);
       const startOfWeek = user.settings?.unitSettings?.startOfTheWeek;
       const queryWindow = resolveActivityCalendarQueryWindow(state.view, state.anchorDate, startOfWeek);
       return this.calendarService.watchEvents(user, queryWindow).pipe(
@@ -131,12 +130,13 @@ export class CalendarPageComponent {
     }),
   ), { initialValue: { status: 'loading', events: [] } as CalendarEventsState });
   readonly plansState = toSignal(this.userService.user$.pipe(
-    filter((user): user is AppUserInterface => !!user?.uid),
-    switchMap(user => this.plansService.watchSchedule(user.uid).pipe(
-      map(schedule => ({ status: 'ready', schedule }) as CalendarPlansState),
-      startWith({ status: 'loading', schedule: null } as CalendarPlansState),
-      catchError(() => of({ status: 'error', schedule: null } as CalendarPlansState)),
-    )),
+    switchMap(user => user?.uid
+      ? this.plansService.watchSchedule(user.uid).pipe(
+        map(schedule => ({ status: 'ready', schedule }) as CalendarPlansState),
+        startWith({ status: 'loading', schedule: null } as CalendarPlansState),
+        catchError(() => of({ status: 'error', schedule: null } as CalendarPlansState)),
+      )
+      : of({ status: 'ready', schedule: null } as CalendarPlansState)),
   ), { initialValue: { status: 'loading', schedule: null } as CalendarPlansState });
   readonly plannedWorkoutsByDate = computed<PlannedWorkoutCalendarOverlay>(() => {
     const schedule = this.plansState().schedule;

--- a/src/app/components/plans/plans-workspace.component.html
+++ b/src/app/components/plans/plans-workspace.component.html
@@ -11,7 +11,8 @@
         <mat-icon aria-hidden="true">calendar_month</mat-icon>
         <span>Calendar</span>
       </a>
-      <button mat-flat-button type="button" (click)="openNewWorkout()" [disabled]="scheduleState().status !== 'ready'">
+      <button mat-flat-button type="button" (click)="openNewWorkout()"
+        [disabled]="scheduleState().status !== 'ready' || busyAction() !== null">
         <mat-icon aria-hidden="true">add</mat-icon>
         <span>Add workout</span>
       </button>
@@ -38,6 +39,7 @@
   <nav class="plans-view-navigation" aria-label="Workout scope">
     <mat-button-toggle-group
       [value]="view()"
+      [disabled]="busyAction() !== null"
       hideSingleSelectionIndicator
       aria-label="View plans or standalone workouts"
       (change)="selectView($event.value)">
@@ -50,7 +52,7 @@
         <span>Standalone</span>
       </mat-button-toggle>
     </mat-button-toggle-group>
-    <button mat-stroked-button type="button" (click)="beginPlanCreation()">
+    <button mat-stroked-button type="button" (click)="beginPlanCreation()" [disabled]="busyAction() !== null">
       <mat-icon aria-hidden="true">playlist_add</mat-icon>
       <span>New plan</span>
     </button>
@@ -97,9 +99,9 @@
           </mat-checkbox>
         </mat-card-content>
         <mat-card-actions align="end">
-          <button mat-button type="button" (click)="cancelPlanCreation()">Cancel</button>
+          <button mat-button type="button" (click)="cancelPlanCreation()" [disabled]="busyAction() !== null">Cancel</button>
           <button mat-flat-button type="button" (click)="createPlan()"
-            [disabled]="busyAction() === 'create-plan' || !planDraft().name.trim()">
+            [disabled]="busyAction() !== null || !planDraft().name.trim()">
             @if (busyAction() === 'create-plan') {
               <mat-spinner diameter="18"></mat-spinner>
             } @else {
@@ -116,7 +118,8 @@
         <div class="plan-selector-row">
           <mat-form-field subscriptSizing="dynamic">
             <mat-label>Training plan</mat-label>
-            <mat-select [value]="selectedPlanId()" (selectionChange)="selectPlan($event.value)">
+            <mat-select [value]="selectedPlanId()" (selectionChange)="selectPlan($event.value)"
+              [disabled]="busyAction() !== null">
               @for (plan of planOptions(); track plan.id) {
                 <mat-option [value]="plan.id">{{ plan.name }} · {{ plan.lifecycle | titlecase }}</mat-option>
               }
@@ -139,20 +142,24 @@
             <div class="plan-actions">
               @if (plan.lifecycle !== 'active') {
                 <button mat-stroked-button type="button" (click)="setPlanLifecycle(plan, 'active')"
-                  [disabled]="busyAction() === 'lifecycle-' + plan.id">
+                  [disabled]="busyAction() !== null">
                   <mat-icon aria-hidden="true">play_circle</mat-icon>
                   <span>Activate</span>
                 </button>
               } @else {
                 <button mat-stroked-button type="button" (click)="setPlanLifecycle(plan, 'paused')"
-                  [disabled]="busyAction() === 'lifecycle-' + plan.id">
+                  [disabled]="busyAction() !== null">
                   <mat-icon aria-hidden="true">pause_circle</mat-icon>
                   <span>Pause</span>
                 </button>
               }
-              <button mat-button type="button" [matMenuTriggerFor]="planActionsMenu">
-                <mat-icon aria-hidden="true">more_horiz</mat-icon>
-                <span>Plan actions</span>
+              <button mat-button type="button" [matMenuTriggerFor]="planActionsMenu" [disabled]="busyAction() !== null">
+                @if (selectedPlanActionBusy()) {
+                  <mat-spinner diameter="18"></mat-spinner>
+                } @else {
+                  <mat-icon aria-hidden="true">more_horiz</mat-icon>
+                }
+                <span>{{ selectedPlanActionBusy() ? 'Updating plan' : 'Plan actions' }}</span>
               </button>
               <mat-menu #planActionsMenu="matMenu" class="qs-menu-panel">
                 <button mat-menu-item type="button" (click)="beginRename(plan)">
@@ -182,8 +189,16 @@
                 <mat-label>Plan name</mat-label>
                 <input matInput maxlength="120" [ngModel]="renameValue()" (ngModelChange)="renameValue.set($event)">
               </mat-form-field>
-              <button mat-flat-button type="button" (click)="renamePlan(plan)" [disabled]="!renameValue().trim()">Save</button>
-              <button mat-button type="button" (click)="renamingPlanId.set(null)">Cancel</button>
+              <button mat-flat-button type="button" (click)="renamePlan(plan)"
+                [disabled]="busyAction() !== null || !renameValue().trim()">
+                @if (busyAction() === 'rename-' + plan.id) {
+                  <mat-spinner diameter="18"></mat-spinner>
+                } @else {
+                  <mat-icon aria-hidden="true">save</mat-icon>
+                }
+                <span>Save</span>
+              </button>
+              <button mat-button type="button" (click)="renamingPlanId.set(null)" [disabled]="busyAction() !== null">Cancel</button>
             </div>
           }
 
@@ -195,8 +210,15 @@
                   (ngModelChange)="shiftDays.set(+$event)">
                 <mat-hint>Negative moves the plan earlier</mat-hint>
               </mat-form-field>
-              <button mat-flat-button type="button" (click)="shiftPlan(plan)">Shift plan</button>
-              <button mat-button type="button" (click)="shiftingPlanId.set(null)">Cancel</button>
+              <button mat-flat-button type="button" (click)="shiftPlan(plan)" [disabled]="busyAction() !== null">
+                @if (busyAction() === 'shift-' + plan.id) {
+                  <mat-spinner diameter="18"></mat-spinner>
+                } @else {
+                  <mat-icon aria-hidden="true">date_range</mat-icon>
+                }
+                <span>Shift plan</span>
+              </button>
+              <button mat-button type="button" (click)="shiftingPlanId.set(null)" [disabled]="busyAction() !== null">Cancel</button>
             </div>
           }
 
@@ -217,12 +239,18 @@
                 </mat-radio-group>
               </mat-card-content>
               <mat-card-actions align="end">
-                <button mat-button type="button" (click)="deletingPlanId.set(null)">Cancel</button>
-                <button mat-stroked-button type="button" (click)="setPlanLifecycle(plan, 'archived')">
-                  Archive instead
+                <button mat-button type="button" (click)="deletingPlanId.set(null)" [disabled]="busyAction() !== null">Cancel</button>
+                <button mat-stroked-button type="button" (click)="setPlanLifecycle(plan, 'archived')"
+                  [disabled]="busyAction() !== null">
+                  @if (busyAction() === 'lifecycle-' + plan.id) {
+                    <mat-spinner diameter="18"></mat-spinner>
+                  } @else {
+                    <mat-icon aria-hidden="true">archive</mat-icon>
+                  }
+                  <span>Archive instead</span>
                 </button>
                 <button mat-flat-button color="warn" type="button" (click)="deletePlan(plan)"
-                  [disabled]="busyAction() === 'delete-plan-' + plan.id">
+                  [disabled]="busyAction() !== null">
                   @if (busyAction() === 'delete-plan-' + plan.id) {
                     <mat-spinner diameter="18"></mat-spinner>
                   } @else {
@@ -238,7 +266,7 @@
             <mat-icon aria-hidden="true">event_note</mat-icon>
             <h2 id="plan-scope-title">No plans yet</h2>
             <p>Create a plan, or switch to Standalone to add workouts without one.</p>
-            <button mat-flat-button type="button" (click)="beginPlanCreation()">Create your first plan</button>
+            <button mat-flat-button type="button" (click)="beginPlanCreation()" [disabled]="busyAction() !== null">Create your first plan</button>
           </section>
         }
       </section>
@@ -248,7 +276,7 @@
           <h2 id="standalone-title">Standalone workouts</h2>
           <p>These workouts do not belong to a plan and can be attached later.</p>
         </div>
-        <button mat-flat-button type="button" (click)="openNewWorkout(null)">
+        <button mat-flat-button type="button" (click)="openNewWorkout(null)" [disabled]="busyAction() !== null">
           <mat-icon aria-hidden="true">add</mat-icon><span>Add standalone</span>
         </button>
       </section>
@@ -371,9 +399,9 @@
           </section>
         </mat-card-content>
         <mat-card-actions align="end">
-          <button mat-button type="button" (click)="cancelEditor()">Cancel</button>
+          <button mat-button type="button" (click)="cancelEditor()" [disabled]="busyAction() !== null">Cancel</button>
           <button mat-flat-button type="button" (click)="saveWorkout()"
-            [disabled]="busyAction() === 'save-workout' || !session.value.title.trim() || session.value.nodes.length === 0">
+            [disabled]="busyAction() !== null || !session.value.title.trim() || session.value.nodes.length === 0">
             @if (busyAction() === 'save-workout') {
               <mat-spinner diameter="18"></mat-spinner>
             } @else {
@@ -420,12 +448,12 @@
           <mat-form-field subscriptSizing="dynamic">
             <mat-label>{{ step.targetKind === 'pace' ? 'Faster min/km' : 'Minimum' }}</mat-label>
             <input matInput type="number" [min]="step.targetKind === 'pace' ? 0.01 : 0" step="0.01" [ngModel]="step.targetMinimum"
-              (ngModelChange)="updateStep(nodeIndex, stepIndex, 'targetMinimum', +$event)">
+              (ngModelChange)="updateStep(nodeIndex, stepIndex, 'targetMinimum', $event)">
           </mat-form-field>
           <mat-form-field subscriptSizing="dynamic">
             <mat-label>{{ step.targetKind === 'pace' ? 'Slower min/km' : 'Maximum' }}</mat-label>
             <input matInput type="number" [min]="step.targetKind === 'pace' ? 0.01 : 0" step="0.01" [ngModel]="step.targetMaximum"
-              (ngModelChange)="updateStep(nodeIndex, stepIndex, 'targetMaximum', +$event)">
+              (ngModelChange)="updateStep(nodeIndex, stepIndex, 'targetMaximum', $event)">
           </mat-form-field>
         }
       </div>
@@ -439,7 +467,7 @@
         </div>
         <button mat-stroked-button type="button"
           (click)="openNewWorkout(view() === 'plans' ? selectedPlanId() : null)"
-          [disabled]="view() === 'plans' && !selectedPlanId()">
+          [disabled]="busyAction() !== null || (view() === 'plans' && !selectedPlanId())">
           <mat-icon aria-hidden="true">add</mat-icon><span>Add here</span>
         </button>
       </div>
@@ -471,23 +499,37 @@
                 </ol>
               </mat-card-content>
               <mat-card-actions align="end">
-                <button mat-button type="button" (click)="editWorkout(row.workout)">
+                <button mat-button type="button" (click)="editWorkout(row.workout)" [disabled]="busyAction() !== null">
                   <mat-icon aria-hidden="true">edit</mat-icon><span>Edit / move</span>
                 </button>
-                <button mat-button type="button" (click)="copyWorkout(row.workout)">
-                  <mat-icon aria-hidden="true">content_copy</mat-icon><span>Copy</span>
+                <button mat-button type="button" (click)="copyWorkout(row.workout)" [disabled]="busyAction() !== null">
+                  @if (busyAction() === 'copy-' + row.workout.id) {
+                    <mat-spinner diameter="18"></mat-spinner>
+                  } @else {
+                    <mat-icon aria-hidden="true">content_copy</mat-icon>
+                  }
+                  <span>Copy</span>
                 </button>
-                <button mat-button type="button" (click)="setWorkoutSkipped(row.workout, row.workout.lifecycle !== 'skipped')">
-                  <mat-icon aria-hidden="true">{{ row.workout.lifecycle === 'skipped' ? 'undo' : 'skip_next' }}</mat-icon>
+                <button mat-button type="button" (click)="setWorkoutSkipped(row.workout, row.workout.lifecycle !== 'skipped')"
+                  [disabled]="busyAction() !== null">
+                  @if (busyAction() === 'skip-' + row.workout.id) {
+                    <mat-spinner diameter="18"></mat-spinner>
+                  } @else {
+                    <mat-icon aria-hidden="true">{{ row.workout.lifecycle === 'skipped' ? 'undo' : 'skip_next' }}</mat-icon>
+                  }
                   <span>{{ row.workout.lifecycle === 'skipped' ? 'Unskip' : 'Skip' }}</span>
                 </button>
                 <button mat-icon-button type="button" matTooltip="Workout history" aria-label="Workout history"
-                  (click)="openHistory(historyScopeForWorkout(row.workout))">
+                  (click)="openHistory(row.historyScope)" [disabled]="busyAction() !== null">
                   <mat-icon>history</mat-icon>
                 </button>
                 <button mat-icon-button type="button" matTooltip="Delete workout" aria-label="Delete workout"
-                  (click)="deleteWorkout(row.workout)">
-                  <mat-icon>delete</mat-icon>
+                  (click)="deleteWorkout(row.workout)" [disabled]="busyAction() !== null">
+                  @if (busyAction() === 'delete-' + row.workout.id) {
+                    <mat-spinner diameter="18"></mat-spinner>
+                  } @else {
+                    <mat-icon>delete</mat-icon>
+                  }
                 </button>
               </mat-card-actions>
             </mat-card>
@@ -511,12 +553,16 @@
                 {{ row.workout.localDate }} · Open {{ row.workout.planId ? 'plan' : 'workout' }} history to restore
               </span>
               <div matListItemMeta class="deleted-workout-actions">
-                <button mat-button type="button" (click)="openHistory(historyScopeForWorkout(row.workout))">
+                <button mat-button type="button" (click)="openHistory(row.historyScope)" [disabled]="busyAction() !== null">
                   <mat-icon aria-hidden="true">history</mat-icon><span>History</span>
                 </button>
                 <button mat-icon-button type="button" matTooltip="Delete permanently" aria-label="Delete workout permanently"
-                  (click)="permanentlyDeleteWorkout(row.workout)">
-                  <mat-icon>delete_forever</mat-icon>
+                  (click)="permanentlyDeleteWorkout(row.workout)" [disabled]="busyAction() !== null">
+                  @if (busyAction() === 'permanent-' + row.workout.id) {
+                    <mat-spinner diameter="18"></mat-spinner>
+                  } @else {
+                    <mat-icon>delete_forever</mat-icon>
+                  }
                 </button>
               </div>
             </mat-list-item>
@@ -551,7 +597,7 @@
                   <span matListItemTitle>Revision {{ entry.revision }} · {{ entry.operationKind }}</span>
                   <span matListItemLine>{{ entry.createdAtMs | date:'medium' }}{{ entry.isCheckpoint ? ' · checkpoint' : '' }}</span>
                   <button mat-stroked-button matListItemMeta type="button" (click)="restoreHistoryEntry(entry)"
-                    [disabled]="busyAction() === 'restore-' + entry.revision">
+                    [disabled]="busyAction() !== null">
                     @if (busyAction() === 'restore-' + entry.revision) {
                       <mat-spinner diameter="18"></mat-spinner>
                     } @else {
@@ -565,7 +611,7 @@
             @if (history.nextBeforeRevision !== null) {
               <div class="history-load-more">
                 <button mat-stroked-button type="button" (click)="loadOlderHistory()"
-                  [disabled]="busyAction() === 'history-older'">
+                  [disabled]="busyAction() !== null">
                   @if (busyAction() === 'history-older') {
                     <mat-spinner diameter="18"></mat-spinner>
                   } @else {

--- a/src/app/components/plans/plans-workspace.component.html
+++ b/src/app/components/plans/plans-workspace.component.html
@@ -419,12 +419,12 @@
         @if (step.targetKind !== 'none') {
           <mat-form-field subscriptSizing="dynamic">
             <mat-label>{{ step.targetKind === 'pace' ? 'Faster min/km' : 'Minimum' }}</mat-label>
-            <input matInput type="number" min="0.01" step="0.01" [ngModel]="step.targetMinimum"
+            <input matInput type="number" [min]="step.targetKind === 'pace' ? 0.01 : 0" step="0.01" [ngModel]="step.targetMinimum"
               (ngModelChange)="updateStep(nodeIndex, stepIndex, 'targetMinimum', +$event)">
           </mat-form-field>
           <mat-form-field subscriptSizing="dynamic">
             <mat-label>{{ step.targetKind === 'pace' ? 'Slower min/km' : 'Maximum' }}</mat-label>
-            <input matInput type="number" min="0.01" step="0.01" [ngModel]="step.targetMaximum"
+            <input matInput type="number" [min]="step.targetKind === 'pace' ? 0.01 : 0" step="0.01" [ngModel]="step.targetMaximum"
               (ngModelChange)="updateStep(nodeIndex, stepIndex, 'targetMaximum', +$event)">
           </mat-form-field>
         }

--- a/src/app/components/plans/plans-workspace.component.html
+++ b/src/app/components/plans/plans-workspace.component.html
@@ -1,0 +1,583 @@
+<main class="plans-workspace qs-workspace-page" aria-labelledby="plans-title">
+  <app-page-header
+    title="Plans"
+    titleId="plans-title"
+    leadingIcon="event_note"
+    eyebrow="Manual planning is free"
+    subtitle="Build standalone workouts or organize them into one active plan"
+    [status]="pageStatus()">
+    <div pageHeaderActions class="plans-header-actions">
+      <a mat-button routerLink="/calendar">
+        <mat-icon aria-hidden="true">calendar_month</mat-icon>
+        <span>Calendar</span>
+      </a>
+      <button mat-flat-button type="button" (click)="openNewWorkout()" [disabled]="scheduleState().status !== 'ready'">
+        <mat-icon aria-hidden="true">add</mat-icon>
+        <span>Add workout</span>
+      </button>
+    </div>
+  </app-page-header>
+
+  <section class="plans-overview" aria-label="Planning overview">
+    <div>
+      <span>Active plan</span>
+      <strong>{{ activePlanLabel() }}</strong>
+    </div>
+    <mat-divider vertical></mat-divider>
+    <div>
+      <span>Current workouts</span>
+      <strong>{{ schedule().state.currentWorkoutCount }}</strong>
+    </div>
+    <mat-divider vertical></mat-divider>
+    <div>
+      <span>Plans</span>
+      <strong>{{ planOptions().length }}</strong>
+    </div>
+  </section>
+
+  <nav class="plans-view-navigation" aria-label="Workout scope">
+    <mat-button-toggle-group
+      [value]="view()"
+      hideSingleSelectionIndicator
+      aria-label="View plans or standalone workouts"
+      (change)="selectView($event.value)">
+      <mat-button-toggle value="plans">
+        <mat-icon aria-hidden="true">event_note</mat-icon>
+        <span>Plans</span>
+      </mat-button-toggle>
+      <mat-button-toggle value="standalone">
+        <mat-icon aria-hidden="true">directions_run</mat-icon>
+        <span>Standalone</span>
+      </mat-button-toggle>
+    </mat-button-toggle-group>
+    <button mat-stroked-button type="button" (click)="beginPlanCreation()">
+      <mat-icon aria-hidden="true">playlist_add</mat-icon>
+      <span>New plan</span>
+    </button>
+  </nav>
+
+  @if (scheduleState().status === 'loading') {
+    <section class="plans-status" aria-live="polite">
+      <mat-spinner diameter="28"></mat-spinner>
+      <span>Loading your training schedule…</span>
+    </section>
+  } @else if (scheduleState().status === 'error') {
+    <section class="plans-status plans-status--error" role="alert">
+      <mat-icon aria-hidden="true">error_outline</mat-icon>
+      <span>{{ scheduleState().message }}</span>
+    </section>
+  } @else {
+    @if (showPlanForm()) {
+      <mat-card class="plan-form-card">
+        <mat-card-header>
+          <mat-card-title>Create a training plan</mat-card-title>
+          <mat-card-subtitle>A plan can span up to 366 days. Only one plan is active at a time.</mat-card-subtitle>
+        </mat-card-header>
+        <mat-card-content>
+          <div class="plan-form-grid">
+            <mat-form-field>
+              <mat-label>Plan name</mat-label>
+              <input matInput maxlength="120" [ngModel]="planDraft().name"
+                (ngModelChange)="updatePlanDraft('name', $event)">
+            </mat-form-field>
+            <mat-form-field>
+              <mat-label>Start date</mat-label>
+              <input matInput type="date" [ngModel]="planDraft().startLocalDate"
+                (ngModelChange)="updatePlanDraft('startLocalDate', $event)">
+            </mat-form-field>
+            <mat-form-field>
+              <mat-label>End date</mat-label>
+              <input matInput type="date" [ngModel]="planDraft().endLocalDate"
+                (ngModelChange)="updatePlanDraft('endLocalDate', $event)">
+            </mat-form-field>
+          </div>
+          <mat-checkbox [ngModel]="planDraft().activate"
+            (ngModelChange)="updatePlanDraft('activate', $event)">
+            Make this the active plan
+          </mat-checkbox>
+        </mat-card-content>
+        <mat-card-actions align="end">
+          <button mat-button type="button" (click)="cancelPlanCreation()">Cancel</button>
+          <button mat-flat-button type="button" (click)="createPlan()"
+            [disabled]="busyAction() === 'create-plan' || !planDraft().name.trim()">
+            @if (busyAction() === 'create-plan') {
+              <mat-spinner diameter="18"></mat-spinner>
+            } @else {
+              <mat-icon aria-hidden="true">add</mat-icon>
+            }
+            <span>Create plan</span>
+          </button>
+        </mat-card-actions>
+      </mat-card>
+    }
+
+    @if (view() === 'plans') {
+      <section class="plan-scope" aria-labelledby="plan-scope-title">
+        <div class="plan-selector-row">
+          <mat-form-field subscriptSizing="dynamic">
+            <mat-label>Training plan</mat-label>
+            <mat-select [value]="selectedPlanId()" (selectionChange)="selectPlan($event.value)">
+              @for (plan of planOptions(); track plan.id) {
+                <mat-option [value]="plan.id">{{ plan.name }} · {{ plan.lifecycle | titlecase }}</mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+          @if (selectedPlan(); as plan) {
+            <mat-chip-set aria-label="Selected plan status">
+              <mat-chip [highlighted]="plan.lifecycle === 'active'">{{ plan.lifecycle | titlecase }}</mat-chip>
+              <mat-chip>{{ plan.startLocalDate }} – {{ plan.endLocalDate }}</mat-chip>
+            </mat-chip-set>
+          }
+        </div>
+
+        @if (selectedPlan(); as plan) {
+          <div class="plan-heading-row">
+            <div>
+              <h2 id="plan-scope-title">{{ plan.name }}</h2>
+              <p>{{ plan.workoutCount }} current workout{{ plan.workoutCount === 1 ? '' : 's' }}</p>
+            </div>
+            <div class="plan-actions">
+              @if (plan.lifecycle !== 'active') {
+                <button mat-stroked-button type="button" (click)="setPlanLifecycle(plan, 'active')"
+                  [disabled]="busyAction() === 'lifecycle-' + plan.id">
+                  <mat-icon aria-hidden="true">play_circle</mat-icon>
+                  <span>Activate</span>
+                </button>
+              } @else {
+                <button mat-stroked-button type="button" (click)="setPlanLifecycle(plan, 'paused')"
+                  [disabled]="busyAction() === 'lifecycle-' + plan.id">
+                  <mat-icon aria-hidden="true">pause_circle</mat-icon>
+                  <span>Pause</span>
+                </button>
+              }
+              <button mat-button type="button" [matMenuTriggerFor]="planActionsMenu">
+                <mat-icon aria-hidden="true">more_horiz</mat-icon>
+                <span>Plan actions</span>
+              </button>
+              <mat-menu #planActionsMenu="matMenu" class="qs-menu-panel">
+                <button mat-menu-item type="button" (click)="beginRename(plan)">
+                  <mat-icon aria-hidden="true">edit</mat-icon><span>Rename</span>
+                </button>
+                <button mat-menu-item type="button" (click)="beginShift(plan)">
+                  <mat-icon aria-hidden="true">date_range</mat-icon><span>Shift dates</span>
+                </button>
+                <button mat-menu-item type="button" (click)="openHistory({ kind: 'plan', id: plan.id })">
+                  <mat-icon aria-hidden="true">history</mat-icon><span>History</span>
+                </button>
+                @if (plan.lifecycle !== 'archived') {
+                  <button mat-menu-item type="button" (click)="setPlanLifecycle(plan, 'archived')">
+                    <mat-icon aria-hidden="true">archive</mat-icon><span>Archive</span>
+                  </button>
+                }
+                <button mat-menu-item type="button" (click)="beginPlanDeletion(plan)">
+                  <mat-icon aria-hidden="true">delete</mat-icon><span>Delete plan</span>
+                </button>
+              </mat-menu>
+            </div>
+          </div>
+
+          @if (renamingPlanId() === plan.id) {
+            <div class="inline-plan-action">
+              <mat-form-field subscriptSizing="dynamic">
+                <mat-label>Plan name</mat-label>
+                <input matInput maxlength="120" [ngModel]="renameValue()" (ngModelChange)="renameValue.set($event)">
+              </mat-form-field>
+              <button mat-flat-button type="button" (click)="renamePlan(plan)" [disabled]="!renameValue().trim()">Save</button>
+              <button mat-button type="button" (click)="renamingPlanId.set(null)">Cancel</button>
+            </div>
+          }
+
+          @if (shiftingPlanId() === plan.id) {
+            <div class="inline-plan-action">
+              <mat-form-field subscriptSizing="dynamic">
+                <mat-label>Days to shift</mat-label>
+                <input matInput type="number" min="-366" max="366" [ngModel]="shiftDays()"
+                  (ngModelChange)="shiftDays.set(+$event)">
+                <mat-hint>Negative moves the plan earlier</mat-hint>
+              </mat-form-field>
+              <button mat-flat-button type="button" (click)="shiftPlan(plan)">Shift plan</button>
+              <button mat-button type="button" (click)="shiftingPlanId.set(null)">Cancel</button>
+            </div>
+          }
+
+          @if (deletingPlanId() === plan.id) {
+            <mat-card class="plan-deletion-card">
+              <mat-card-header>
+                <mat-card-title>Delete {{ plan.name }}?</mat-card-title>
+                <mat-card-subtitle>Archiving is the non-destructive alternative. Deleting removes plan history.</mat-card-subtitle>
+              </mat-card-header>
+              <mat-card-content>
+                <mat-radio-group [ngModel]="deleteDisposition()" (ngModelChange)="deleteDisposition.set($event)">
+                  <mat-radio-button value="convert-to-standalone">
+                    Keep current workouts as standalone
+                  </mat-radio-button>
+                  <mat-radio-button value="delete-workouts">
+                    Permanently delete current workouts
+                  </mat-radio-button>
+                </mat-radio-group>
+              </mat-card-content>
+              <mat-card-actions align="end">
+                <button mat-button type="button" (click)="deletingPlanId.set(null)">Cancel</button>
+                <button mat-stroked-button type="button" (click)="setPlanLifecycle(plan, 'archived')">
+                  Archive instead
+                </button>
+                <button mat-flat-button color="warn" type="button" (click)="deletePlan(plan)"
+                  [disabled]="busyAction() === 'delete-plan-' + plan.id">
+                  @if (busyAction() === 'delete-plan-' + plan.id) {
+                    <mat-spinner diameter="18"></mat-spinner>
+                  } @else {
+                    <mat-icon aria-hidden="true">delete</mat-icon>
+                  }
+                  <span>Delete plan</span>
+                </button>
+              </mat-card-actions>
+            </mat-card>
+          }
+        } @else {
+          <section class="plans-empty-state">
+            <mat-icon aria-hidden="true">event_note</mat-icon>
+            <h2 id="plan-scope-title">No plans yet</h2>
+            <p>Create a plan, or switch to Standalone to add workouts without one.</p>
+            <button mat-flat-button type="button" (click)="beginPlanCreation()">Create your first plan</button>
+          </section>
+        }
+      </section>
+    } @else {
+      <section class="standalone-heading" aria-labelledby="standalone-title">
+        <div>
+          <h2 id="standalone-title">Standalone workouts</h2>
+          <p>These workouts do not belong to a plan and can be attached later.</p>
+        </div>
+        <button mat-flat-button type="button" (click)="openNewWorkout(null)">
+          <mat-icon aria-hidden="true">add</mat-icon><span>Add standalone</span>
+        </button>
+      </section>
+    }
+
+    @if (editor(); as session) {
+      <mat-card class="workout-editor" aria-labelledby="workout-editor-title">
+        <mat-card-header>
+          <mat-card-title id="workout-editor-title">{{ session.mode === 'create' ? 'Add workout' : 'Edit workout' }}</mat-card-title>
+          <mat-card-subtitle>Running and cycling · date only · time or distance steps · fixed repeats · one absolute target</mat-card-subtitle>
+        </mat-card-header>
+        <mat-card-content>
+          <div class="workout-editor-basics">
+            <mat-form-field>
+              <mat-label>Workout title</mat-label>
+              <input matInput maxlength="120" [ngModel]="session.value.title"
+                (ngModelChange)="updateEditorField('title', $event)">
+            </mat-form-field>
+            <mat-form-field>
+              <mat-label>Date</mat-label>
+              <input matInput type="date" [ngModel]="session.value.localDate"
+                (ngModelChange)="updateEditorField('localDate', $event)">
+            </mat-form-field>
+            <mat-form-field>
+              <mat-label>Sport</mat-label>
+              <mat-select [value]="session.value.sport" (selectionChange)="updateEditorField('sport', $event.value)">
+                @for (sport of sportOptions; track sport.value) {
+                  <mat-option [value]="sport.value">{{ sport.label }}</mat-option>
+                }
+              </mat-select>
+            </mat-form-field>
+          </div>
+
+          <fieldset class="workout-destination">
+            <legend>Workout association</legend>
+            <mat-button-toggle-group
+              [value]="session.destinationPlanId === null ? 'standalone' : 'plan'"
+              hideSingleSelectionIndicator
+              aria-label="Plan association"
+              (change)="updateEditorDestination($event.value === 'standalone' ? null : (selectedPlanId() || activePlan()?.id || planOptions()[0]?.id || null))">
+              <mat-button-toggle value="plan" [disabled]="planOptions().length === 0">Plan</mat-button-toggle>
+              <mat-button-toggle value="standalone">Standalone</mat-button-toggle>
+            </mat-button-toggle-group>
+            @if (session.destinationPlanId !== null) {
+              <mat-form-field subscriptSizing="dynamic">
+                <mat-label>Plan</mat-label>
+                <mat-select [value]="session.destinationPlanId" (selectionChange)="updateEditorDestination($event.value)">
+                  @for (plan of planOptions(); track plan.id) {
+                    @if (plan.lifecycle !== 'archived' || plan.id === session.destinationPlanId) {
+                      <mat-option [value]="plan.id">{{ plan.name }} · {{ plan.lifecycle | titlecase }}</mat-option>
+                    }
+                  }
+                </mat-select>
+              </mat-form-field>
+            } @else {
+              <p class="workout-destination-note">This workout will stay visible in your calendar without a plan.</p>
+            }
+          </fieldset>
+
+          <section class="workout-nodes" aria-labelledby="workout-steps-title">
+            <div class="workout-nodes-heading">
+              <div>
+                <h3 id="workout-steps-title">Workout steps</h3>
+                <p>Steps run in this order. Repeats may contain steps, but not other repeats.</p>
+              </div>
+              <div class="workout-node-add-actions">
+                <button mat-stroked-button type="button" (click)="addEditorStep()">
+                  <mat-icon aria-hidden="true">add</mat-icon><span>Step</span>
+                </button>
+                <button mat-stroked-button type="button" (click)="addEditorRepeat()">
+                  <mat-icon aria-hidden="true">repeat</mat-icon><span>Repeat</span>
+                </button>
+              </div>
+            </div>
+
+            @for (node of session.value.nodes; track node.id; let nodeIndex = $index) {
+              <mat-card class="workout-node-card" appearance="outlined">
+                <mat-card-header>
+                  <mat-card-title>{{ node.kind === 'step' ? 'Step ' + (nodeIndex + 1) : 'Repeat ' + (nodeIndex + 1) }}</mat-card-title>
+                  <button mat-icon-button type="button" matTooltip="Remove node"
+                    [attr.aria-label]="'Remove workout node ' + (nodeIndex + 1)" (click)="removeEditorNode(nodeIndex)">
+                    <mat-icon>delete</mat-icon>
+                  </button>
+                </mat-card-header>
+                <mat-card-content>
+                  @if (node.kind === 'repeat') {
+                    <div class="repeat-heading">
+                      <mat-form-field subscriptSizing="dynamic">
+                        <mat-label>Repeat count</mat-label>
+                        <input matInput type="number" min="1" max="100" [ngModel]="node.count"
+                          (ngModelChange)="updateNode(nodeIndex, 'count', +$event)">
+                      </mat-form-field>
+                      <button mat-button type="button" (click)="addRepeatStep(nodeIndex)">
+                        <mat-icon aria-hidden="true">add</mat-icon><span>Add repeat step</span>
+                      </button>
+                    </div>
+                    @for (step of node.steps; track step.id; let stepIndex = $index) {
+                      <div class="workout-step-editor repeat-step-editor">
+                        <div class="step-index">{{ stepIndex + 1 }}</div>
+                        <ng-container *ngTemplateOutlet="stepFields; context: {
+                          $implicit: step, nodeIndex: nodeIndex, stepIndex: stepIndex
+                        }"></ng-container>
+                        <button mat-icon-button type="button" matTooltip="Remove repeat step"
+                          [attr.aria-label]="'Remove repeat step ' + (stepIndex + 1)"
+                          (click)="removeRepeatStep(nodeIndex, stepIndex)">
+                          <mat-icon>remove_circle</mat-icon>
+                        </button>
+                      </div>
+                    }
+                  } @else {
+                    <div class="workout-step-editor">
+                      <ng-container *ngTemplateOutlet="stepFields; context: {
+                        $implicit: node, nodeIndex: nodeIndex, stepIndex: null
+                      }"></ng-container>
+                    </div>
+                  }
+                </mat-card-content>
+              </mat-card>
+            }
+          </section>
+        </mat-card-content>
+        <mat-card-actions align="end">
+          <button mat-button type="button" (click)="cancelEditor()">Cancel</button>
+          <button mat-flat-button type="button" (click)="saveWorkout()"
+            [disabled]="busyAction() === 'save-workout' || !session.value.title.trim() || session.value.nodes.length === 0">
+            @if (busyAction() === 'save-workout') {
+              <mat-spinner diameter="18"></mat-spinner>
+            } @else {
+              <mat-icon aria-hidden="true">save</mat-icon>
+            }
+            <span>{{ session.mode === 'create' ? 'Add workout' : 'Save workout' }}</span>
+          </button>
+        </mat-card-actions>
+      </mat-card>
+    }
+
+    <ng-template #stepFields let-step let-nodeIndex="nodeIndex" let-stepIndex="stepIndex">
+      <div class="step-fields">
+        <mat-form-field subscriptSizing="dynamic">
+          <mat-label>Purpose</mat-label>
+          <mat-select [value]="step.purpose" (selectionChange)="updateStep(nodeIndex, stepIndex, 'purpose', $event.value)">
+            @for (purpose of purposeOptions; track purpose) {
+              <mat-option [value]="purpose">{{ purpose | titlecase }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+        <mat-form-field subscriptSizing="dynamic">
+          <mat-label>End by</mat-label>
+          <mat-select [value]="step.endingKind" (selectionChange)="updateStep(nodeIndex, stepIndex, 'endingKind', $event.value)">
+            @for (ending of endingOptions; track ending.value) {
+              <mat-option [value]="ending.value">{{ ending.label }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+        <mat-form-field subscriptSizing="dynamic">
+          <mat-label>{{ step.endingKind === 'time' ? 'Minutes' : 'Kilometres' }}</mat-label>
+          <input matInput type="number" min="0.01" step="0.01" [ngModel]="step.endingValue"
+            (ngModelChange)="updateStep(nodeIndex, stepIndex, 'endingValue', +$event)">
+        </mat-form-field>
+        <mat-form-field subscriptSizing="dynamic">
+          <mat-label>Target</mat-label>
+          <mat-select [value]="step.targetKind" (selectionChange)="updateStep(nodeIndex, stepIndex, 'targetKind', $event.value)">
+            @for (target of targetOptions; track target.value) {
+              <mat-option [value]="target.value">{{ target.label }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+        @if (step.targetKind !== 'none') {
+          <mat-form-field subscriptSizing="dynamic">
+            <mat-label>{{ step.targetKind === 'pace' ? 'Faster min/km' : 'Minimum' }}</mat-label>
+            <input matInput type="number" min="0.01" step="0.01" [ngModel]="step.targetMinimum"
+              (ngModelChange)="updateStep(nodeIndex, stepIndex, 'targetMinimum', +$event)">
+          </mat-form-field>
+          <mat-form-field subscriptSizing="dynamic">
+            <mat-label>{{ step.targetKind === 'pace' ? 'Slower min/km' : 'Maximum' }}</mat-label>
+            <input matInput type="number" min="0.01" step="0.01" [ngModel]="step.targetMaximum"
+              (ngModelChange)="updateStep(nodeIndex, stepIndex, 'targetMaximum', +$event)">
+          </mat-form-field>
+        }
+      </div>
+    </ng-template>
+
+    <section class="workout-list" [attr.aria-labelledby]="view() === 'plans' ? 'plan-workouts-title' : 'standalone-workouts-title'">
+      <div class="workout-list-heading">
+        <div>
+          <h2 [id]="view() === 'plans' ? 'plan-workouts-title' : 'standalone-workouts-title'">{{ selectedScopeLabel() }}</h2>
+          <p>Planned workouts stay separate from completed activity totals.</p>
+        </div>
+        <button mat-stroked-button type="button"
+          (click)="openNewWorkout(view() === 'plans' ? selectedPlanId() : null)"
+          [disabled]="view() === 'plans' && !selectedPlanId()">
+          <mat-icon aria-hidden="true">add</mat-icon><span>Add here</span>
+        </button>
+      </div>
+
+      @if (currentWorkoutRows().length === 0) {
+        <div class="workout-empty-state" role="status">
+          <mat-icon aria-hidden="true">event_available</mat-icon>
+          <span>No current workouts in this scope.</span>
+        </div>
+      } @else {
+        <div class="workout-cards">
+          @for (row of currentWorkoutRows(); track row.workout.id) {
+            <mat-card class="workout-card" appearance="outlined"
+              [class.workout-card--skipped]="row.workout.lifecycle === 'skipped'">
+              <mat-card-header>
+                <app-activity-type-icon mat-card-avatar [activityType]="row.workout.structure.sport" size="28px"
+                  aria-hidden="true"></app-activity-type-icon>
+                <mat-card-title>{{ row.workout.title }}</mat-card-title>
+                <mat-card-subtitle>{{ row.workout.localDate }} · {{ row.planName }}</mat-card-subtitle>
+                <mat-chip-set aria-label="Workout state">
+                  <mat-chip [highlighted]="row.workout.lifecycle === 'planned'">{{ row.workout.lifecycle | titlecase }}</mat-chip>
+                </mat-chip-set>
+              </mat-card-header>
+              <mat-card-content>
+                <ol class="workout-summary">
+                  @for (summary of row.summary; track $index) {
+                    <li>{{ summary }}</li>
+                  }
+                </ol>
+              </mat-card-content>
+              <mat-card-actions align="end">
+                <button mat-button type="button" (click)="editWorkout(row.workout)">
+                  <mat-icon aria-hidden="true">edit</mat-icon><span>Edit / move</span>
+                </button>
+                <button mat-button type="button" (click)="copyWorkout(row.workout)">
+                  <mat-icon aria-hidden="true">content_copy</mat-icon><span>Copy</span>
+                </button>
+                <button mat-button type="button" (click)="setWorkoutSkipped(row.workout, row.workout.lifecycle !== 'skipped')">
+                  <mat-icon aria-hidden="true">{{ row.workout.lifecycle === 'skipped' ? 'undo' : 'skip_next' }}</mat-icon>
+                  <span>{{ row.workout.lifecycle === 'skipped' ? 'Unskip' : 'Skip' }}</span>
+                </button>
+                <button mat-icon-button type="button" matTooltip="Workout history" aria-label="Workout history"
+                  (click)="openHistory(historyScopeForWorkout(row.workout))">
+                  <mat-icon>history</mat-icon>
+                </button>
+                <button mat-icon-button type="button" matTooltip="Delete workout" aria-label="Delete workout"
+                  (click)="deleteWorkout(row.workout)">
+                  <mat-icon>delete</mat-icon>
+                </button>
+              </mat-card-actions>
+            </mat-card>
+          }
+        </div>
+      }
+    </section>
+
+    @if (deletedWorkoutRows().length) {
+      <mat-expansion-panel class="deleted-workouts-panel">
+        <mat-expansion-panel-header>
+          <mat-panel-title>Deleted workouts</mat-panel-title>
+          <mat-panel-description>{{ deletedWorkoutRows().length }} recoverable</mat-panel-description>
+        </mat-expansion-panel-header>
+        <mat-list>
+          @for (row of deletedWorkoutRows(); track row.workout.id) {
+            <mat-list-item>
+              <mat-icon matListItemIcon aria-hidden="true">delete</mat-icon>
+              <span matListItemTitle>{{ row.workout.title }}</span>
+              <span matListItemLine>
+                {{ row.workout.localDate }} · Open {{ row.workout.planId ? 'plan' : 'workout' }} history to restore
+              </span>
+              <div matListItemMeta class="deleted-workout-actions">
+                <button mat-button type="button" (click)="openHistory(historyScopeForWorkout(row.workout))">
+                  <mat-icon aria-hidden="true">history</mat-icon><span>History</span>
+                </button>
+                <button mat-icon-button type="button" matTooltip="Delete permanently" aria-label="Delete workout permanently"
+                  (click)="permanentlyDeleteWorkout(row.workout)">
+                  <mat-icon>delete_forever</mat-icon>
+                </button>
+              </div>
+            </mat-list-item>
+          }
+        </mat-list>
+      </mat-expansion-panel>
+    }
+
+    @if (historyPanel(); as history) {
+      <mat-card class="history-panel" aria-labelledby="history-panel-title">
+        <mat-card-header>
+          <mat-card-title id="history-panel-title">Revision history</mat-card-title>
+          <mat-card-subtitle>Restoring creates a new revision; it never rewrites history.</mat-card-subtitle>
+          <button mat-icon-button type="button" matTooltip="Close history" aria-label="Close history" (click)="closeHistory()">
+            <mat-icon>close</mat-icon>
+          </button>
+        </mat-card-header>
+        <mat-card-content>
+          @if (history.status === 'loading') {
+            <div class="history-status"><mat-spinner diameter="24"></mat-spinner><span>Loading history…</span></div>
+          } @else if (history.status === 'error') {
+            <div class="history-status history-status--error" role="alert">
+              <mat-icon aria-hidden="true">error_outline</mat-icon><span>{{ history.error }}</span>
+            </div>
+          } @else if (history.entries.length === 0) {
+            <p>No revisions are available.</p>
+          } @else {
+            <mat-list>
+              @for (entry of history.entries; track entry.revision) {
+                <mat-list-item>
+                  <mat-icon matListItemIcon aria-hidden="true">history</mat-icon>
+                  <span matListItemTitle>Revision {{ entry.revision }} · {{ entry.operationKind }}</span>
+                  <span matListItemLine>{{ entry.createdAtMs | date:'medium' }}{{ entry.isCheckpoint ? ' · checkpoint' : '' }}</span>
+                  <button mat-stroked-button matListItemMeta type="button" (click)="restoreHistoryEntry(entry)"
+                    [disabled]="busyAction() === 'restore-' + entry.revision">
+                    @if (busyAction() === 'restore-' + entry.revision) {
+                      <mat-spinner diameter="18"></mat-spinner>
+                    } @else {
+                      <mat-icon aria-hidden="true">restore</mat-icon>
+                    }
+                    <span>Restore</span>
+                  </button>
+                </mat-list-item>
+              }
+            </mat-list>
+            @if (history.nextBeforeRevision !== null) {
+              <div class="history-load-more">
+                <button mat-stroked-button type="button" (click)="loadOlderHistory()"
+                  [disabled]="busyAction() === 'history-older'">
+                  @if (busyAction() === 'history-older') {
+                    <mat-spinner diameter="18"></mat-spinner>
+                  } @else {
+                    <mat-icon aria-hidden="true">expand_more</mat-icon>
+                  }
+                  <span>Load older revisions</span>
+                </button>
+              </div>
+            }
+          }
+        </mat-card-content>
+      </mat-card>
+    }
+  }
+</main>

--- a/src/app/components/plans/plans-workspace.component.scss
+++ b/src/app/components/plans/plans-workspace.component.scss
@@ -1,0 +1,320 @@
+:host {
+  display: block;
+}
+
+.plans-header-actions,
+.plans-view-navigation,
+.plan-selector-row,
+.plan-heading-row,
+.plan-actions,
+.inline-plan-action,
+.standalone-heading,
+.workout-nodes-heading,
+.workout-node-add-actions,
+.repeat-heading,
+.workout-list-heading,
+.deleted-workout-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.plans-overview {
+  display: flex;
+  align-items: stretch;
+  gap: 20px;
+  margin-block: 20px;
+  padding: 16px 20px;
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: var(--mat-sys-corner-medium);
+  background: var(--mat-sys-surface-container-low);
+}
+
+.plans-overview > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.plans-overview span,
+.plan-heading-row p,
+.standalone-heading p,
+.workout-nodes-heading p,
+.workout-list-heading p,
+.workout-destination-note {
+  color: var(--mat-sys-on-surface-variant);
+}
+
+.plans-overview strong {
+  font: var(--mat-sys-title-medium);
+}
+
+.plans-view-navigation,
+.plan-heading-row,
+.standalone-heading,
+.workout-nodes-heading,
+.workout-list-heading {
+  justify-content: space-between;
+}
+
+.plan-form-card,
+.plan-scope,
+.workout-editor,
+.workout-list,
+.deleted-workouts-panel,
+.history-panel {
+  margin-block: 20px;
+}
+
+.plan-form-grid,
+.workout-editor-basics,
+.step-fields {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.plan-form-card mat-card-content,
+.workout-editor mat-card-content,
+.plan-deletion-card mat-card-content {
+  padding-top: 16px;
+}
+
+.plan-selector-row {
+  flex-wrap: wrap;
+}
+
+.plan-selector-row mat-form-field {
+  min-width: min(100%, 320px);
+}
+
+.plan-heading-row,
+.standalone-heading,
+.workout-list-heading {
+  margin-block: 18px;
+}
+
+.plan-heading-row h2,
+.standalone-heading h2,
+.workout-list-heading h2,
+.workout-nodes-heading h3 {
+  margin: 0;
+  font: var(--mat-sys-title-large);
+}
+
+.plan-heading-row p,
+.standalone-heading p,
+.workout-list-heading p,
+.workout-nodes-heading p {
+  margin: 4px 0 0;
+}
+
+.plan-actions,
+.inline-plan-action,
+.workout-node-add-actions {
+  flex-wrap: wrap;
+}
+
+.inline-plan-action {
+  align-items: flex-start;
+  margin-block: 12px;
+}
+
+.plan-deletion-card {
+  border-inline-start: 4px solid var(--mat-sys-error);
+}
+
+.plan-deletion-card mat-radio-group {
+  display: grid;
+  gap: 8px;
+}
+
+.plans-status,
+.history-status,
+.workout-empty-state,
+.plans-empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  min-height: 120px;
+  color: var(--mat-sys-on-surface-variant);
+}
+
+.plans-status--error,
+.history-status--error {
+  color: var(--mat-sys-error);
+}
+
+.history-load-more {
+  display: flex;
+  justify-content: center;
+  padding-top: 12px;
+}
+
+.plans-empty-state {
+  flex-direction: column;
+  text-align: center;
+  padding: 32px;
+}
+
+.plans-empty-state h2,
+.plans-empty-state p {
+  margin: 0;
+}
+
+.workout-destination {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin: 8px 0 24px;
+  padding: 16px;
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: var(--mat-sys-corner-small);
+}
+
+.workout-destination legend {
+  padding-inline: 6px;
+  font: var(--mat-sys-label-large);
+}
+
+.workout-destination p {
+  margin: 0;
+}
+
+.workout-nodes {
+  display: grid;
+  gap: 14px;
+}
+
+.workout-node-card mat-card-header,
+.history-panel mat-card-header {
+  align-items: center;
+}
+
+.workout-node-card mat-card-header button,
+.history-panel mat-card-header button {
+  margin-inline-start: auto;
+}
+
+.workout-node-card mat-card-content {
+  padding-top: 12px;
+}
+
+.workout-step-editor {
+  display: flex;
+  align-items: start;
+  gap: 10px;
+}
+
+.workout-step-editor .step-fields {
+  flex: 1;
+}
+
+.repeat-step-editor + .repeat-step-editor {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--mat-sys-outline-variant);
+}
+
+.step-index {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  margin-top: 8px;
+  border-radius: 50%;
+  background: var(--mat-sys-secondary-container);
+  color: var(--mat-sys-on-secondary-container);
+  font: var(--mat-sys-label-large);
+}
+
+.workout-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 360px), 1fr));
+  gap: 16px;
+}
+
+.workout-card--skipped {
+  opacity: 0.78;
+}
+
+.workout-card mat-card-header {
+  align-items: center;
+}
+
+.workout-card mat-chip-set {
+  margin-inline-start: auto;
+}
+
+.workout-summary {
+  margin: 16px 0 0;
+  padding-inline-start: 22px;
+  color: var(--mat-sys-on-surface-variant);
+}
+
+.workout-summary li + li {
+  margin-top: 6px;
+}
+
+.deleted-workouts-panel mat-list-item,
+.history-panel mat-list-item {
+  height: auto;
+  min-height: 64px;
+}
+
+mat-card-actions button,
+.plans-header-actions button,
+.plans-header-actions a,
+.plans-view-navigation button,
+.plan-actions button,
+.standalone-heading button,
+.workout-node-add-actions button,
+.workout-list-heading button,
+.deleted-workout-actions button {
+  align-items: center;
+}
+
+@media (max-width: 900px) {
+  .plan-form-grid,
+  .workout-editor-basics,
+  .step-fields {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .plan-heading-row,
+  .standalone-heading,
+  .workout-nodes-heading,
+  .workout-list-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 600px) {
+  .plans-overview {
+    gap: 12px;
+    overflow-x: auto;
+  }
+
+  .plans-view-navigation {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .plan-form-grid,
+  .workout-editor-basics,
+  .step-fields {
+    grid-template-columns: 1fr;
+  }
+
+  .workout-step-editor {
+    flex-wrap: wrap;
+  }
+
+  .workout-card mat-card-actions {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+}

--- a/src/app/components/plans/plans-workspace.component.spec.ts
+++ b/src/app/components/plans/plans-workspace.component.spec.ts
@@ -174,6 +174,32 @@ describe('PlansWorkspaceComponent', () => {
     }));
   });
 
+  it('reports a failed range-extension retry without losing the open editor', async () => {
+    route.snapshot.queryParamMap = convertToParamMap({ date: '2026-10-10' });
+    mutate
+      .mockRejectedValueOnce(new Error('Moving this workout requires extending Autumn build to include 2026-10-10.'))
+      .mockRejectedValueOnce(new Error('The schedule changed before the extension was applied.'));
+    const fixture = await renderPlans();
+    const componentDialog = (fixture.componentInstance as unknown as { dialog: MatDialog }).dialog;
+    const componentSnackBar = (fixture.componentInstance as unknown as { snackBar: MatSnackBar }).snackBar;
+    vi.spyOn(componentDialog, 'open').mockReturnValue({ afterClosed: () => of(true) } as never);
+    const errorNotice = vi.spyOn(componentSnackBar, 'open');
+    fixture.componentInstance.updateEditorField('title', 'Long run');
+
+    await expect(fixture.componentInstance.saveWorkout()).resolves.toBeUndefined();
+
+    expect(mutate).toHaveBeenCalledTimes(2);
+    expect(mutate).toHaveBeenLastCalledWith(expect.objectContaining({
+      operation: expect.objectContaining({ confirmPlanRangeExtension: true }),
+    }));
+    expect(errorNotice).toHaveBeenCalledWith(
+      'The schedule changed before the extension was applied.',
+      'Dismiss',
+      { duration: 7000 },
+    );
+    expect(fixture.componentInstance.editor()).not.toBeNull();
+  });
+
   it('closes the destructive deletion panel after archiving instead', async () => {
     const fixture = await renderPlans();
     const plan = schedule.plans[0];
@@ -185,6 +211,16 @@ describe('PlansWorkspaceComponent', () => {
       operation: { kind: 'set-plan-lifecycle', planId: plan.id, lifecycle: 'archived' },
     }));
     expect(fixture.componentInstance.deletingPlanId()).toBeNull();
+  });
+
+  it('keeps plan mutations visibly pending beside the triggering controls', async () => {
+    const fixture = await renderPlans();
+
+    fixture.componentInstance.busyAction.set('shift-active-plan');
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.selectedPlanActionBusy()).toBe(true);
+    expect(fixture.nativeElement.textContent).toContain('Updating plan');
   });
 
   it('keeps restore revisions fixed across preview and confirmation', async () => {
@@ -240,14 +276,72 @@ describe('PlansWorkspaceComponent', () => {
 
   it('routes plan-bound workout history through the plan stream and standalone history through the workout stream', async () => {
     const fixture = await renderPlans();
-    const [planWorkout, standaloneWorkout] = schedule.workouts;
 
-    expect(fixture.componentInstance.historyScopeForWorkout(planWorkout)).toEqual({
+    expect(fixture.componentInstance.workoutRows()[0]?.historyScope).toEqual({
       kind: 'plan', id: 'active-plan',
     });
-    expect(fixture.componentInstance.historyScopeForWorkout(standaloneWorkout)).toEqual({
+    fixture.componentInstance.selectView('standalone');
+    expect(fixture.componentInstance.workoutRows()[0]?.historyScope).toEqual({
       kind: 'workout', id: 'standalone-workout',
     });
+  });
+
+  it('does not reopen revision history after an in-flight request is closed', async () => {
+    let resolveHistory: (value: unknown) => void = () => undefined;
+    getHistory.mockReturnValue(new Promise(resolve => { resolveHistory = resolve; }));
+    const fixture = await renderPlans();
+
+    const pending = fixture.componentInstance.openHistory({ kind: 'plan', id: 'active-plan' });
+    fixture.componentInstance.closeHistory();
+    resolveHistory({
+      scope: { kind: 'plan', id: 'active-plan' },
+      entries: [],
+      nextBeforeRevision: null,
+    });
+    await pending;
+
+    expect(fixture.componentInstance.historyPanel()).toBeNull();
+  });
+
+  it('does not continue a restore after its history panel is closed', async () => {
+    let resolvePreview: (value: {
+      scope: { kind: 'plan'; id: string };
+      targetRevision: number;
+      changedPlanIds: string[];
+      changedWorkoutIds: string[];
+      skippedWorkoutIds: string[];
+      warnings: string[];
+    }) => void = () => undefined;
+    previewRestore.mockReturnValue(new Promise(resolve => { resolvePreview = resolve; }));
+    const fixture = await renderPlans();
+    fixture.componentInstance.historyPanel.set({
+      scope: { kind: 'plan', id: 'active-plan' },
+      status: 'ready',
+      entries: [],
+      nextBeforeRevision: null,
+      error: null,
+    });
+
+    const pending = fixture.componentInstance.restoreHistoryEntry({
+      revision: 1,
+      operationKind: 'create-plan',
+      createdAtMs: 1,
+      mutationId: 'create',
+      isCheckpoint: true,
+    });
+    fixture.componentInstance.closeHistory();
+    resolvePreview({
+      scope: { kind: 'plan', id: 'active-plan' },
+      targetRevision: 1,
+      changedPlanIds: ['active-plan'],
+      changedWorkoutIds: [],
+      skippedWorkoutIds: [],
+      warnings: [],
+    });
+    await pending;
+
+    expect(dialogOpen).not.toHaveBeenCalled();
+    expect(restoreSchedule).not.toHaveBeenCalled();
   });
 
   it('loads older history pages without replacing newer revisions', async () => {

--- a/src/app/components/plans/plans-workspace.component.spec.ts
+++ b/src/app/components/plans/plans-workspace.component.spec.ts
@@ -20,6 +20,9 @@ describe('PlansWorkspaceComponent', () => {
   let watchSchedule: ReturnType<typeof vi.fn>;
   let mutate: ReturnType<typeof vi.fn>;
   let getHistory: ReturnType<typeof vi.fn>;
+  let previewRestore: ReturnType<typeof vi.fn>;
+  let restoreSchedule: ReturnType<typeof vi.fn>;
+  let dialogOpen: ReturnType<typeof vi.fn>;
   let snackBarOpen: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
@@ -35,6 +38,9 @@ describe('PlansWorkspaceComponent', () => {
       permanentlyDeletedWorkoutIds: [],
     }));
     getHistory = vi.fn();
+    previewRestore = vi.fn();
+    restoreSchedule = vi.fn();
+    dialogOpen = vi.fn();
     snackBarOpen = vi.fn();
     await TestBed.configureTestingModule({
       imports: [PlansWorkspaceComponent],
@@ -50,12 +56,12 @@ describe('PlansWorkspaceComponent', () => {
             createMutationId: vi.fn().mockReturnValue('mutation-1'),
             mutate,
             getHistory,
-            previewRestore: vi.fn(),
-            restore: vi.fn(),
+            previewRestore,
+            restore: restoreSchedule,
             deletePlan: vi.fn(),
           },
         },
-        { provide: MatDialog, useValue: { open: vi.fn() } },
+        { provide: MatDialog, useValue: { open: dialogOpen } },
         { provide: MatSnackBar, useValue: { open: snackBarOpen } },
         {
           provide: AppEventColorService,
@@ -123,6 +129,112 @@ describe('PlansWorkspaceComponent', () => {
         localDate: '2026-09-10',
         title: 'Unplanned run',
       }),
+    }));
+  });
+
+  it('saves content, date, and plan association in one atomic update mutation', async () => {
+    route.snapshot.queryParamMap = convertToParamMap({ workout: 'standalone-workout' });
+    const fixture = await renderPlans();
+    fixture.componentInstance.updateEditorField('title', 'Attached run');
+    fixture.componentInstance.updateEditorField('localDate', '2026-09-10');
+    fixture.componentInstance.updateEditorDestination('active-plan');
+
+    await fixture.componentInstance.saveWorkout();
+
+    expect(mutate).toHaveBeenCalledOnce();
+    expect(mutate).toHaveBeenCalledWith(expect.objectContaining({
+      expectedRevisions: [
+        { scope: 'state', id: 'current', revision: 4 },
+        { scope: 'plan', id: 'active-plan', revision: 2 },
+        { scope: 'workout', id: 'standalone-workout', revision: 1 },
+      ],
+      operation: expect.objectContaining({
+        kind: 'update-workout',
+        workoutId: 'standalone-workout',
+        planId: 'active-plan',
+        localDate: '2026-09-10',
+        title: 'Attached run',
+        confirmPlanRangeExtension: false,
+      }),
+    }));
+  });
+
+  it('keeps the editor-open workout revision instead of borrowing a concurrent update', async () => {
+    route.snapshot.queryParamMap = convertToParamMap({ workout: 'standalone-workout' });
+    const fixture = await renderPlans();
+    fixture.componentInstance.updateEditorField('title', 'My pending edit');
+    schedule.workouts.find(workout => workout.id === 'standalone-workout')!.revision = 9;
+
+    await fixture.componentInstance.saveWorkout();
+
+    expect(mutate).toHaveBeenCalledWith(expect.objectContaining({
+      expectedRevisions: expect.arrayContaining([
+        { scope: 'workout', id: 'standalone-workout', revision: 1 },
+      ]),
+    }));
+  });
+
+  it('closes the destructive deletion panel after archiving instead', async () => {
+    const fixture = await renderPlans();
+    const plan = schedule.plans[0];
+    fixture.componentInstance.beginPlanDeletion(plan);
+
+    await fixture.componentInstance.setPlanLifecycle(plan, 'archived');
+
+    expect(mutate).toHaveBeenCalledWith(expect.objectContaining({
+      operation: { kind: 'set-plan-lifecycle', planId: plan.id, lifecycle: 'archived' },
+    }));
+    expect(fixture.componentInstance.deletingPlanId()).toBeNull();
+  });
+
+  it('keeps restore revisions fixed across preview and confirmation', async () => {
+    const fixture = await renderPlans();
+    previewRestore.mockImplementation(async () => {
+      schedule.state.revision = 8;
+      schedule.plans[0].revision = 7;
+      return {
+        scope: { kind: 'plan', id: 'active-plan' },
+        targetRevision: 1,
+        changedPlanIds: ['active-plan'],
+        changedWorkoutIds: [],
+        skippedWorkoutIds: [],
+        warnings: [],
+      };
+    });
+    restoreSchedule.mockResolvedValue({
+      mutation: {
+        mutationId: 'mutation-1',
+        state: schedule.state,
+        plans: [],
+        workouts: [],
+        removedPlanIds: [],
+        permanentlyDeletedWorkoutIds: [],
+      },
+      skippedWorkoutIds: [],
+    });
+    const componentDialog = (fixture.componentInstance as unknown as { dialog: MatDialog }).dialog;
+    vi.spyOn(componentDialog, 'open').mockReturnValue({ afterClosed: () => of(true) } as never);
+    fixture.componentInstance.historyPanel.set({
+      scope: { kind: 'plan', id: 'active-plan' },
+      status: 'ready',
+      entries: [],
+      nextBeforeRevision: null,
+      error: null,
+    });
+
+    await fixture.componentInstance.restoreHistoryEntry({
+      revision: 1,
+      operationKind: 'create-plan',
+      createdAtMs: 1,
+      mutationId: 'create',
+      isCheckpoint: true,
+    });
+
+    expect(restoreSchedule).toHaveBeenCalledWith(expect.objectContaining({
+      expectedRevisions: [
+        { scope: 'state', id: 'current', revision: 4 },
+        { scope: 'plan', id: 'active-plan', revision: 2 },
+      ],
     }));
   });
 

--- a/src/app/components/plans/plans-workspace.component.spec.ts
+++ b/src/app/components/plans/plans-workspace.component.spec.ts
@@ -1,0 +1,230 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { ActivityTypes } from '@sports-alliance/sports-lib';
+import { of } from 'rxjs';
+import { AppUserService } from '../../services/app.user.service';
+import { AppEventColorService } from '../../services/color/app.event.color.service';
+import {
+  TrainingPlansService,
+  type CurrentTrainingScheduleV1,
+} from '../../services/training-plans.service';
+import { PlansWorkspaceComponent } from './plans-workspace.component';
+
+describe('PlansWorkspaceComponent', () => {
+  const user = { uid: 'user-1', settings: { unitSettings: {} } };
+  let route: { snapshot: { queryParamMap: ReturnType<typeof convertToParamMap> } };
+  let schedule: CurrentTrainingScheduleV1;
+  let watchSchedule: ReturnType<typeof vi.fn>;
+  let mutate: ReturnType<typeof vi.fn>;
+  let getHistory: ReturnType<typeof vi.fn>;
+  let snackBarOpen: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    route = { snapshot: { queryParamMap: convertToParamMap({}) } };
+    schedule = populatedSchedule();
+    watchSchedule = vi.fn().mockImplementation(() => of(schedule));
+    mutate = vi.fn().mockImplementation(async request => ({
+      mutationId: request.mutationId,
+      state: schedule.state,
+      plans: [],
+      workouts: [],
+      removedPlanIds: [],
+      permanentlyDeletedWorkoutIds: [],
+    }));
+    getHistory = vi.fn();
+    snackBarOpen = vi.fn();
+    await TestBed.configureTestingModule({
+      imports: [PlansWorkspaceComponent],
+      providers: [
+        provideRouter([]),
+        { provide: ActivatedRoute, useValue: route },
+        { provide: AppUserService, useValue: { user: signal(user), user$: of(user) } },
+        {
+          provide: TrainingPlansService,
+          useValue: {
+            watchSchedule,
+            createEntityId: vi.fn().mockReturnValue('workout-new'),
+            createMutationId: vi.fn().mockReturnValue('mutation-1'),
+            mutate,
+            getHistory,
+            previewRestore: vi.fn(),
+            restore: vi.fn(),
+            deletePlan: vi.fn(),
+          },
+        },
+        { provide: MatDialog, useValue: { open: vi.fn() } },
+        { provide: MatSnackBar, useValue: { open: snackBarOpen } },
+        {
+          provide: AppEventColorService,
+          useValue: {
+            getActivityColor: vi.fn().mockReturnValue(''),
+            getColorForActivityTypeByActivityTypeGroup: vi.fn().mockReturnValue(''),
+          },
+        },
+      ],
+    }).compileComponents();
+  });
+
+  it('defaults a calendar add request to the active plan', async () => {
+    route.snapshot.queryParamMap = convertToParamMap({ date: '2026-09-10' });
+    const fixture = await renderPlans();
+
+    expect(fixture.componentInstance.editor()).toMatchObject({
+      mode: 'create',
+      destinationPlanId: 'active-plan',
+      value: { localDate: '2026-09-10' },
+    });
+  });
+
+  it('honors the prominent standalone calendar add path even with an active plan', async () => {
+    route.snapshot.queryParamMap = convertToParamMap({ date: '2026-09-10', scope: 'standalone' });
+    const fixture = await renderPlans();
+
+    expect(fixture.componentInstance.editor()?.destinationPlanId).toBeNull();
+    expect(fixture.componentInstance.editor()?.value.localDate).toBe('2026-09-10');
+  });
+
+  it('defaults calendar adds to standalone when there is no active plan', async () => {
+    schedule = { ...populatedSchedule(), state: { ...populatedSchedule().state, activePlanId: null } };
+    route.snapshot.queryParamMap = convertToParamMap({ date: '2026-09-10' });
+    const fixture = await renderPlans();
+
+    expect(fixture.componentInstance.editor()?.destinationPlanId).toBeNull();
+  });
+
+  it('opens a linked standalone workout in the editor without requiring a plan', async () => {
+    route.snapshot.queryParamMap = convertToParamMap({ workout: 'standalone-workout' });
+    const fixture = await renderPlans();
+
+    expect(fixture.componentInstance.view()).toBe('standalone');
+    expect(fixture.componentInstance.editor()).toMatchObject({
+      mode: 'edit',
+      destinationPlanId: null,
+      original: { id: 'standalone-workout' },
+    });
+  });
+
+  it('creates a standalone workout through the same revisioned mutation path', async () => {
+    route.snapshot.queryParamMap = convertToParamMap({ date: '2026-09-10', scope: 'standalone' });
+    const fixture = await renderPlans();
+    fixture.componentInstance.updateEditorField('title', 'Unplanned run');
+
+    await fixture.componentInstance.saveWorkout();
+
+    expect(mutate).toHaveBeenCalledWith(expect.objectContaining({
+      expectedRevisions: [{ scope: 'state', id: 'current', revision: 4 }],
+      operation: expect.objectContaining({
+        kind: 'create-workout',
+        workoutId: 'workout-new',
+        planId: null,
+        localDate: '2026-09-10',
+        title: 'Unplanned run',
+      }),
+    }));
+  });
+
+  it('routes plan-bound workout history through the plan stream and standalone history through the workout stream', async () => {
+    const fixture = await renderPlans();
+    const [planWorkout, standaloneWorkout] = schedule.workouts;
+
+    expect(fixture.componentInstance.historyScopeForWorkout(planWorkout)).toEqual({
+      kind: 'plan', id: 'active-plan',
+    });
+    expect(fixture.componentInstance.historyScopeForWorkout(standaloneWorkout)).toEqual({
+      kind: 'workout', id: 'standalone-workout',
+    });
+  });
+
+  it('loads older history pages without replacing newer revisions', async () => {
+    getHistory
+      .mockResolvedValueOnce({
+        scope: { kind: 'plan', id: 'active-plan' },
+        entries: [{ revision: 3, operationKind: 'rename-plan', createdAtMs: 3, mutationId: 'm3', isCheckpoint: false }],
+        nextBeforeRevision: 3,
+      })
+      .mockResolvedValueOnce({
+        scope: { kind: 'plan', id: 'active-plan' },
+        entries: [{ revision: 2, operationKind: 'create-workout', createdAtMs: 2, mutationId: 'm2', isCheckpoint: false }],
+        nextBeforeRevision: null,
+      });
+    const fixture = await renderPlans();
+
+    await fixture.componentInstance.openHistory({ kind: 'plan', id: 'active-plan' });
+    await fixture.componentInstance.loadOlderHistory();
+
+    expect(getHistory).toHaveBeenLastCalledWith({
+      scope: { kind: 'plan', id: 'active-plan' },
+      beforeRevision: 3,
+      limit: 50,
+    });
+    expect(fixture.componentInstance.historyPanel()?.entries.map(entry => entry.revision)).toEqual([3, 2]);
+    expect(fixture.componentInstance.historyPanel()?.nextBeforeRevision).toBeNull();
+  });
+
+  async function renderPlans() {
+    const fixture = TestBed.createComponent(PlansWorkspaceComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture;
+  }
+});
+
+function populatedSchedule(): CurrentTrainingScheduleV1 {
+  const structure = {
+    version: 1 as const,
+    sport: ActivityTypes.Running,
+    nodes: [{
+      kind: 'step' as const,
+      id: 'steady',
+      purpose: 'work' as const,
+      ending: { kind: 'time' as const, seconds: 1800 },
+      targets: [],
+    }],
+  };
+  return {
+    state: { schemaVersion: 1, activePlanId: 'active-plan', revision: 4, currentWorkoutCount: 2, updatedAtMs: 4 },
+    plans: [{
+      schemaVersion: 1,
+      id: 'active-plan',
+      name: 'Autumn build',
+      lifecycle: 'active',
+      startLocalDate: '2026-09-01',
+      endLocalDate: '2026-09-30',
+      revision: 2,
+      lastCheckpointRevision: 1,
+      workoutCount: 1,
+      createdAtMs: 1,
+      updatedAtMs: 2,
+    }],
+    workouts: [
+      {
+        schemaVersion: 1,
+        id: 'plan-workout',
+        planId: 'active-plan',
+        localDate: '2026-09-09',
+        lifecycle: 'planned',
+        title: 'Plan run',
+        structure,
+        revision: 1,
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      },
+      {
+        schemaVersion: 1,
+        id: 'standalone-workout',
+        planId: null,
+        localDate: '2026-09-08',
+        lifecycle: 'planned',
+        title: 'Standalone run',
+        structure,
+        revision: 1,
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      },
+    ],
+  };
+}

--- a/src/app/components/plans/plans-workspace.component.ts
+++ b/src/app/components/plans/plans-workspace.component.ts
@@ -12,7 +12,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute } from '@angular/router';
 import { ActivityTypes } from '@sports-alliance/sports-lib';
-import { catchError, filter, map, of, startWith, switchMap } from 'rxjs';
+import { catchError, map, of, startWith, switchMap } from 'rxjs';
 import type { AppUserInterface } from '../../models/app-user.interface';
 import { SharedModule } from '../../modules/shared.module';
 import { AppUserService } from '../../services/app.user.service';
@@ -58,6 +58,7 @@ interface ScheduleLoadState {
 interface WorkoutEditorSession {
   mode: 'create' | 'edit';
   original: ScheduledWorkoutV1 | null;
+  originalWorkoutRevision: number | null;
   destinationPlanId: string | null;
   value: ManualWorkoutEditorValue;
 }
@@ -126,16 +127,17 @@ export class PlansWorkspaceComponent {
 
   readonly currentUser = computed(() => this.userService.user() as AppUserInterface | null);
   readonly scheduleState = toSignal(this.userService.user$.pipe(
-    filter((user): user is AppUserInterface => !!user?.uid),
-    switchMap(user => this.plansService.watchSchedule(user.uid).pipe(
-      map(schedule => ({ status: 'ready', schedule, message: null }) as ScheduleLoadState),
-      startWith({ status: 'loading', schedule: EMPTY_SCHEDULE, message: null } as ScheduleLoadState),
-      catchError(error => of({
-        status: 'error',
-        schedule: EMPTY_SCHEDULE,
-        message: errorMessage(error),
-      } as ScheduleLoadState)),
-    )),
+    switchMap(user => user?.uid
+      ? this.plansService.watchSchedule(user.uid).pipe(
+        map(schedule => ({ status: 'ready', schedule, message: null }) as ScheduleLoadState),
+        startWith({ status: 'loading', schedule: EMPTY_SCHEDULE, message: null } as ScheduleLoadState),
+        catchError(error => of({
+          status: 'error',
+          schedule: EMPTY_SCHEDULE,
+          message: errorMessage(error),
+        } as ScheduleLoadState)),
+      )
+      : of({ status: 'ready', schedule: EMPTY_SCHEDULE, message: null } as ScheduleLoadState)),
   ), { initialValue: { status: 'loading', schedule: EMPTY_SCHEDULE, message: null } as ScheduleLoadState });
   readonly schedule = computed(() => this.scheduleState().schedule);
   readonly view = signal<PlansView>('plans');
@@ -289,7 +291,10 @@ export class PlansWorkspaceComponent {
     if (!name) return;
     const response = await this.runMutation({
       mutationId: this.plansService.createMutationId('rename-plan'),
-      expectedRevisions: this.expectedRevisions({ planIds: [plan.id] }),
+      expectedRevisions: this.expectedRevisions({
+        planIds: [plan.id],
+        planRevisionOverrides: new Map([[plan.id, plan.revision]]),
+      }),
       operation: { kind: 'rename-plan', planId: plan.id, name },
     }, `rename-${plan.id}`);
     if (!response) return;
@@ -304,10 +309,17 @@ export class PlansWorkspaceComponent {
     }
     const response = await this.runMutation({
       mutationId: this.plansService.createMutationId(`plan-${lifecycle}`),
-      expectedRevisions: this.expectedRevisions({ planIds }),
+      expectedRevisions: this.expectedRevisions({
+        planIds,
+        planRevisionOverrides: new Map([[plan.id, plan.revision]]),
+      }),
       operation: { kind: 'set-plan-lifecycle', planId: plan.id, lifecycle },
     }, `lifecycle-${plan.id}`);
-    if (response) this.snackBar.open(`Plan ${lifecycle}.`, 'Dismiss', { duration: 3000 });
+    if (!response) return;
+    if (lifecycle === 'archived' && this.deletingPlanId() === plan.id) {
+      this.deletingPlanId.set(null);
+    }
+    this.snackBar.open(`Plan ${lifecycle}.`, 'Dismiss', { duration: 3000 });
   }
 
   beginShift(plan: TrainingPlanV1): void {
@@ -323,7 +335,10 @@ export class PlansWorkspaceComponent {
     }
     const response = await this.runMutation({
       mutationId: this.plansService.createMutationId('shift-plan'),
-      expectedRevisions: this.expectedRevisions({ planIds: [plan.id] }),
+      expectedRevisions: this.expectedRevisions({
+        planIds: [plan.id],
+        planRevisionOverrides: new Map([[plan.id, plan.revision]]),
+      }),
       operation: { kind: 'shift-plan', planId: plan.id, days },
     }, `shift-${plan.id}`);
     if (!response) return;
@@ -338,6 +353,10 @@ export class PlansWorkspaceComponent {
 
   async deletePlan(plan: TrainingPlanV1): Promise<void> {
     const disposition = this.deleteDisposition();
+    const expectedRevisions = this.expectedRevisions({
+      planIds: [plan.id],
+      planRevisionOverrides: new Map([[plan.id, plan.revision]]),
+    });
     const confirmed = await this.confirm(
       'Delete training plan?',
       disposition === 'convert-to-standalone'
@@ -352,7 +371,7 @@ export class PlansWorkspaceComponent {
       await this.plansService.deletePlan({
         mutationId: this.plansService.createMutationId('delete-plan'),
         planId: plan.id,
-        expectedRevisions: this.expectedRevisions({ planIds: [plan.id] }),
+        expectedRevisions,
         workoutDisposition: disposition,
         confirmPlanDeletion: true,
       });
@@ -372,6 +391,7 @@ export class PlansWorkspaceComponent {
     this.editor.set({
       mode: 'create',
       original: null,
+      originalWorkoutRevision: null,
       destinationPlanId: defaultDestination ?? null,
       value: createManualWorkoutEditorValue(localDate, this.nextNodeId('step')),
     });
@@ -382,6 +402,7 @@ export class PlansWorkspaceComponent {
       this.editor.set({
         mode: 'edit',
         original: workout,
+        originalWorkoutRevision: workout.revision,
         destinationPlanId: workout.planId,
         value: workoutStructureToManualEditor(workout.title, workout.localDate, workout.structure),
       });
@@ -527,34 +548,24 @@ export class PlansWorkspaceComponent {
     }
 
     const original = session.original!;
-    const updateResponse = await this.runMutation({
+    const response = await this.runMutation({
       mutationId: this.plansService.createMutationId('update-workout'),
       expectedRevisions: this.expectedRevisions({
         workoutIds: [original.id],
-        planIds: original.planId ? [original.planId] : [],
+        workoutRevisionOverrides: new Map([[original.id, session.originalWorkoutRevision!]]),
+        planIds: [original.planId, session.destinationPlanId].filter((id): id is string => !!id),
       }),
-      operation: { kind: 'update-workout', workoutId: original.id, title, structure },
+      operation: {
+        kind: 'update-workout',
+        workoutId: original.id,
+        planId: session.destinationPlanId,
+        localDate: session.value.localDate,
+        title,
+        structure,
+        confirmPlanRangeExtension: false,
+      },
     }, 'save-workout');
-    if (!updateResponse) return;
-
-    if (original.planId !== session.destinationPlanId || original.localDate !== session.value.localDate) {
-      const afterUpdate = mergeMutationResponse(this.schedule(), updateResponse);
-      const moveResponse = await this.runMutation({
-        mutationId: this.plansService.createMutationId('move-workout'),
-        expectedRevisions: expectedRevisionsFromSchedule(afterUpdate, {
-          workoutIds: [original.id],
-          planIds: [original.planId, session.destinationPlanId].filter((id): id is string => !!id),
-        }),
-        operation: {
-          kind: 'move-workout',
-          workoutId: original.id,
-          planId: session.destinationPlanId,
-          localDate: session.value.localDate,
-          confirmPlanRangeExtension: false,
-        },
-      }, 'save-workout');
-      if (!moveResponse) return;
-    }
+    if (!response) return;
     this.editor.set(null);
     this.snackBar.open('Workout updated.', 'Dismiss', { duration: 3000 });
   }
@@ -564,7 +575,11 @@ export class PlansWorkspaceComponent {
     const planIds = workout.planId ? [workout.planId] : [];
     const response = await this.runMutation({
       mutationId: this.plansService.createMutationId('copy-workout'),
-      expectedRevisions: this.expectedRevisions({ workoutIds: [workout.id], planIds }),
+      expectedRevisions: this.expectedRevisions({
+        workoutIds: [workout.id],
+        workoutRevisionOverrides: new Map([[workout.id, workout.revision]]),
+        planIds,
+      }),
       operation: {
         kind: 'copy-workout',
         sourceWorkoutId: workout.id,
@@ -582,6 +597,7 @@ export class PlansWorkspaceComponent {
       mutationId: this.plansService.createMutationId(skipped ? 'skip-workout' : 'unskip-workout'),
       expectedRevisions: this.expectedRevisions({
         workoutIds: [workout.id],
+        workoutRevisionOverrides: new Map([[workout.id, workout.revision]]),
         planIds: workout.planId ? [workout.planId] : [],
       }),
       operation: { kind: 'set-workout-lifecycle', workoutId: workout.id, lifecycle: skipped ? 'skipped' : 'planned' },
@@ -590,6 +606,11 @@ export class PlansWorkspaceComponent {
   }
 
   async deleteWorkout(workout: ScheduledWorkoutV1): Promise<void> {
+    const expectedRevisions = this.expectedRevisions({
+      workoutIds: [workout.id],
+      workoutRevisionOverrides: new Map([[workout.id, workout.revision]]),
+      planIds: workout.planId ? [workout.planId] : [],
+    });
     const confirmed = await this.confirm(
       'Delete workout?',
       'The workout will remain in history and can be restored.',
@@ -599,29 +620,33 @@ export class PlansWorkspaceComponent {
     if (!confirmed) return;
     const response = await this.runMutation({
       mutationId: this.plansService.createMutationId('delete-workout'),
-      expectedRevisions: this.expectedRevisions({
-        workoutIds: [workout.id],
-        planIds: workout.planId ? [workout.planId] : [],
-      }),
+      expectedRevisions,
       operation: { kind: 'delete-workout', workoutId: workout.id },
     }, `delete-${workout.id}`);
     if (response) this.snackBar.open('Workout deleted. Open history to restore it.', 'Dismiss', { duration: 5000 });
   }
 
   async permanentlyDeleteWorkout(workout: ScheduledWorkoutV1): Promise<void> {
+    const expectedRevisions = this.expectedRevisions({
+      workoutIds: [workout.id],
+      workoutRevisionOverrides: new Map([[workout.id, workout.revision]]),
+      planIds: workout.planId ? [workout.planId] : [],
+    });
     const confirmed = await this.confirm(
       'Permanently delete workout?',
-      'This removes the workout and all of its history. This cannot be undone.',
+      workout.planId
+        ? 'This removes the workout and prevents restoration. Its plan revision audit remains until the plan is deleted. This cannot be undone.'
+        : 'This removes the workout and its standalone revision history. This cannot be undone.',
       'Delete permanently',
       'warn',
     );
     if (!confirmed) return;
     const response = await this.runMutation({
       mutationId: this.plansService.createMutationId('permanent-workout-delete'),
-      expectedRevisions: this.expectedRevisions({ workoutIds: [workout.id] }),
+      expectedRevisions,
       operation: { kind: 'permanently-delete-workout', workoutId: workout.id, confirmPermanentDeletion: true },
     }, `permanent-${workout.id}`);
-    if (response) this.snackBar.open('Workout history permanently deleted.', 'Dismiss', { duration: 4000 });
+    if (response) this.snackBar.open('Workout permanently retired and can no longer be restored.', 'Dismiss', { duration: 4000 });
   }
 
   async openHistory(scope: TrainingScheduleRevisionScope): Promise<void> {
@@ -685,6 +710,14 @@ export class PlansWorkspaceComponent {
   async restoreHistoryEntry(entry: TrainingScheduleHistoryEntryV1): Promise<void> {
     const panel = this.historyPanel();
     if (!panel) return;
+    const expected = panel.scope.kind === 'workout'
+      ? this.expectedRevisions({ workoutIds: [panel.scope.id] })
+      : this.expectedRevisions({
+        planIds: [
+          panel.scope.id,
+          ...(this.activePlan() && this.activePlan()!.id !== panel.scope.id ? [this.activePlan()!.id] : []),
+        ],
+      });
     this.busyAction.set(`restore-${entry.revision}`);
     try {
       const preview = await this.plansService.previewRestore({ scope: panel.scope, targetRevision: entry.revision });
@@ -696,14 +729,6 @@ export class PlansWorkspaceComponent {
         'Restore revision',
       );
       if (!confirmed) return;
-      const expected = panel.scope.kind === 'workout'
-        ? this.expectedRevisions({ workoutIds: [panel.scope.id] })
-        : this.expectedRevisions({
-          planIds: [
-            panel.scope.id,
-            ...(this.activePlan() && this.activePlan()!.id !== panel.scope.id ? [this.activePlan()!.id] : []),
-          ],
-        });
       const response = await this.plansService.restore({
         mutationId: this.plansService.createMutationId('restore-schedule'),
         expectedRevisions: expected,
@@ -724,7 +749,12 @@ export class PlansWorkspaceComponent {
     }
   }
 
-  private expectedRevisions(options: { planIds?: string[]; workoutIds?: string[] }): ExpectedTrainingScheduleRevision[] {
+  private expectedRevisions(options: {
+    planIds?: string[];
+    workoutIds?: string[];
+    planRevisionOverrides?: ReadonlyMap<string, number>;
+    workoutRevisionOverrides?: ReadonlyMap<string, number>;
+  }): ExpectedTrainingScheduleRevision[] {
     return expectedRevisionsFromSchedule(this.schedule(), options);
   }
 
@@ -778,34 +808,34 @@ export class PlansWorkspaceComponent {
 
 function expectedRevisionsFromSchedule(
   schedule: CurrentTrainingScheduleV1,
-  options: { planIds?: string[]; workoutIds?: string[] },
+  options: {
+    planIds?: string[];
+    workoutIds?: string[];
+    planRevisionOverrides?: ReadonlyMap<string, number>;
+    workoutRevisionOverrides?: ReadonlyMap<string, number>;
+  },
 ): ExpectedTrainingScheduleRevision[] {
   const expected: ExpectedTrainingScheduleRevision[] = [
     { scope: 'state', id: 'current', revision: schedule.state.revision },
   ];
   [...new Set(options.planIds ?? [])].forEach((planId) => {
     const plan = schedule.plans.find(candidate => candidate.id === planId);
-    if (plan) expected.push({ scope: 'plan', id: plan.id, revision: plan.revision });
+    if (plan) expected.push({
+      scope: 'plan',
+      id: plan.id,
+      revision: options.planRevisionOverrides?.get(plan.id) ?? plan.revision,
+    });
   });
   [...new Set(options.workoutIds ?? [])].forEach((workoutId) => {
     const workout = schedule.workouts.find(candidate => candidate.id === workoutId);
-    if (workout) expected.push({ scope: 'workout', id: workout.id, revision: workout.revision });
+    if (workout) expected.push({
+      scope: 'workout',
+      id: workout.id,
+      revision: options.workoutRevisionOverrides?.get(workout.id) ?? workout.revision,
+    });
   });
   if (expected.length > 4) throw new Error('This change requires too many concurrent revision checks.');
   return expected;
-}
-
-function mergeMutationResponse(
-  schedule: CurrentTrainingScheduleV1,
-  response: MutateTrainingScheduleResponseV1,
-): CurrentTrainingScheduleV1 {
-  const plans = new Map(schedule.plans.map(plan => [plan.id, plan]));
-  response.plans.forEach(plan => plans.set(plan.id, plan));
-  response.removedPlanIds.forEach(id => plans.delete(id));
-  const workouts = new Map(schedule.workouts.map(workout => [workout.id, workout]));
-  response.workouts.forEach(workout => workouts.set(workout.id, workout));
-  response.permanentlyDeletedWorkoutIds.forEach(id => workouts.delete(id));
-  return { state: response.state, plans: [...plans.values()], workouts: [...workouts.values()] };
 }
 
 function errorMessage(error: unknown): string {

--- a/src/app/components/plans/plans-workspace.component.ts
+++ b/src/app/components/plans/plans-workspace.component.ts
@@ -67,6 +67,7 @@ interface WorkoutRow {
   workout: ScheduledWorkoutV1;
   summary: string[];
   planName: string;
+  historyScope: TrainingScheduleRevisionScope;
 }
 
 interface PlanDraft {
@@ -106,6 +107,7 @@ export class PlansWorkspaceComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly locale = inject(LOCALE_ID);
   private requestedEditorOpened = false;
+  private historyRequestSequence = 0;
   private nodeSequence = 1;
 
   readonly activityTypes = ActivityTypes;
@@ -161,6 +163,16 @@ export class PlansWorkspaceComponent {
   readonly selectedPlan = computed(() => this.schedule().plans.find(plan => (
     plan.id === this.selectedPlanId()
   )) ?? null);
+  readonly selectedPlanActionBusy = computed(() => {
+    const planId = this.selectedPlanId();
+    const action = this.busyAction();
+    return Boolean(planId && action && [
+      `rename-${planId}`,
+      `shift-${planId}`,
+      `lifecycle-${planId}`,
+      `delete-plan-${planId}`,
+    ].includes(action));
+  });
   readonly activePlanLabel = computed(() => this.activePlan()?.name ?? 'None');
   readonly workoutRows = computed<WorkoutRow[]>(() => {
     const selectedPlanId = this.view() === 'plans' ? this.selectedPlanId() : null;
@@ -177,6 +189,9 @@ export class PlansWorkspaceComponent {
           this.locale,
         ),
         planName: workout.planId ? planNames.get(workout.planId) ?? 'Unknown plan' : 'Standalone',
+        historyScope: workout.planId
+          ? { kind: 'plan', id: workout.planId }
+          : { kind: 'workout', id: workout.id },
       }));
   });
   readonly currentWorkoutRows = computed(() => this.workoutRows().filter(row => row.workout.lifecycle !== 'deleted'));
@@ -233,14 +248,14 @@ export class PlansWorkspaceComponent {
   selectView(view: PlansView): void {
     this.view.set(view);
     this.cancelEditor();
-    this.historyPanel.set(null);
+    this.closeHistory();
   }
 
   selectPlan(planId: string): void {
     this.selectedPlanId.set(planId);
     this.view.set('plans');
     this.cancelEditor();
-    this.historyPanel.set(null);
+    this.closeHistory();
   }
 
   beginPlanCreation(): void {
@@ -650,9 +665,11 @@ export class PlansWorkspaceComponent {
   }
 
   async openHistory(scope: TrainingScheduleRevisionScope): Promise<void> {
+    const requestSequence = ++this.historyRequestSequence;
     this.historyPanel.set({ scope, status: 'loading', entries: [], nextBeforeRevision: null, error: null });
     try {
       const response = await this.plansService.getHistory({ scope, limit: 50 });
+      if (!this.isCurrentHistoryPanel(scope, requestSequence)) return;
       this.historyPanel.set({
         scope,
         status: 'ready',
@@ -661,6 +678,7 @@ export class PlansWorkspaceComponent {
         error: null,
       });
     } catch (error) {
+      if (!this.isCurrentHistoryPanel(scope, requestSequence)) return;
       this.historyPanel.set({
         scope,
         status: 'error',
@@ -671,15 +689,10 @@ export class PlansWorkspaceComponent {
     }
   }
 
-  historyScopeForWorkout(workout: ScheduledWorkoutV1): TrainingScheduleRevisionScope {
-    return workout.planId
-      ? { kind: 'plan', id: workout.planId }
-      : { kind: 'workout', id: workout.id };
-  }
-
   async loadOlderHistory(): Promise<void> {
     const panel = this.historyPanel();
     if (!panel || panel.status !== 'ready' || panel.nextBeforeRevision === null) return;
+    const requestSequence = this.historyRequestSequence;
     this.busyAction.set('history-older');
     try {
       const response = await this.plansService.getHistory({
@@ -687,8 +700,8 @@ export class PlansWorkspaceComponent {
         beforeRevision: panel.nextBeforeRevision,
         limit: 50,
       });
-      const current = this.historyPanel();
-      if (!current || current.scope.kind !== panel.scope.kind || current.scope.id !== panel.scope.id) return;
+      if (!this.isCurrentHistoryPanel(panel.scope, requestSequence)) return;
+      const current = this.historyPanel()!;
       const entries = new Map(current.entries.map(entry => [entry.revision, entry]));
       response.entries.forEach(entry => entries.set(entry.revision, entry));
       this.historyPanel.set({
@@ -704,12 +717,14 @@ export class PlansWorkspaceComponent {
   }
 
   closeHistory(): void {
+    this.historyRequestSequence += 1;
     this.historyPanel.set(null);
   }
 
   async restoreHistoryEntry(entry: TrainingScheduleHistoryEntryV1): Promise<void> {
     const panel = this.historyPanel();
     if (!panel) return;
+    const requestSequence = this.historyRequestSequence;
     const expected = panel.scope.kind === 'workout'
       ? this.expectedRevisions({ workoutIds: [panel.scope.id] })
       : this.expectedRevisions({
@@ -721,6 +736,7 @@ export class PlansWorkspaceComponent {
     this.busyAction.set(`restore-${entry.revision}`);
     try {
       const preview = await this.plansService.previewRestore({ scope: panel.scope, targetRevision: entry.revision });
+      if (!this.isCurrentHistoryPanel(panel.scope, requestSequence)) return;
       const changedCount = preview.changedPlanIds.length + preview.changedWorkoutIds.length;
       const warnings = preview.warnings.length ? ` ${preview.warnings.join(' ')}` : '';
       const confirmed = await this.confirm(
@@ -728,14 +744,14 @@ export class PlansWorkspaceComponent {
         `This creates a new revision and changes ${changedCount} item${changedCount === 1 ? '' : 's'}.${warnings}`,
         'Restore revision',
       );
-      if (!confirmed) return;
+      if (!confirmed || !this.isCurrentHistoryPanel(panel.scope, requestSequence)) return;
       const response = await this.plansService.restore({
         mutationId: this.plansService.createMutationId('restore-schedule'),
         expectedRevisions: expected,
         scope: panel.scope,
         targetRevision: entry.revision,
       });
-      this.historyPanel.set(null);
+      this.closeHistory();
       const skipped = response.skippedWorkoutIds.length;
       this.snackBar.open(
         skipped ? `Revision restored; ${skipped} workout${skipped === 1 ? '' : 's'} left unchanged.` : 'Revision restored.',
@@ -758,6 +774,12 @@ export class PlansWorkspaceComponent {
     return expectedRevisionsFromSchedule(this.schedule(), options);
   }
 
+  private isCurrentHistoryPanel(scope: TrainingScheduleRevisionScope, requestSequence: number): boolean {
+    if (requestSequence !== this.historyRequestSequence) return false;
+    const current = this.historyPanel();
+    return Boolean(current && current.scope.kind === scope.kind && current.scope.id === scope.id);
+  }
+
   private async runMutation(
     request: MutateTrainingScheduleRequestV1,
     action: string,
@@ -770,10 +792,15 @@ export class PlansWorkspaceComponent {
       if (/requires extending/i.test(message) && 'confirmPlanRangeExtension' in request.operation) {
         const confirmed = await this.confirm('Extend plan dates?', message, 'Extend and continue');
         if (confirmed) {
-          return await this.plansService.mutate({
-            ...request,
-            operation: { ...request.operation, confirmPlanRangeExtension: true },
-          } as MutateTrainingScheduleRequestV1);
+          try {
+            return await this.plansService.mutate({
+              ...request,
+              operation: { ...request.operation, confirmPlanRangeExtension: true },
+            } as MutateTrainingScheduleRequestV1);
+          } catch (retryError) {
+            this.showError(retryError);
+            return null;
+          }
         }
         return null;
       }

--- a/src/app/components/plans/plans-workspace.component.ts
+++ b/src/app/components/plans/plans-workspace.component.ts
@@ -1,0 +1,835 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  LOCALE_ID,
+  computed,
+  effect,
+  inject,
+  signal,
+} from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { ActivatedRoute } from '@angular/router';
+import { ActivityTypes } from '@sports-alliance/sports-lib';
+import { catchError, filter, map, of, startWith, switchMap } from 'rxjs';
+import type { AppUserInterface } from '../../models/app-user.interface';
+import { SharedModule } from '../../modules/shared.module';
+import { AppUserService } from '../../services/app.user.service';
+import {
+  TrainingPlansService,
+  type CurrentTrainingScheduleV1,
+} from '../../services/training-plans.service';
+import { ConfirmationDialogComponent } from '../confirmation-dialog/confirmation-dialog.component';
+import {
+  createManualWorkoutEditorStep,
+  createManualWorkoutEditorValue,
+  formatManualWorkoutStructure,
+  manualWorkoutEditorToStructure,
+  workoutStructureToManualEditor,
+  type ManualWorkoutEditorNode,
+  type ManualWorkoutEditorStep,
+  type ManualWorkoutEditorValue,
+  type ManualWorkoutEnding,
+  type ManualWorkoutSport,
+  type ManualWorkoutTarget,
+} from '../../helpers/planned-workout-editor.helper';
+import {
+  normalizeTrainingLocalDate,
+  type DeleteTrainingPlanRequestV1,
+  type ExpectedTrainingScheduleRevision,
+  type MutateTrainingScheduleRequestV1,
+  type MutateTrainingScheduleResponseV1,
+  type ScheduledWorkoutV1,
+  type TrainingPlanLifecycle,
+  type TrainingPlanV1,
+  type TrainingScheduleHistoryEntryV1,
+  type TrainingScheduleRevisionScope,
+} from '@shared/training-plans';
+
+type PlansView = 'plans' | 'standalone';
+
+interface ScheduleLoadState {
+  status: 'loading' | 'ready' | 'error';
+  schedule: CurrentTrainingScheduleV1;
+  message: string | null;
+}
+
+interface WorkoutEditorSession {
+  mode: 'create' | 'edit';
+  original: ScheduledWorkoutV1 | null;
+  destinationPlanId: string | null;
+  value: ManualWorkoutEditorValue;
+}
+
+interface WorkoutRow {
+  workout: ScheduledWorkoutV1;
+  summary: string[];
+  planName: string;
+}
+
+interface PlanDraft {
+  name: string;
+  startLocalDate: string;
+  endLocalDate: string;
+  activate: boolean;
+}
+
+interface HistoryPanelState {
+  scope: TrainingScheduleRevisionScope;
+  status: 'loading' | 'ready' | 'error';
+  entries: TrainingScheduleHistoryEntryV1[];
+  nextBeforeRevision: number | null;
+  error: string | null;
+}
+
+const EMPTY_SCHEDULE: CurrentTrainingScheduleV1 = {
+  state: { schemaVersion: 1, activePlanId: null, revision: 0, currentWorkoutCount: 0, updatedAtMs: 0 },
+  plans: [],
+  workouts: [],
+};
+
+@Component({
+  selector: 'app-plans-workspace',
+  standalone: true,
+  imports: [SharedModule],
+  templateUrl: './plans-workspace.component.html',
+  styleUrls: ['./plans-workspace.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PlansWorkspaceComponent {
+  private readonly userService = inject(AppUserService);
+  private readonly plansService = inject(TrainingPlansService);
+  private readonly dialog = inject(MatDialog);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly route = inject(ActivatedRoute);
+  private readonly locale = inject(LOCALE_ID);
+  private requestedEditorOpened = false;
+  private nodeSequence = 1;
+
+  readonly activityTypes = ActivityTypes;
+  readonly sportOptions: ReadonlyArray<{ value: ManualWorkoutSport; label: string }> = [
+    { value: ActivityTypes.Running, label: 'Running' },
+    { value: ActivityTypes.Cycling, label: 'Cycling' },
+  ];
+  readonly purposeOptions = ['warmup', 'work', 'recovery', 'cooldown', 'rest', 'other'] as const;
+  readonly endingOptions: ReadonlyArray<{ value: ManualWorkoutEnding; label: string }> = [
+    { value: 'time', label: 'Time' },
+    { value: 'distance', label: 'Distance' },
+  ];
+  readonly targetOptions: ReadonlyArray<{ value: ManualWorkoutTarget; label: string }> = [
+    { value: 'none', label: 'No target' },
+    { value: 'heart-rate', label: 'Heart rate' },
+    { value: 'power', label: 'Power' },
+    { value: 'pace', label: 'Pace' },
+  ];
+
+  readonly currentUser = computed(() => this.userService.user() as AppUserInterface | null);
+  readonly scheduleState = toSignal(this.userService.user$.pipe(
+    filter((user): user is AppUserInterface => !!user?.uid),
+    switchMap(user => this.plansService.watchSchedule(user.uid).pipe(
+      map(schedule => ({ status: 'ready', schedule, message: null }) as ScheduleLoadState),
+      startWith({ status: 'loading', schedule: EMPTY_SCHEDULE, message: null } as ScheduleLoadState),
+      catchError(error => of({
+        status: 'error',
+        schedule: EMPTY_SCHEDULE,
+        message: errorMessage(error),
+      } as ScheduleLoadState)),
+    )),
+  ), { initialValue: { status: 'loading', schedule: EMPTY_SCHEDULE, message: null } as ScheduleLoadState });
+  readonly schedule = computed(() => this.scheduleState().schedule);
+  readonly view = signal<PlansView>('plans');
+  readonly selectedPlanId = signal<string | null>(null);
+  readonly showPlanForm = signal(false);
+  readonly planDraft = signal<PlanDraft>(defaultPlanDraft());
+  readonly renamingPlanId = signal<string | null>(null);
+  readonly renameValue = signal('');
+  readonly shiftingPlanId = signal<string | null>(null);
+  readonly shiftDays = signal(1);
+  readonly deletingPlanId = signal<string | null>(null);
+  readonly deleteDisposition = signal<DeleteTrainingPlanRequestV1['workoutDisposition']>('convert-to-standalone');
+  readonly editor = signal<WorkoutEditorSession | null>(null);
+  readonly busyAction = signal<string | null>(null);
+  readonly historyPanel = signal<HistoryPanelState | null>(null);
+
+  readonly planOptions = computed(() => this.schedule().plans);
+  readonly activePlan = computed(() => this.schedule().plans.find(plan => (
+    plan.id === this.schedule().state.activePlanId
+  )) ?? null);
+  readonly selectedPlan = computed(() => this.schedule().plans.find(plan => (
+    plan.id === this.selectedPlanId()
+  )) ?? null);
+  readonly activePlanLabel = computed(() => this.activePlan()?.name ?? 'None');
+  readonly workoutRows = computed<WorkoutRow[]>(() => {
+    const selectedPlanId = this.view() === 'plans' ? this.selectedPlanId() : null;
+    const planNames = new Map(this.schedule().plans.map(plan => [plan.id, plan.name]));
+    return this.schedule().workouts
+      .filter(workout => this.view() === 'standalone'
+        ? workout.planId === null
+        : workout.planId === selectedPlanId)
+      .map(workout => ({
+        workout,
+        summary: formatManualWorkoutStructure(
+          workout.structure,
+          this.currentUser()?.settings?.unitSettings ?? null,
+          this.locale,
+        ),
+        planName: workout.planId ? planNames.get(workout.planId) ?? 'Unknown plan' : 'Standalone',
+      }));
+  });
+  readonly currentWorkoutRows = computed(() => this.workoutRows().filter(row => row.workout.lifecycle !== 'deleted'));
+  readonly deletedWorkoutRows = computed(() => this.workoutRows().filter(row => row.workout.lifecycle === 'deleted'));
+  readonly selectedScopeLabel = computed(() => this.view() === 'standalone'
+    ? 'Standalone workouts'
+    : this.selectedPlan()?.name ?? 'Select a plan');
+  readonly pageStatus = computed(() => {
+    if (this.scheduleState().status === 'loading') return 'pending' as const;
+    if (this.scheduleState().status === 'error') return 'warning' as const;
+    return null;
+  });
+
+  private readonly selectionEffect = effect(() => {
+    const plans = this.schedule().plans;
+    const selected = this.selectedPlanId();
+    if (selected && plans.some(plan => plan.id === selected)) return;
+    this.selectedPlanId.set(this.schedule().state.activePlanId ?? plans[0]?.id ?? null);
+  });
+
+  private readonly requestedEditorEffect = effect(() => {
+    if (this.requestedEditorOpened || this.scheduleState().status !== 'ready') return;
+    const requestedWorkoutId = `${this.route.snapshot.queryParamMap.get('workout') || ''}`.trim();
+    if (requestedWorkoutId) {
+      const workout = this.schedule().workouts.find(candidate => (
+        candidate.id === requestedWorkoutId && candidate.lifecycle !== 'deleted'
+      ));
+      if (workout) {
+        this.requestedEditorOpened = true;
+        this.view.set(workout.planId ? 'plans' : 'standalone');
+        this.selectedPlanId.set(workout.planId);
+        this.editWorkout(workout);
+        return;
+      }
+    }
+    const requestedDate = this.route.snapshot.queryParamMap.get('date');
+    if (!requestedDate) {
+      this.requestedEditorOpened = true;
+      if (requestedWorkoutId) {
+        this.snackBar.open('That planned workout is no longer available.', 'Dismiss', { duration: 5000 });
+      }
+      return;
+    }
+    try {
+      const localDate = normalizeTrainingLocalDate(requestedDate);
+      const standalone = this.route.snapshot.queryParamMap.get('scope') === 'standalone';
+      this.requestedEditorOpened = true;
+      this.openNewWorkout(standalone ? null : this.schedule().state.activePlanId, localDate);
+    } catch {
+      this.requestedEditorOpened = true;
+    }
+  });
+
+  selectView(view: PlansView): void {
+    this.view.set(view);
+    this.cancelEditor();
+    this.historyPanel.set(null);
+  }
+
+  selectPlan(planId: string): void {
+    this.selectedPlanId.set(planId);
+    this.view.set('plans');
+    this.cancelEditor();
+    this.historyPanel.set(null);
+  }
+
+  beginPlanCreation(): void {
+    this.planDraft.set(defaultPlanDraft());
+    this.showPlanForm.set(true);
+  }
+
+  cancelPlanCreation(): void {
+    this.showPlanForm.set(false);
+  }
+
+  updatePlanDraft<K extends keyof PlanDraft>(field: K, value: PlanDraft[K]): void {
+    this.planDraft.update(draft => ({ ...draft, [field]: value }));
+  }
+
+  async createPlan(): Promise<void> {
+    const draft = this.planDraft();
+    const planId = this.plansService.createEntityId('plan');
+    const expected = this.expectedRevisions({
+      planIds: draft.activate && this.activePlan() ? [this.activePlan()!.id] : [],
+    });
+    const response = await this.runMutation({
+      mutationId: this.plansService.createMutationId('create-plan'),
+      expectedRevisions: expected,
+      operation: {
+        kind: 'create-plan',
+        planId,
+        name: draft.name,
+        startLocalDate: draft.startLocalDate,
+        endLocalDate: draft.endLocalDate,
+        activate: draft.activate,
+      },
+    }, 'create-plan');
+    if (!response) return;
+    this.showPlanForm.set(false);
+    this.selectedPlanId.set(planId);
+    this.view.set('plans');
+    this.snackBar.open('Training plan created.', 'Dismiss', { duration: 3500 });
+  }
+
+  beginRename(plan: TrainingPlanV1): void {
+    this.renamingPlanId.set(plan.id);
+    this.renameValue.set(plan.name);
+  }
+
+  async renamePlan(plan: TrainingPlanV1): Promise<void> {
+    const name = this.renameValue().trim();
+    if (!name) return;
+    const response = await this.runMutation({
+      mutationId: this.plansService.createMutationId('rename-plan'),
+      expectedRevisions: this.expectedRevisions({ planIds: [plan.id] }),
+      operation: { kind: 'rename-plan', planId: plan.id, name },
+    }, `rename-${plan.id}`);
+    if (!response) return;
+    this.renamingPlanId.set(null);
+    this.snackBar.open('Plan renamed.', 'Dismiss', { duration: 3000 });
+  }
+
+  async setPlanLifecycle(plan: TrainingPlanV1, lifecycle: TrainingPlanLifecycle): Promise<void> {
+    const planIds = [plan.id];
+    if (lifecycle === 'active' && this.activePlan() && this.activePlan()!.id !== plan.id) {
+      planIds.push(this.activePlan()!.id);
+    }
+    const response = await this.runMutation({
+      mutationId: this.plansService.createMutationId(`plan-${lifecycle}`),
+      expectedRevisions: this.expectedRevisions({ planIds }),
+      operation: { kind: 'set-plan-lifecycle', planId: plan.id, lifecycle },
+    }, `lifecycle-${plan.id}`);
+    if (response) this.snackBar.open(`Plan ${lifecycle}.`, 'Dismiss', { duration: 3000 });
+  }
+
+  beginShift(plan: TrainingPlanV1): void {
+    this.shiftingPlanId.set(plan.id);
+    this.shiftDays.set(1);
+  }
+
+  async shiftPlan(plan: TrainingPlanV1): Promise<void> {
+    const days = Number(this.shiftDays());
+    if (!Number.isSafeInteger(days) || days === 0 || Math.abs(days) > 366) {
+      this.snackBar.open('Enter a non-zero whole-day shift up to 366 days.', 'Dismiss', { duration: 5000 });
+      return;
+    }
+    const response = await this.runMutation({
+      mutationId: this.plansService.createMutationId('shift-plan'),
+      expectedRevisions: this.expectedRevisions({ planIds: [plan.id] }),
+      operation: { kind: 'shift-plan', planId: plan.id, days },
+    }, `shift-${plan.id}`);
+    if (!response) return;
+    this.shiftingPlanId.set(null);
+    this.snackBar.open(`Plan shifted ${Math.abs(days)} day${Math.abs(days) === 1 ? '' : 's'}.`, 'Dismiss', { duration: 3500 });
+  }
+
+  beginPlanDeletion(plan: TrainingPlanV1): void {
+    this.deletingPlanId.set(plan.id);
+    this.deleteDisposition.set('convert-to-standalone');
+  }
+
+  async deletePlan(plan: TrainingPlanV1): Promise<void> {
+    const disposition = this.deleteDisposition();
+    const confirmed = await this.confirm(
+      'Delete training plan?',
+      disposition === 'convert-to-standalone'
+        ? `Delete ${plan.name} and keep its current workouts as standalone workouts? Plan history will be removed.`
+        : `Delete ${plan.name}, its current workouts, and their history permanently?`,
+      'Delete plan',
+      'warn',
+    );
+    if (!confirmed) return;
+    this.busyAction.set(`delete-plan-${plan.id}`);
+    try {
+      await this.plansService.deletePlan({
+        mutationId: this.plansService.createMutationId('delete-plan'),
+        planId: plan.id,
+        expectedRevisions: this.expectedRevisions({ planIds: [plan.id] }),
+        workoutDisposition: disposition,
+        confirmPlanDeletion: true,
+      });
+      this.deletingPlanId.set(null);
+      this.snackBar.open('Training plan deleted.', 'Dismiss', { duration: 4000 });
+    } catch (error) {
+      this.showError(error);
+    } finally {
+      this.busyAction.set(null);
+    }
+  }
+
+  openNewWorkout(destinationPlanId?: string | null, localDate = todayLocalDate()): void {
+    const defaultDestination = destinationPlanId === undefined
+      ? (this.view() === 'plans' ? this.selectedPlanId() : null)
+      : destinationPlanId;
+    this.editor.set({
+      mode: 'create',
+      original: null,
+      destinationPlanId: defaultDestination ?? null,
+      value: createManualWorkoutEditorValue(localDate, this.nextNodeId('step')),
+    });
+  }
+
+  editWorkout(workout: ScheduledWorkoutV1): void {
+    try {
+      this.editor.set({
+        mode: 'edit',
+        original: workout,
+        destinationPlanId: workout.planId,
+        value: workoutStructureToManualEditor(workout.title, workout.localDate, workout.structure),
+      });
+    } catch (error) {
+      this.showError(error);
+    }
+  }
+
+  cancelEditor(): void {
+    this.editor.set(null);
+  }
+
+  updateEditorField<K extends keyof ManualWorkoutEditorValue>(field: K, value: ManualWorkoutEditorValue[K]): void {
+    this.editor.update(session => session ? { ...session, value: { ...session.value, [field]: value } } : null);
+  }
+
+  updateEditorDestination(planId: string | null): void {
+    this.editor.update(session => session ? { ...session, destinationPlanId: planId } : null);
+  }
+
+  addEditorStep(): void {
+    this.editor.update(session => session ? {
+      ...session,
+      value: {
+        ...session.value,
+        nodes: [...session.value.nodes, createManualWorkoutEditorStep(this.nextNodeId('step'))],
+      },
+    } : null);
+  }
+
+  addEditorRepeat(): void {
+    this.editor.update(session => session ? {
+      ...session,
+      value: {
+        ...session.value,
+        nodes: [...session.value.nodes, {
+          kind: 'repeat',
+          id: this.nextNodeId('repeat'),
+          count: 4,
+          steps: [
+            createManualWorkoutEditorStep(this.nextNodeId('step')),
+            { ...createManualWorkoutEditorStep(this.nextNodeId('step')), purpose: 'recovery' },
+          ],
+        }],
+      },
+    } : null);
+  }
+
+  removeEditorNode(nodeIndex: number): void {
+    this.editor.update(session => session ? {
+      ...session,
+      value: { ...session.value, nodes: session.value.nodes.filter((_, index) => index !== nodeIndex) },
+    } : null);
+  }
+
+  addRepeatStep(nodeIndex: number): void {
+    this.editor.update(session => {
+      if (!session) return null;
+      const nodes = session.value.nodes.map((node, index) => index === nodeIndex && node.kind === 'repeat'
+        ? { ...node, steps: [...node.steps, createManualWorkoutEditorStep(this.nextNodeId('step'))] }
+        : node);
+      return { ...session, value: { ...session.value, nodes } };
+    });
+  }
+
+  removeRepeatStep(nodeIndex: number, stepIndex: number): void {
+    this.editor.update(session => {
+      if (!session) return null;
+      const nodes = session.value.nodes.map((node, index) => index === nodeIndex && node.kind === 'repeat'
+        ? { ...node, steps: node.steps.filter((_, candidate) => candidate !== stepIndex) }
+        : node);
+      return { ...session, value: { ...session.value, nodes } };
+    });
+  }
+
+  updateNode(nodeIndex: number, field: string, value: unknown): void {
+    this.editor.update(session => {
+      if (!session) return null;
+      const nodes = session.value.nodes.map((node, index) => index === nodeIndex
+        ? { ...node, [field]: value } as ManualWorkoutEditorNode
+        : node);
+      return { ...session, value: { ...session.value, nodes } };
+    });
+  }
+
+  updateStep(nodeIndex: number, stepIndex: number | null, field: string, value: unknown): void {
+    this.editor.update(session => {
+      if (!session) return null;
+      const nodes = session.value.nodes.map((node, index) => {
+        if (index !== nodeIndex) return node;
+        if (stepIndex === null && node.kind === 'step') return { ...node, [field]: value } as ManualWorkoutEditorStep;
+        if (stepIndex !== null && node.kind === 'repeat') {
+          return {
+            ...node,
+            steps: node.steps.map((step, candidate) => candidate === stepIndex
+              ? { ...step, [field]: value } as ManualWorkoutEditorStep
+              : step),
+          };
+        }
+        return node;
+      });
+      return { ...session, value: { ...session.value, nodes } };
+    });
+  }
+
+  async saveWorkout(): Promise<void> {
+    const session = this.editor();
+    if (!session) return;
+    const title = session.value.title.trim();
+    if (!title) {
+      this.snackBar.open('Enter a workout title.', 'Dismiss', { duration: 4000 });
+      return;
+    }
+    let structure;
+    try {
+      structure = manualWorkoutEditorToStructure(session.value);
+      normalizeTrainingLocalDate(session.value.localDate);
+    } catch (error) {
+      this.showError(error);
+      return;
+    }
+    if (session.mode === 'create') {
+      const workoutId = this.plansService.createEntityId('workout');
+      const response = await this.runMutation({
+        mutationId: this.plansService.createMutationId('create-workout'),
+        expectedRevisions: this.expectedRevisions({
+          planIds: session.destinationPlanId ? [session.destinationPlanId] : [],
+        }),
+        operation: {
+          kind: 'create-workout',
+          workoutId,
+          planId: session.destinationPlanId,
+          localDate: session.value.localDate,
+          title,
+          structure,
+          confirmPlanRangeExtension: false,
+        },
+      }, 'save-workout');
+      if (!response) return;
+      this.editor.set(null);
+      this.snackBar.open('Workout added.', 'Dismiss', { duration: 3000 });
+      return;
+    }
+
+    const original = session.original!;
+    const updateResponse = await this.runMutation({
+      mutationId: this.plansService.createMutationId('update-workout'),
+      expectedRevisions: this.expectedRevisions({
+        workoutIds: [original.id],
+        planIds: original.planId ? [original.planId] : [],
+      }),
+      operation: { kind: 'update-workout', workoutId: original.id, title, structure },
+    }, 'save-workout');
+    if (!updateResponse) return;
+
+    if (original.planId !== session.destinationPlanId || original.localDate !== session.value.localDate) {
+      const afterUpdate = mergeMutationResponse(this.schedule(), updateResponse);
+      const moveResponse = await this.runMutation({
+        mutationId: this.plansService.createMutationId('move-workout'),
+        expectedRevisions: expectedRevisionsFromSchedule(afterUpdate, {
+          workoutIds: [original.id],
+          planIds: [original.planId, session.destinationPlanId].filter((id): id is string => !!id),
+        }),
+        operation: {
+          kind: 'move-workout',
+          workoutId: original.id,
+          planId: session.destinationPlanId,
+          localDate: session.value.localDate,
+          confirmPlanRangeExtension: false,
+        },
+      }, 'save-workout');
+      if (!moveResponse) return;
+    }
+    this.editor.set(null);
+    this.snackBar.open('Workout updated.', 'Dismiss', { duration: 3000 });
+  }
+
+  async copyWorkout(workout: ScheduledWorkoutV1): Promise<void> {
+    const workoutId = this.plansService.createEntityId('workout');
+    const planIds = workout.planId ? [workout.planId] : [];
+    const response = await this.runMutation({
+      mutationId: this.plansService.createMutationId('copy-workout'),
+      expectedRevisions: this.expectedRevisions({ workoutIds: [workout.id], planIds }),
+      operation: {
+        kind: 'copy-workout',
+        sourceWorkoutId: workout.id,
+        workoutId,
+        planId: workout.planId,
+        localDate: workout.localDate,
+        confirmPlanRangeExtension: false,
+      },
+    }, `copy-${workout.id}`);
+    if (response) this.snackBar.open('Workout copied.', 'Dismiss', { duration: 3000 });
+  }
+
+  async setWorkoutSkipped(workout: ScheduledWorkoutV1, skipped: boolean): Promise<void> {
+    const response = await this.runMutation({
+      mutationId: this.plansService.createMutationId(skipped ? 'skip-workout' : 'unskip-workout'),
+      expectedRevisions: this.expectedRevisions({
+        workoutIds: [workout.id],
+        planIds: workout.planId ? [workout.planId] : [],
+      }),
+      operation: { kind: 'set-workout-lifecycle', workoutId: workout.id, lifecycle: skipped ? 'skipped' : 'planned' },
+    }, `skip-${workout.id}`);
+    if (response) this.snackBar.open(skipped ? 'Workout marked skipped.' : 'Workout restored to planned.', 'Dismiss', { duration: 3000 });
+  }
+
+  async deleteWorkout(workout: ScheduledWorkoutV1): Promise<void> {
+    const confirmed = await this.confirm(
+      'Delete workout?',
+      'The workout will remain in history and can be restored.',
+      'Delete workout',
+      'warn',
+    );
+    if (!confirmed) return;
+    const response = await this.runMutation({
+      mutationId: this.plansService.createMutationId('delete-workout'),
+      expectedRevisions: this.expectedRevisions({
+        workoutIds: [workout.id],
+        planIds: workout.planId ? [workout.planId] : [],
+      }),
+      operation: { kind: 'delete-workout', workoutId: workout.id },
+    }, `delete-${workout.id}`);
+    if (response) this.snackBar.open('Workout deleted. Open history to restore it.', 'Dismiss', { duration: 5000 });
+  }
+
+  async permanentlyDeleteWorkout(workout: ScheduledWorkoutV1): Promise<void> {
+    const confirmed = await this.confirm(
+      'Permanently delete workout?',
+      'This removes the workout and all of its history. This cannot be undone.',
+      'Delete permanently',
+      'warn',
+    );
+    if (!confirmed) return;
+    const response = await this.runMutation({
+      mutationId: this.plansService.createMutationId('permanent-workout-delete'),
+      expectedRevisions: this.expectedRevisions({ workoutIds: [workout.id] }),
+      operation: { kind: 'permanently-delete-workout', workoutId: workout.id, confirmPermanentDeletion: true },
+    }, `permanent-${workout.id}`);
+    if (response) this.snackBar.open('Workout history permanently deleted.', 'Dismiss', { duration: 4000 });
+  }
+
+  async openHistory(scope: TrainingScheduleRevisionScope): Promise<void> {
+    this.historyPanel.set({ scope, status: 'loading', entries: [], nextBeforeRevision: null, error: null });
+    try {
+      const response = await this.plansService.getHistory({ scope, limit: 50 });
+      this.historyPanel.set({
+        scope,
+        status: 'ready',
+        entries: response.entries,
+        nextBeforeRevision: response.nextBeforeRevision,
+        error: null,
+      });
+    } catch (error) {
+      this.historyPanel.set({
+        scope,
+        status: 'error',
+        entries: [],
+        nextBeforeRevision: null,
+        error: errorMessage(error),
+      });
+    }
+  }
+
+  historyScopeForWorkout(workout: ScheduledWorkoutV1): TrainingScheduleRevisionScope {
+    return workout.planId
+      ? { kind: 'plan', id: workout.planId }
+      : { kind: 'workout', id: workout.id };
+  }
+
+  async loadOlderHistory(): Promise<void> {
+    const panel = this.historyPanel();
+    if (!panel || panel.status !== 'ready' || panel.nextBeforeRevision === null) return;
+    this.busyAction.set('history-older');
+    try {
+      const response = await this.plansService.getHistory({
+        scope: panel.scope,
+        beforeRevision: panel.nextBeforeRevision,
+        limit: 50,
+      });
+      const current = this.historyPanel();
+      if (!current || current.scope.kind !== panel.scope.kind || current.scope.id !== panel.scope.id) return;
+      const entries = new Map(current.entries.map(entry => [entry.revision, entry]));
+      response.entries.forEach(entry => entries.set(entry.revision, entry));
+      this.historyPanel.set({
+        ...current,
+        entries: [...entries.values()].sort((left, right) => right.revision - left.revision),
+        nextBeforeRevision: response.nextBeforeRevision,
+      });
+    } catch (error) {
+      this.showError(error);
+    } finally {
+      this.busyAction.set(null);
+    }
+  }
+
+  closeHistory(): void {
+    this.historyPanel.set(null);
+  }
+
+  async restoreHistoryEntry(entry: TrainingScheduleHistoryEntryV1): Promise<void> {
+    const panel = this.historyPanel();
+    if (!panel) return;
+    this.busyAction.set(`restore-${entry.revision}`);
+    try {
+      const preview = await this.plansService.previewRestore({ scope: panel.scope, targetRevision: entry.revision });
+      const changedCount = preview.changedPlanIds.length + preview.changedWorkoutIds.length;
+      const warnings = preview.warnings.length ? ` ${preview.warnings.join(' ')}` : '';
+      const confirmed = await this.confirm(
+        `Restore revision ${entry.revision}?`,
+        `This creates a new revision and changes ${changedCount} item${changedCount === 1 ? '' : 's'}.${warnings}`,
+        'Restore revision',
+      );
+      if (!confirmed) return;
+      const expected = panel.scope.kind === 'workout'
+        ? this.expectedRevisions({ workoutIds: [panel.scope.id] })
+        : this.expectedRevisions({
+          planIds: [
+            panel.scope.id,
+            ...(this.activePlan() && this.activePlan()!.id !== panel.scope.id ? [this.activePlan()!.id] : []),
+          ],
+        });
+      const response = await this.plansService.restore({
+        mutationId: this.plansService.createMutationId('restore-schedule'),
+        expectedRevisions: expected,
+        scope: panel.scope,
+        targetRevision: entry.revision,
+      });
+      this.historyPanel.set(null);
+      const skipped = response.skippedWorkoutIds.length;
+      this.snackBar.open(
+        skipped ? `Revision restored; ${skipped} workout${skipped === 1 ? '' : 's'} left unchanged.` : 'Revision restored.',
+        'Dismiss',
+        { duration: 6000 },
+      );
+    } catch (error) {
+      this.showError(error);
+    } finally {
+      this.busyAction.set(null);
+    }
+  }
+
+  private expectedRevisions(options: { planIds?: string[]; workoutIds?: string[] }): ExpectedTrainingScheduleRevision[] {
+    return expectedRevisionsFromSchedule(this.schedule(), options);
+  }
+
+  private async runMutation(
+    request: MutateTrainingScheduleRequestV1,
+    action: string,
+  ): Promise<MutateTrainingScheduleResponseV1 | null> {
+    this.busyAction.set(action);
+    try {
+      return await this.plansService.mutate(request);
+    } catch (error) {
+      const message = errorMessage(error);
+      if (/requires extending/i.test(message) && 'confirmPlanRangeExtension' in request.operation) {
+        const confirmed = await this.confirm('Extend plan dates?', message, 'Extend and continue');
+        if (confirmed) {
+          return await this.plansService.mutate({
+            ...request,
+            operation: { ...request.operation, confirmPlanRangeExtension: true },
+          } as MutateTrainingScheduleRequestV1);
+        }
+        return null;
+      }
+      this.showError(error);
+      return null;
+    } finally {
+      this.busyAction.set(null);
+    }
+  }
+
+  private async confirm(
+    title: string,
+    message: string,
+    confirmText: string,
+    confirmColor: 'primary' | 'accent' | 'warn' = 'primary',
+  ): Promise<boolean> {
+    const reference = this.dialog.open(ConfirmationDialogComponent, {
+      data: { title, message, confirmText, confirmColor },
+    });
+    return new Promise(resolve => reference.afterClosed().subscribe(value => resolve(value === true)));
+  }
+
+  private showError(error: unknown): void {
+    this.snackBar.open(errorMessage(error), 'Dismiss', { duration: 7000 });
+  }
+
+  private nextNodeId(prefix: 'step' | 'repeat'): string {
+    this.nodeSequence += 1;
+    return `${prefix}-${Date.now().toString(36)}-${this.nodeSequence}`;
+  }
+}
+
+function expectedRevisionsFromSchedule(
+  schedule: CurrentTrainingScheduleV1,
+  options: { planIds?: string[]; workoutIds?: string[] },
+): ExpectedTrainingScheduleRevision[] {
+  const expected: ExpectedTrainingScheduleRevision[] = [
+    { scope: 'state', id: 'current', revision: schedule.state.revision },
+  ];
+  [...new Set(options.planIds ?? [])].forEach((planId) => {
+    const plan = schedule.plans.find(candidate => candidate.id === planId);
+    if (plan) expected.push({ scope: 'plan', id: plan.id, revision: plan.revision });
+  });
+  [...new Set(options.workoutIds ?? [])].forEach((workoutId) => {
+    const workout = schedule.workouts.find(candidate => candidate.id === workoutId);
+    if (workout) expected.push({ scope: 'workout', id: workout.id, revision: workout.revision });
+  });
+  if (expected.length > 4) throw new Error('This change requires too many concurrent revision checks.');
+  return expected;
+}
+
+function mergeMutationResponse(
+  schedule: CurrentTrainingScheduleV1,
+  response: MutateTrainingScheduleResponseV1,
+): CurrentTrainingScheduleV1 {
+  const plans = new Map(schedule.plans.map(plan => [plan.id, plan]));
+  response.plans.forEach(plan => plans.set(plan.id, plan));
+  response.removedPlanIds.forEach(id => plans.delete(id));
+  const workouts = new Map(schedule.workouts.map(workout => [workout.id, workout]));
+  response.workouts.forEach(workout => workouts.set(workout.id, workout));
+  response.permanentlyDeletedWorkoutIds.forEach(id => workouts.delete(id));
+  return { state: response.state, plans: [...plans.values()], workouts: [...workouts.values()] };
+}
+
+function errorMessage(error: unknown): string {
+  const message = (error as { message?: unknown } | null)?.message;
+  if (typeof message === 'string' && message.trim()) {
+    return message.replace(/^FirebaseError:\s*/i, '').replace(/^functions\/[^:]+:\s*/i, '');
+  }
+  return 'The training schedule could not be updated. Try again.';
+}
+
+function todayLocalDate(now = new Date()): string {
+  const year = now.getFullYear();
+  const month = `${now.getMonth() + 1}`.padStart(2, '0');
+  const day = `${now.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function defaultPlanDraft(now = new Date()): PlanDraft {
+  const startLocalDate = todayLocalDate(now);
+  const end = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 27);
+  return {
+    name: '',
+    startLocalDate,
+    endLocalDate: todayLocalDate(end),
+    activate: true,
+  };
+}

--- a/src/app/components/sidenav/sidenav.component.html
+++ b/src/app/components/sidenav/sidenav.component.html
@@ -50,6 +50,11 @@
     <span>Calendar</span>
   </mat-list-item>
 
+  <mat-list-item routerLinkActive="active" routerLink="/plans" (click)="closeSideNav()">
+    <mat-icon>event_note</mat-icon>
+    <span>Plans</span>
+  </mat-list-item>
+
   <mat-list-item routerLinkActive="active" routerLink="/training" (click)="closeSideNav()">
     <mat-icon>monitoring</mat-icon>
     <span>Training</span>

--- a/src/app/components/sidenav/sidenav.component.html
+++ b/src/app/components/sidenav/sidenav.component.html
@@ -50,10 +50,12 @@
     <span>Calendar</span>
   </mat-list-item>
 
-  <mat-list-item routerLinkActive="active" routerLink="/plans" (click)="closeSideNav()">
-    <mat-icon>event_note</mat-icon>
-    <span>Plans</span>
-  </mat-list-item>
+  @if (hasTrainingPlanningNavigationAccess()) {
+    <mat-list-item routerLinkActive="active" routerLink="/plans" (click)="closeSideNav()">
+      <mat-icon>event_note</mat-icon>
+      <span>Plans</span>
+    </mat-list-item>
+  }
 
   <mat-list-item routerLinkActive="active" routerLink="/training" (click)="closeSideNav()">
     <mat-icon>monitoring</mat-icon>

--- a/src/app/components/sidenav/sidenav.component.spec.ts
+++ b/src/app/components/sidenav/sidenav.component.spec.ts
@@ -18,6 +18,9 @@ import { AppWhatsNewService } from '../../services/app.whats-new.service';
 import { signal } from '@angular/core';
 import { AppThemes } from '@sports-alliance/sports-lib';
 import { SYSTEM_THEME_PREFERENCE } from '../../models/app-theme-preference.type';
+import { TRAINING_PLANNING_NAVIGATION_ALLOWED_UIDS } from '@shared/training-planning-rollout';
+
+const TRAINING_PLANNING_NAVIGATION_ALLOWED_UID = TRAINING_PLANNING_NAVIGATION_ALLOWED_UIDS[0];
 
 describe('SideNavComponent', () => {
     let component: SideNavComponent;
@@ -309,6 +312,37 @@ describe('SideNavComponent', () => {
         expect(healthItem).toBeUndefined();
     });
 
+    it('shows Plans navigation to the staged Training Planning user', () => {
+        mockUserService.user = vi.fn().mockReturnValue({
+            uid: TRAINING_PLANNING_NAVIGATION_ALLOWED_UID,
+            displayName: 'Athlete',
+            email: 'athlete@example.com'
+        });
+
+        fixture.detectChanges();
+        const plansItem = fixture.debugElement
+            .queryAll(By.css('mat-list-item'))
+            .find(item => item.nativeElement.textContent.includes('Plans'));
+
+        expect(plansItem).toBeTruthy();
+        expect(plansItem?.nativeElement.getAttribute('routerlink')).toBe('/plans');
+    });
+
+    it('silently hides Plans navigation from signed-in users outside the staged rollout', () => {
+        mockUserService.user = vi.fn().mockReturnValue({
+            uid: 'another-user',
+            displayName: 'Athlete',
+            email: 'athlete@example.com'
+        });
+
+        fixture.detectChanges();
+        const plansItem = fixture.debugElement
+            .queryAll(By.css('mat-list-item'))
+            .find(item => item.nativeElement.textContent.includes('Plans'));
+
+        expect(plansItem).toBeUndefined();
+    });
+
     it('opens the profile section when the signed-in profile shortcut is selected', () => {
         mockUserService.user = vi.fn().mockReturnValue({
             uid: 'user-1',
@@ -328,7 +362,7 @@ describe('SideNavComponent', () => {
 
     it('orders signed-in navigation with Assistant last', () => {
         mockUserService.user = vi.fn().mockReturnValue({
-            uid: 'user-1',
+            uid: TRAINING_PLANNING_NAVIGATION_ALLOWED_UID,
             displayName: 'Athlete',
             email: 'athlete@example.com'
         });

--- a/src/app/components/sidenav/sidenav.component.spec.ts
+++ b/src/app/components/sidenav/sidenav.component.spec.ts
@@ -338,6 +338,7 @@ describe('SideNavComponent', () => {
         const dashboardItem = navigationItems.find(item => item.nativeElement.textContent.includes('Dashboard'));
         const healthItem = navigationItems.find(item => item.nativeElement.textContent.includes('Health'));
         const calendarItem = navigationItems.find(item => item.nativeElement.textContent.includes('Calendar'));
+        const plansItem = navigationItems.find(item => item.nativeElement.textContent.includes('Plans'));
         const trainingItem = navigationItems.find(item => item.nativeElement.textContent.includes('Training'));
         const routesItem = navigationItems.find(item => item.nativeElement.textContent.includes('Routes'));
         const myTracksItem = navigationItems.find(item => item.nativeElement.textContent.includes('My Tracks'));
@@ -347,6 +348,7 @@ describe('SideNavComponent', () => {
         expect(dashboardItem).toBeTruthy();
         expect(healthItem).toBeTruthy();
         expect(calendarItem).toBeTruthy();
+        expect(plansItem).toBeTruthy();
         expect(trainingItem).toBeTruthy();
         expect(routesItem).toBeTruthy();
         expect(myTracksItem).toBeTruthy();
@@ -356,6 +358,7 @@ describe('SideNavComponent', () => {
         expect([
             navigationItems.indexOf(dashboardItem!),
             navigationItems.indexOf(calendarItem!),
+            navigationItems.indexOf(plansItem!),
             navigationItems.indexOf(trainingItem!),
             navigationItems.indexOf(healthItem!),
             navigationItems.indexOf(routesItem!),
@@ -371,6 +374,7 @@ describe('SideNavComponent', () => {
             dashboardIndex + 5,
             dashboardIndex + 6,
             dashboardIndex + 7,
+            dashboardIndex + 8,
         ]);
         expect(assistantItem?.nativeElement.textContent).toContain('Assistant');
         expect(assistantItem?.nativeElement.textContent).not.toContain('Going away');

--- a/src/app/components/sidenav/sidenav.component.ts
+++ b/src/app/components/sidenav/sidenav.component.ts
@@ -1,5 +1,6 @@
-import { Component, inject } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
+import { isTrainingPlanningNavigationUIDAllowed } from '@shared/training-planning-rollout';
 import { EventInterface } from '@sports-alliance/sports-lib';
 import { AppAuthService } from '../../authentication/app.auth.service';
 import { AppSideNavService } from '../../services/side-nav/app-side-nav.service';
@@ -33,6 +34,8 @@ export class SideNavComponent {
   public themePreference = toSignal(this.themeService.getThemePreference(), { initialValue: SYSTEM_THEME_PREFERENCE });
   private analyticsService = inject(AppAnalyticsService);
   private hapticsService = inject(AppHapticsService);
+  public readonly hasTrainingPlanningNavigationAccess = computed(() =>
+    isTrainingPlanningNavigationUIDAllowed(this.userService.user()?.uid));
 
   constructor(
     public authService: AppAuthService,

--- a/src/app/helpers/planned-workout-calendar.helper.spec.ts
+++ b/src/app/helpers/planned-workout-calendar.helper.spec.ts
@@ -64,4 +64,21 @@ describe('planned workout calendar overlay', () => {
       ariaLabel: '2 planned workouts, 1 skipped workout',
     });
   });
+
+  it('keeps paused and archived plan workouts out of calendar overlays', () => {
+    const pausedPlan = { ...PLAN, id: 'paused-plan', lifecycle: 'paused' as const };
+    const archivedPlan = { ...PLAN, id: 'archived-plan', lifecycle: 'archived' as const };
+    const pausedWorkout = { ...workout('paused-workout'), planId: pausedPlan.id };
+    const archivedWorkout = { ...workout('archived-workout'), planId: archivedPlan.id };
+
+    const overlay = buildPlannedWorkoutCalendarOverlay([
+      workout('tempo'),
+      workout('standalone'),
+      pausedWorkout,
+      archivedWorkout,
+    ], [PLAN, pausedPlan, archivedPlan]);
+
+    expect(overlay['2026-09-02'].entries.map(entry => entry.workout.id))
+      .toEqual(['standalone', 'tempo']);
+  });
 });

--- a/src/app/helpers/planned-workout-calendar.helper.spec.ts
+++ b/src/app/helpers/planned-workout-calendar.helper.spec.ts
@@ -81,4 +81,17 @@ describe('planned workout calendar overlay', () => {
     expect(overlay['2026-09-02'].entries.map(entry => entry.workout.id))
       .toEqual(['standalone', 'tempo']);
   });
+
+  it('uses the authoritative active-plan state while lifecycle listeners catch up', () => {
+    const stalePlan = { ...PLAN, lifecycle: 'paused' as const };
+
+    const overlay = buildPlannedWorkoutCalendarOverlay(
+      [workout('tempo'), workout('standalone')],
+      [stalePlan],
+      stalePlan.id,
+    );
+
+    expect(overlay['2026-09-02'].entries.map(entry => entry.workout.id))
+      .toEqual(['standalone', 'tempo']);
+  });
 });

--- a/src/app/helpers/planned-workout-calendar.helper.spec.ts
+++ b/src/app/helpers/planned-workout-calendar.helper.spec.ts
@@ -1,0 +1,67 @@
+import { ActivityTypes } from '@sports-alliance/sports-lib';
+import { describe, expect, it } from 'vitest';
+import type { ScheduledWorkoutV1, TrainingPlanV1 } from '@shared/training-plans';
+import { buildPlannedWorkoutCalendarOverlay } from './planned-workout-calendar.helper';
+
+const STRUCTURE = {
+  version: 1 as const,
+  sport: ActivityTypes.Running,
+  nodes: [{
+    kind: 'step' as const,
+    id: 'steady',
+    purpose: 'work' as const,
+    ending: { kind: 'time' as const, seconds: 1800 },
+    targets: [],
+  }],
+};
+
+function workout(id: string, lifecycle: ScheduledWorkoutV1['lifecycle'] = 'planned'): ScheduledWorkoutV1 {
+  return {
+    schemaVersion: 1,
+    id,
+    planId: id === 'standalone' ? null : 'plan-1',
+    localDate: '2026-09-02',
+    lifecycle,
+    title: id,
+    structure: STRUCTURE,
+    revision: 1,
+    createdAtMs: 1,
+    updatedAtMs: 1,
+    ...(lifecycle === 'deleted' ? { deletedAtMs: 2 } : {}),
+  };
+}
+
+const PLAN: TrainingPlanV1 = {
+  schemaVersion: 1,
+  id: 'plan-1',
+  name: 'Autumn build',
+  lifecycle: 'active',
+  startLocalDate: '2026-09-01',
+  endLocalDate: '2026-09-30',
+  revision: 1,
+  lastCheckpointRevision: 1,
+  workoutCount: 2,
+  createdAtMs: 1,
+  updatedAtMs: 1,
+};
+
+describe('planned workout calendar overlay', () => {
+  it('groups plan and standalone workouts separately from deleted history', () => {
+    const overlay = buildPlannedWorkoutCalendarOverlay([
+      workout('tempo'),
+      workout('standalone'),
+      workout('recovery', 'skipped'),
+      workout('deleted', 'deleted'),
+    ], [PLAN]);
+
+    expect(overlay['2026-09-02'].entries.map(entry => entry.workout.id))
+      .toEqual(['standalone', 'tempo', 'recovery']);
+    expect(overlay['2026-09-02'].entries.map(entry => entry.planName))
+      .toEqual([null, 'Autumn build', 'Autumn build']);
+    expect(overlay['2026-09-02']).toMatchObject({
+      overflowCount: 1,
+      hasSkipped: true,
+      ariaLabel: '2 planned workouts, 1 skipped workout',
+    });
+  });
+});

--- a/src/app/helpers/planned-workout-calendar.helper.ts
+++ b/src/app/helpers/planned-workout-calendar.helper.ts
@@ -18,11 +18,12 @@ export type PlannedWorkoutCalendarOverlay = Readonly<Record<string, PlannedWorko
 export function buildPlannedWorkoutCalendarOverlay(
   workouts: readonly ScheduledWorkoutV1[],
   plans: readonly TrainingPlanV1[] = [],
+  activePlanId?: string | null,
 ): PlannedWorkoutCalendarOverlay {
   const planNames = new Map(plans.map(plan => [plan.id, plan.name]));
-  const activePlanIds = new Set(plans
-    .filter(plan => plan.lifecycle === 'active')
-    .map(plan => plan.id));
+  const activePlanIds = activePlanId === undefined
+    ? new Set(plans.filter(plan => plan.lifecycle === 'active').map(plan => plan.id))
+    : new Set(activePlanId ? [activePlanId] : []);
   const grouped = new Map<string, PlannedWorkoutCalendarEntry[]>();
   workouts
     .filter(workout => (

--- a/src/app/helpers/planned-workout-calendar.helper.ts
+++ b/src/app/helpers/planned-workout-calendar.helper.ts
@@ -1,0 +1,55 @@
+import type { ScheduledWorkoutV1, TrainingPlanV1 } from '@shared/training-plans';
+
+export interface PlannedWorkoutCalendarEntry {
+  workout: ScheduledWorkoutV1;
+  planName: string | null;
+}
+
+export interface PlannedWorkoutCalendarDayOverlay {
+  entries: PlannedWorkoutCalendarEntry[];
+  visibleEntries: PlannedWorkoutCalendarEntry[];
+  overflowCount: number;
+  hasSkipped: boolean;
+  ariaLabel: string;
+}
+
+export type PlannedWorkoutCalendarOverlay = Readonly<Record<string, PlannedWorkoutCalendarDayOverlay>>;
+
+export function buildPlannedWorkoutCalendarOverlay(
+  workouts: readonly ScheduledWorkoutV1[],
+  plans: readonly TrainingPlanV1[] = [],
+): PlannedWorkoutCalendarOverlay {
+  const planNames = new Map(plans.map(plan => [plan.id, plan.name]));
+  const grouped = new Map<string, PlannedWorkoutCalendarEntry[]>();
+  workouts
+    .filter(workout => workout.lifecycle !== 'deleted')
+    .forEach((workout) => {
+      const entries = grouped.get(workout.localDate) ?? [];
+      entries.push({
+        workout,
+        planName: workout.planId ? planNames.get(workout.planId) ?? 'Plan workout' : null,
+      });
+      grouped.set(workout.localDate, entries);
+    });
+
+  return Object.fromEntries([...grouped.entries()].map(([date, entries]) => {
+    const sorted = [...entries].sort((left, right) => (
+      Number(left.workout.lifecycle === 'skipped') - Number(right.workout.lifecycle === 'skipped')
+      || left.workout.title.localeCompare(right.workout.title)
+      || left.workout.id.localeCompare(right.workout.id)
+    ));
+    const skippedCount = sorted.filter(entry => entry.workout.lifecycle === 'skipped').length;
+    const plannedCount = sorted.length - skippedCount;
+    const parts = [
+      plannedCount ? `${plannedCount} planned workout${plannedCount === 1 ? '' : 's'}` : '',
+      skippedCount ? `${skippedCount} skipped workout${skippedCount === 1 ? '' : 's'}` : '',
+    ].filter(Boolean);
+    return [date, {
+      entries: sorted,
+      visibleEntries: sorted.slice(0, 2),
+      overflowCount: Math.max(0, sorted.length - 2),
+      hasSkipped: skippedCount > 0,
+      ariaLabel: parts.join(', '),
+    } satisfies PlannedWorkoutCalendarDayOverlay];
+  }));
+}

--- a/src/app/helpers/planned-workout-calendar.helper.ts
+++ b/src/app/helpers/planned-workout-calendar.helper.ts
@@ -20,9 +20,15 @@ export function buildPlannedWorkoutCalendarOverlay(
   plans: readonly TrainingPlanV1[] = [],
 ): PlannedWorkoutCalendarOverlay {
   const planNames = new Map(plans.map(plan => [plan.id, plan.name]));
+  const activePlanIds = new Set(plans
+    .filter(plan => plan.lifecycle === 'active')
+    .map(plan => plan.id));
   const grouped = new Map<string, PlannedWorkoutCalendarEntry[]>();
   workouts
-    .filter(workout => workout.lifecycle !== 'deleted')
+    .filter(workout => (
+      workout.lifecycle !== 'deleted'
+      && (workout.planId === null || activePlanIds.has(workout.planId))
+    ))
     .forEach((workout) => {
       const entries = grouped.get(workout.localDate) ?? [];
       entries.push({

--- a/src/app/helpers/planned-workout-editor.helper.spec.ts
+++ b/src/app/helpers/planned-workout-editor.helper.spec.ts
@@ -1,5 +1,6 @@
 import { ActivityTypes } from '@sports-alliance/sports-lib';
 import { describe, expect, it } from 'vitest';
+import type { WorkoutStructureV1 } from '@shared/planned-workout';
 import {
   createManualWorkoutEditorStep,
   manualWorkoutEditorToStructure,
@@ -88,5 +89,72 @@ describe('manual planned-workout editor conversion', () => {
       targetMaximum: 150,
     }];
     expect(() => manualWorkoutEditorToStructure(value)).toThrow('minimum must not exceed');
+  });
+
+  it('preserves step notes and accepts canonical zero-watt bounds', () => {
+    const structure: WorkoutStructureV1 = {
+      version: 1,
+      sport: ActivityTypes.Cycling,
+      nodes: [{
+        kind: 'step',
+        id: 'recovery',
+        purpose: 'recovery',
+        ending: { kind: 'time', seconds: 300 },
+        targets: [{
+          kind: 'power',
+          mode: 'absolute',
+          minimumWatts: 0,
+          maximumWatts: 100,
+        }],
+        note: 'Keep the legs moving',
+      }],
+    };
+
+    const editor = workoutStructureToManualEditor('Recovery', '2026-09-03', structure);
+    expect(editor.nodes[0]).toMatchObject({
+      targetKind: 'power',
+      targetMinimum: 0,
+      targetMaximum: 100,
+      note: 'Keep the legs moving',
+    });
+    expect(manualWorkoutEditorToStructure(editor)).toEqual(structure);
+  });
+
+  it('rejects targets the first editor cannot represent instead of silently dropping them', () => {
+    const base: WorkoutStructureV1 = {
+      version: 1,
+      sport: ActivityTypes.Running,
+      nodes: [{
+        kind: 'step',
+        id: 'work',
+        purpose: 'work',
+        ending: { kind: 'time', seconds: 600 },
+        targets: [{
+          kind: 'cadence',
+          mode: 'absolute',
+          minimumRpm: 170,
+          maximumRpm: 180,
+        }],
+      }],
+    };
+    expect(() => workoutStructureToManualEditor('Cadence', '2026-09-03', base))
+      .toThrow('cadence target');
+
+    const relative: WorkoutStructureV1 = {
+      ...base,
+      nodes: [{
+        ...base.nodes[0],
+        kind: 'step',
+        targets: [{
+          kind: 'heart-rate',
+          mode: 'relative',
+          minimumPercent: 80,
+          maximumPercent: 90,
+          reference: { kind: 'max-heart-rate', bpm: 190 },
+        }],
+      }],
+    };
+    expect(() => workoutStructureToManualEditor('Relative', '2026-09-03', relative))
+      .toThrow('relative target');
   });
 });

--- a/src/app/helpers/planned-workout-editor.helper.spec.ts
+++ b/src/app/helpers/planned-workout-editor.helper.spec.ts
@@ -1,0 +1,92 @@
+import { ActivityTypes } from '@sports-alliance/sports-lib';
+import { describe, expect, it } from 'vitest';
+import {
+  createManualWorkoutEditorStep,
+  manualWorkoutEditorToStructure,
+  workoutStructureToManualEditor,
+  type ManualWorkoutEditorValue,
+} from './planned-workout-editor.helper';
+
+describe('manual planned-workout editor conversion', () => {
+  it('stores minutes and kilometres as canonical seconds and metres', () => {
+    const value: ManualWorkoutEditorValue = {
+      title: 'Brick',
+      localDate: '2026-09-03',
+      sport: ActivityTypes.Cycling,
+      nodes: [
+        { ...createManualWorkoutEditorStep('time'), endingValue: 12.5 },
+        { ...createManualWorkoutEditorStep('distance'), endingKind: 'distance', endingValue: 5 },
+      ],
+    };
+    const structure = manualWorkoutEditorToStructure(value);
+
+    expect(structure.nodes[0]).toMatchObject({ ending: { kind: 'time', seconds: 750 } });
+    expect(structure.nodes[1]).toMatchObject({ ending: { kind: 'distance', meters: 5000 } });
+  });
+
+  it('creates fixed repeats without nested repeat nodes', () => {
+    const value: ManualWorkoutEditorValue = {
+      title: 'Intervals',
+      localDate: '2026-09-03',
+      sport: ActivityTypes.Running,
+      nodes: [{
+        kind: 'repeat',
+        id: 'repeat-1',
+        count: 6,
+        steps: [createManualWorkoutEditorStep('work'), {
+          ...createManualWorkoutEditorStep('recover'), purpose: 'recovery', endingValue: 2,
+        }],
+      }],
+    };
+
+    expect(manualWorkoutEditorToStructure(value).nodes[0]).toMatchObject({
+      kind: 'repeat', count: 6, steps: [{ kind: 'step' }, { kind: 'step', purpose: 'recovery' }],
+    });
+  });
+
+  it('converts pace ranges to ordered m/s while preserving pace presentation', () => {
+    const value: ManualWorkoutEditorValue = {
+      title: 'Tempo',
+      localDate: '2026-09-03',
+      sport: ActivityTypes.Running,
+      nodes: [{
+        ...createManualWorkoutEditorStep('tempo'),
+        targetKind: 'pace',
+        targetMinimum: 4,
+        targetMaximum: 5,
+      }],
+    };
+    const structure = manualWorkoutEditorToStructure(value);
+
+    expect(structure.nodes[0]).toMatchObject({
+      targets: [{
+        kind: 'speed', mode: 'absolute', presentation: 'pace',
+        minimumMetersPerSecond: 1000 / 300,
+        maximumMetersPerSecond: 1000 / 240,
+      }],
+    });
+    expect(workoutStructureToManualEditor('Tempo', value.localDate, structure).nodes[0]).toMatchObject({
+      targetKind: 'pace', targetMinimum: 4, targetMaximum: 5,
+    });
+  });
+
+  it('rejects invalid repeat and target ranges before the callable', () => {
+    const value: ManualWorkoutEditorValue = {
+      title: 'Invalid',
+      localDate: '2026-09-03',
+      sport: ActivityTypes.Running,
+      nodes: [{
+        kind: 'repeat', id: 'repeat', count: 0, steps: [createManualWorkoutEditorStep('work')],
+      }],
+    };
+    expect(() => manualWorkoutEditorToStructure(value)).toThrow('Repeat counts');
+
+    value.nodes = [{
+      ...createManualWorkoutEditorStep('work'),
+      targetKind: 'heart-rate',
+      targetMinimum: 170,
+      targetMaximum: 150,
+    }];
+    expect(() => manualWorkoutEditorToStructure(value)).toThrow('minimum must not exceed');
+  });
+});

--- a/src/app/helpers/planned-workout-editor.helper.ts
+++ b/src/app/helpers/planned-workout-editor.helper.ts
@@ -1,0 +1,208 @@
+import { ActivityTypes, type UserUnitSettingsInterface } from '@sports-alliance/sports-lib';
+import {
+  formatWorkoutStepV1,
+  parseWorkoutStructureV1,
+  type WorkoutEndingV1,
+  type WorkoutNodeV1,
+  type WorkoutStepPurposeV1,
+  type WorkoutStepV1,
+  type WorkoutStructureV1,
+  type WorkoutTargetV1,
+} from '@shared/planned-workout';
+
+export type ManualWorkoutSport = typeof ActivityTypes.Running | typeof ActivityTypes.Cycling;
+export type ManualWorkoutEnding = 'time' | 'distance';
+export type ManualWorkoutTarget = 'none' | 'heart-rate' | 'power' | 'pace';
+
+export interface ManualWorkoutEditorStep {
+  kind: 'step';
+  id: string;
+  purpose: WorkoutStepPurposeV1;
+  endingKind: ManualWorkoutEnding;
+  endingValue: number;
+  targetKind: ManualWorkoutTarget;
+  targetMinimum: number | null;
+  targetMaximum: number | null;
+}
+
+export interface ManualWorkoutEditorRepeat {
+  kind: 'repeat';
+  id: string;
+  count: number;
+  steps: ManualWorkoutEditorStep[];
+}
+
+export type ManualWorkoutEditorNode = ManualWorkoutEditorStep | ManualWorkoutEditorRepeat;
+
+export interface ManualWorkoutEditorValue {
+  title: string;
+  localDate: string;
+  sport: ManualWorkoutSport;
+  nodes: ManualWorkoutEditorNode[];
+}
+
+export function createManualWorkoutEditorStep(id: string): ManualWorkoutEditorStep {
+  return {
+    kind: 'step',
+    id,
+    purpose: 'work',
+    endingKind: 'time',
+    endingValue: 10,
+    targetKind: 'none',
+    targetMinimum: null,
+    targetMaximum: null,
+  };
+}
+
+export function createManualWorkoutEditorValue(
+  localDate: string,
+  nodeId = 'step-1',
+): ManualWorkoutEditorValue {
+  return {
+    title: '',
+    localDate,
+    sport: ActivityTypes.Running,
+    nodes: [createManualWorkoutEditorStep(nodeId)],
+  };
+}
+
+function endingFromEditor(step: ManualWorkoutEditorStep): WorkoutEndingV1 {
+  if (!Number.isFinite(step.endingValue) || step.endingValue <= 0) {
+    throw new Error('Every step needs a positive duration or distance.');
+  }
+  return step.endingKind === 'time'
+    ? { kind: 'time', seconds: step.endingValue * 60 }
+    : { kind: 'distance', meters: step.endingValue * 1000 };
+}
+
+function targetFromEditor(step: ManualWorkoutEditorStep): WorkoutTargetV1[] {
+  if (step.targetKind === 'none') return [];
+  const minimum = Number(step.targetMinimum);
+  const maximum = Number(step.targetMaximum);
+  if (!Number.isFinite(minimum) || !Number.isFinite(maximum) || minimum <= 0 || maximum <= 0) {
+    throw new Error('Target ranges need two positive values.');
+  }
+  if (step.targetKind === 'pace') {
+    const fasterMinutesPerKilometer = Math.min(minimum, maximum);
+    const slowerMinutesPerKilometer = Math.max(minimum, maximum);
+    return [{
+      kind: 'speed',
+      mode: 'absolute',
+      minimumMetersPerSecond: 1000 / (slowerMinutesPerKilometer * 60),
+      maximumMetersPerSecond: 1000 / (fasterMinutesPerKilometer * 60),
+      presentation: 'pace',
+    }];
+  }
+  if (minimum > maximum) throw new Error('The target minimum must not exceed its maximum.');
+  return step.targetKind === 'heart-rate'
+    ? [{ kind: 'heart-rate', mode: 'absolute', minimumBpm: minimum, maximumBpm: maximum }]
+    : [{ kind: 'power', mode: 'absolute', minimumWatts: minimum, maximumWatts: maximum }];
+}
+
+function stepFromEditor(step: ManualWorkoutEditorStep): WorkoutStepV1 {
+  return {
+    kind: 'step',
+    id: step.id,
+    purpose: step.purpose,
+    ending: endingFromEditor(step),
+    targets: targetFromEditor(step),
+  };
+}
+
+export function manualWorkoutEditorToStructure(value: ManualWorkoutEditorValue): WorkoutStructureV1 {
+  if (!value.nodes.length) throw new Error('Add at least one workout step.');
+  const nodes: WorkoutNodeV1[] = value.nodes.map((node) => {
+    if (node.kind === 'step') return stepFromEditor(node);
+    if (!Number.isSafeInteger(node.count) || node.count < 1 || node.count > 100) {
+      throw new Error('Repeat counts must be between 1 and 100.');
+    }
+    if (!node.steps.length) throw new Error('A repeat needs at least one step.');
+    return {
+      kind: 'repeat',
+      id: node.id,
+      count: node.count,
+      steps: node.steps.map(stepFromEditor),
+    };
+  });
+  return parseWorkoutStructureV1({ version: 1, sport: value.sport, nodes });
+}
+
+function editorTarget(target: WorkoutTargetV1 | undefined): Pick<
+  ManualWorkoutEditorStep,
+  'targetKind' | 'targetMinimum' | 'targetMaximum'
+> {
+  if (!target || target.mode !== 'absolute') {
+    return { targetKind: 'none', targetMinimum: null, targetMaximum: null };
+  }
+  switch (target.kind) {
+    case 'heart-rate':
+      return {
+        targetKind: 'heart-rate',
+        targetMinimum: target.minimumBpm,
+        targetMaximum: target.maximumBpm,
+      };
+    case 'power':
+      return {
+        targetKind: 'power',
+        targetMinimum: target.minimumWatts,
+        targetMaximum: target.maximumWatts,
+      };
+    case 'speed':
+      if (target.presentation !== 'pace') return { targetKind: 'none', targetMinimum: null, targetMaximum: null };
+      return {
+        targetKind: 'pace',
+        targetMinimum: roundEditorNumber(1000 / target.maximumMetersPerSecond / 60),
+        targetMaximum: roundEditorNumber(1000 / target.minimumMetersPerSecond / 60),
+      };
+    case 'cadence':
+      return { targetKind: 'none', targetMinimum: null, targetMaximum: null };
+  }
+}
+
+function roundEditorNumber(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}
+
+function editorStep(step: WorkoutStepV1): ManualWorkoutEditorStep {
+  if (step.ending.kind !== 'time' && step.ending.kind !== 'distance') {
+    throw new Error('This workout uses an ending that the first manual editor cannot change.');
+  }
+  if (step.targets.length > 1) throw new Error('This workout has more targets than the first manual editor supports.');
+  const target = editorTarget(step.targets[0]);
+  return {
+    kind: 'step',
+    id: step.id,
+    purpose: step.purpose,
+    endingKind: step.ending.kind,
+    endingValue: step.ending.kind === 'time' ? step.ending.seconds / 60 : step.ending.meters / 1000,
+    ...target,
+  };
+}
+
+export function workoutStructureToManualEditor(
+  title: string,
+  localDate: string,
+  structure: WorkoutStructureV1,
+): ManualWorkoutEditorValue {
+  if (structure.sport !== ActivityTypes.Running && structure.sport !== ActivityTypes.Cycling) {
+    throw new Error('The first manual editor supports running and cycling workouts.');
+  }
+  return {
+    title,
+    localDate,
+    sport: structure.sport,
+    nodes: structure.nodes.map(node => node.kind === 'step'
+      ? editorStep(node)
+      : { kind: 'repeat', id: node.id, count: node.count, steps: node.steps.map(editorStep) }),
+  };
+}
+
+export function formatManualWorkoutStructure(
+  structure: WorkoutStructureV1,
+  unitSettings?: UserUnitSettingsInterface | null,
+  locale?: string,
+): string[] {
+  return structure.nodes.map(node => node.kind === 'step'
+    ? formatWorkoutStepV1(node, unitSettings, locale)
+    : `${node.count}× (${node.steps.map(step => formatWorkoutStepV1(step, unitSettings, locale)).join('; ')})`);
+}

--- a/src/app/helpers/planned-workout-editor.helper.ts
+++ b/src/app/helpers/planned-workout-editor.helper.ts
@@ -23,6 +23,7 @@ export interface ManualWorkoutEditorStep {
   targetKind: ManualWorkoutTarget;
   targetMinimum: number | null;
   targetMaximum: number | null;
+  note?: string;
 }
 
 export interface ManualWorkoutEditorRepeat {
@@ -77,12 +78,18 @@ function endingFromEditor(step: ManualWorkoutEditorStep): WorkoutEndingV1 {
 
 function targetFromEditor(step: ManualWorkoutEditorStep): WorkoutTargetV1[] {
   if (step.targetKind === 'none') return [];
-  const minimum = Number(step.targetMinimum);
-  const maximum = Number(step.targetMaximum);
-  if (!Number.isFinite(minimum) || !Number.isFinite(maximum) || minimum <= 0 || maximum <= 0) {
-    throw new Error('Target ranges need two positive values.');
+  if (typeof step.targetMinimum !== 'number' || typeof step.targetMaximum !== 'number') {
+    throw new Error('Target ranges need two numeric values.');
+  }
+  const minimum = step.targetMinimum;
+  const maximum = step.targetMaximum;
+  if (!Number.isFinite(minimum) || !Number.isFinite(maximum)) {
+    throw new Error('Target ranges need two finite values.');
   }
   if (step.targetKind === 'pace') {
+    if (minimum <= 0 || maximum <= 0) {
+      throw new Error('Pace target ranges need two positive values.');
+    }
     const fasterMinutesPerKilometer = Math.min(minimum, maximum);
     const slowerMinutesPerKilometer = Math.max(minimum, maximum);
     return [{
@@ -93,6 +100,9 @@ function targetFromEditor(step: ManualWorkoutEditorStep): WorkoutTargetV1[] {
       presentation: 'pace',
     }];
   }
+  if (minimum < 0 || maximum < 0) {
+    throw new Error('Heart-rate and power target ranges cannot be negative.');
+  }
   if (minimum > maximum) throw new Error('The target minimum must not exceed its maximum.');
   return step.targetKind === 'heart-rate'
     ? [{ kind: 'heart-rate', mode: 'absolute', minimumBpm: minimum, maximumBpm: maximum }]
@@ -100,13 +110,14 @@ function targetFromEditor(step: ManualWorkoutEditorStep): WorkoutTargetV1[] {
 }
 
 function stepFromEditor(step: ManualWorkoutEditorStep): WorkoutStepV1 {
-  return {
+  const converted: WorkoutStepV1 = {
     kind: 'step',
     id: step.id,
     purpose: step.purpose,
     ending: endingFromEditor(step),
     targets: targetFromEditor(step),
   };
+  return step.note === undefined ? converted : { ...converted, note: step.note };
 }
 
 export function manualWorkoutEditorToStructure(value: ManualWorkoutEditorValue): WorkoutStructureV1 {
@@ -132,7 +143,8 @@ function editorTarget(target: WorkoutTargetV1 | undefined): Pick<
   'targetKind' | 'targetMinimum' | 'targetMaximum'
 > {
   if (!target || target.mode !== 'absolute') {
-    return { targetKind: 'none', targetMinimum: null, targetMaximum: null };
+    if (!target) return { targetKind: 'none', targetMinimum: null, targetMaximum: null };
+    throw new Error('This workout uses a relative target that the first manual editor cannot change.');
   }
   switch (target.kind) {
     case 'heart-rate':
@@ -148,14 +160,16 @@ function editorTarget(target: WorkoutTargetV1 | undefined): Pick<
         targetMaximum: target.maximumWatts,
       };
     case 'speed':
-      if (target.presentation !== 'pace') return { targetKind: 'none', targetMinimum: null, targetMaximum: null };
+      if (target.presentation !== 'pace') {
+        throw new Error('This workout uses a speed target that the first manual editor cannot change.');
+      }
       return {
         targetKind: 'pace',
         targetMinimum: roundEditorNumber(1000 / target.maximumMetersPerSecond / 60),
         targetMaximum: roundEditorNumber(1000 / target.minimumMetersPerSecond / 60),
       };
     case 'cadence':
-      return { targetKind: 'none', targetMinimum: null, targetMaximum: null };
+      throw new Error('This workout uses a cadence target that the first manual editor cannot change.');
   }
 }
 
@@ -176,6 +190,7 @@ function editorStep(step: WorkoutStepV1): ManualWorkoutEditorStep {
     endingKind: step.ending.kind,
     endingValue: step.ending.kind === 'time' ? step.ending.seconds / 60 : step.ending.meters / 1000,
     ...target,
+    ...(step.note === undefined ? {} : { note: step.note }),
   };
 }
 

--- a/src/app/helpers/planned-workout.shared.spec.ts
+++ b/src/app/helpers/planned-workout.shared.spec.ts
@@ -1,0 +1,357 @@
+import {
+  ActivityTypes,
+  DistanceUnits,
+  PaceUnits,
+  SpeedUnits,
+} from '@sports-alliance/sports-lib';
+import { normalizeUserUnitSettings } from '@shared/unit-aware-display';
+import {
+  INITIAL_MANUAL_WORKOUT_EDITOR_PROFILE_V1,
+  WORKOUT_STRUCTURE_MAX_NODES,
+  WorkoutStructureValidationError,
+  countWorkoutStructureNodesV1,
+  deserializeWorkoutStructureV1,
+  evaluateWorkoutCompatibilityV1,
+  formatWorkoutEndingV1,
+  formatWorkoutTargetV1,
+  parseWorkoutStructureV1,
+  serializeWorkoutStructureV1,
+  toFirestoreWorkoutStructureV1,
+  type WorkoutStructureV1,
+} from '@shared/planned-workout';
+
+const COMPLETE_STRUCTURE_INPUT = {
+  version: 1,
+  sport: 'run',
+  nodes: [
+    {
+      kind: 'step',
+      id: 'warmup',
+      purpose: 'warmup',
+      ending: { kind: 'time', seconds: 600 },
+      targets: [{
+        kind: 'heart-rate',
+        mode: 'absolute',
+        minimumBpm: 120,
+        maximumBpm: 140,
+      }],
+      note: '  Easy start  ',
+    },
+    {
+      kind: 'repeat',
+      id: 'main-set',
+      count: 4,
+      steps: [
+        {
+          kind: 'step',
+          id: 'work',
+          purpose: 'work',
+          ending: { kind: 'distance', meters: 1000 },
+          targets: [
+            {
+              kind: 'speed',
+              mode: 'absolute',
+              minimumMetersPerSecond: 1000 / 300,
+              maximumMetersPerSecond: 1000 / 240,
+              presentation: 'pace',
+            },
+            {
+              kind: 'cadence',
+              mode: 'relative',
+              minimumPercent: 95,
+              maximumPercent: 105,
+              reference: { kind: 'preferred-cadence', rpm: 180 },
+            },
+          ],
+        },
+        {
+          kind: 'step',
+          id: 'recovery',
+          purpose: 'recovery',
+          ending: { kind: 'manual' },
+          targets: [],
+        },
+      ],
+    },
+  ],
+};
+
+function expectValidationIssue(
+  value: unknown,
+  code: WorkoutStructureValidationError['issues'][number]['code'],
+  path?: string,
+): void {
+  try {
+    parseWorkoutStructureV1(value);
+    throw new Error('Expected workout validation to fail.');
+  } catch (error) {
+    expect(error).toBeInstanceOf(WorkoutStructureValidationError);
+    const issues = (error as WorkoutStructureValidationError).issues;
+    expect(issues.some(issue => issue.code === code && (path === undefined || issue.path === path))).toBe(true);
+  }
+}
+
+describe('planned workout v1 contract', () => {
+  it('normalizes Sports Lib activity aliases and trims optional notes', () => {
+    const result = parseWorkoutStructureV1(COMPLETE_STRUCTURE_INPUT);
+
+    expect(result.sport).toBe(ActivityTypes.Running);
+    expect(result.nodes[0]).toMatchObject({ note: 'Easy start' });
+    expect(countWorkoutStructureNodesV1(result)).toBe(4);
+  });
+
+  it('round-trips through JSON without changing the canonical v1 value', () => {
+    const normalized = parseWorkoutStructureV1(COMPLETE_STRUCTURE_INPUT);
+    const serialized = serializeWorkoutStructureV1(normalized);
+
+    expect(deserializeWorkoutStructureV1(serialized)).toEqual(normalized);
+    expect(JSON.stringify(deserializeWorkoutStructureV1(serialized))).toBe(serialized);
+  });
+
+  it('returns a detached Firestore-safe plain JSON value', () => {
+    const normalized = parseWorkoutStructureV1(COMPLETE_STRUCTURE_INPUT);
+    const firestoreValue = toFirestoreWorkoutStructureV1(normalized);
+
+    expect(firestoreValue).toEqual(normalized);
+    expect(firestoreValue).not.toBe(normalized);
+    expect(JSON.parse(JSON.stringify(firestoreValue))).toEqual(firestoreValue);
+    expect(JSON.stringify(firestoreValue)).not.toContain('undefined');
+  });
+
+  it('rejects invalid JSON and unsupported structure versions', () => {
+    expect(() => deserializeWorkoutStructureV1('{oops')).toThrow(WorkoutStructureValidationError);
+    expectValidationIssue({ ...COMPLETE_STRUCTURE_INPUT, version: 2 }, 'unsupported_version', '$.version');
+  });
+
+  it('rejects invalid sports, unknown fields, and unknown discriminants', () => {
+    expectValidationIssue({ ...COMPLETE_STRUCTURE_INPUT, sport: 'space jogging' }, 'invalid_value', '$.sport');
+    expectValidationIssue({ ...COMPLETE_STRUCTURE_INPUT, provider: 'garmin' }, 'unknown_field', '$.provider');
+    expectValidationIssue({
+      ...COMPLETE_STRUCTURE_INPUT,
+      nodes: [{ kind: 'teleport', id: 'bad' }],
+    }, 'unknown_discriminant', '$.nodes[0].kind');
+  });
+
+  it('rejects duplicate IDs and nested repeats', () => {
+    expectValidationIssue({
+      ...COMPLETE_STRUCTURE_INPUT,
+      nodes: [COMPLETE_STRUCTURE_INPUT.nodes[0], { ...COMPLETE_STRUCTURE_INPUT.nodes[0] }],
+    }, 'duplicate_id', '$.nodes[1].id');
+
+    expectValidationIssue({
+      version: 1,
+      sport: ActivityTypes.Cycling,
+      nodes: [{
+        kind: 'repeat',
+        id: 'outer',
+        count: 2,
+        steps: [{ kind: 'repeat', id: 'inner', count: 2, steps: [] }],
+      }],
+    }, 'unknown_discriminant', '$.nodes[0].steps[0].kind');
+  });
+
+  it('rejects non-finite, negative, and inverted scalar ranges', () => {
+    expectValidationIssue({
+      version: 1,
+      sport: ActivityTypes.Running,
+      nodes: [{
+        kind: 'step',
+        id: 'bad-time',
+        purpose: 'work',
+        ending: { kind: 'time', seconds: Number.POSITIVE_INFINITY },
+        targets: [],
+      }],
+    }, 'invalid_value', '$.nodes[0].ending.seconds');
+
+    expectValidationIssue({
+      version: 1,
+      sport: ActivityTypes.Running,
+      nodes: [{
+        kind: 'step',
+        id: 'bad-distance',
+        purpose: 'work',
+        ending: { kind: 'distance', meters: -1 },
+        targets: [],
+      }],
+    }, 'invalid_value', '$.nodes[0].ending.meters');
+
+    expectValidationIssue({
+      version: 1,
+      sport: ActivityTypes.Cycling,
+      nodes: [{
+        kind: 'step',
+        id: 'bad-range',
+        purpose: 'work',
+        ending: { kind: 'time', seconds: 300 },
+        targets: [{
+          kind: 'power',
+          mode: 'absolute',
+          minimumWatts: 300,
+          maximumWatts: 250,
+        }],
+      }],
+    }, 'inverted_range', '$.nodes[0].targets[0].maximumWatts');
+  });
+
+  it('allows zero target bounds while keeping endings and pace speeds positive', () => {
+    expect(parseWorkoutStructureV1({
+      version: 1,
+      sport: ActivityTypes.Cycling,
+      nodes: [{
+        kind: 'step',
+        id: 'coast',
+        purpose: 'recovery',
+        ending: { kind: 'time', seconds: 60 },
+        targets: [{ kind: 'power', mode: 'absolute', minimumWatts: 0, maximumWatts: 50 }],
+      }],
+    }).nodes[0]).toMatchObject({ targets: [{ minimumWatts: 0, maximumWatts: 50 }] });
+
+    expectValidationIssue({
+      version: 1,
+      sport: ActivityTypes.Running,
+      nodes: [{
+        kind: 'step',
+        id: 'bad-pace',
+        purpose: 'work',
+        ending: { kind: 'time', seconds: 60 },
+        targets: [{
+          kind: 'speed',
+          mode: 'absolute',
+          minimumMetersPerSecond: 0,
+          maximumMetersPerSecond: 3,
+          presentation: 'pace',
+        }],
+      }],
+    }, 'invalid_value', '$.nodes[0].targets[0]');
+  });
+
+  it('enforces node, repeat, and target limits', () => {
+    const nodes = Array.from({ length: WORKOUT_STRUCTURE_MAX_NODES + 1 }, (_, index) => ({
+      kind: 'step',
+      id: `step-${index}`,
+      purpose: 'work',
+      ending: { kind: 'time', seconds: 1 },
+      targets: [],
+    }));
+    expectValidationIssue({ version: 1, sport: ActivityTypes.Running, nodes }, 'limit_exceeded', '$.nodes');
+
+    expectValidationIssue({
+      version: 1,
+      sport: ActivityTypes.Running,
+      nodes: [{
+        kind: 'repeat',
+        id: 'too-many',
+        count: 101,
+        steps: [{
+          kind: 'step',
+          id: 'work',
+          purpose: 'work',
+          ending: { kind: 'time', seconds: 60 },
+          targets: [],
+        }],
+      }],
+    }, 'limit_exceeded', '$.nodes[0].count');
+
+    expectValidationIssue({
+      version: 1,
+      sport: ActivityTypes.Running,
+      nodes: [{
+        kind: 'step',
+        id: 'too-many-targets',
+        purpose: 'work',
+        ending: { kind: 'time', seconds: 60 },
+        targets: [
+          { kind: 'heart-rate', mode: 'absolute', minimumBpm: 120, maximumBpm: 140 },
+          { kind: 'power', mode: 'absolute', minimumWatts: 200, maximumWatts: 250 },
+          { kind: 'cadence', mode: 'absolute', minimumRpm: 80, maximumRpm: 90 },
+        ],
+      }],
+    }, 'limit_exceeded', '$.nodes[0].targets');
+  });
+});
+
+describe('planned workout compatibility', () => {
+  it('accepts the first manual editor slice', () => {
+    const workout: WorkoutStructureV1 = {
+      version: 1,
+      sport: ActivityTypes.Cycling,
+      nodes: [{
+        kind: 'step',
+        id: 'ride',
+        purpose: 'work',
+        ending: { kind: 'time', seconds: 1800 },
+        targets: [{ kind: 'power', mode: 'absolute', minimumWatts: 180, maximumWatts: 220 }],
+      }],
+    };
+
+    expect(evaluateWorkoutCompatibilityV1(workout, INITIAL_MANUAL_WORKOUT_EDITOR_PROFILE_V1)).toEqual({
+      compatible: true,
+      issues: [],
+    });
+  });
+
+  it('reports every unsupported feature instead of degrading the recipe silently', () => {
+    const result = evaluateWorkoutCompatibilityV1({
+      version: 1,
+      sport: ActivityTypes.TrailRunning,
+      nodes: [{
+        kind: 'step',
+        id: 'trail',
+        purpose: 'work',
+        ending: { kind: 'manual' },
+        targets: [{
+          kind: 'cadence',
+          mode: 'relative',
+          minimumPercent: 95,
+          maximumPercent: 105,
+          reference: { kind: 'preferred-cadence', rpm: 170 },
+        }],
+      }],
+    }, INITIAL_MANUAL_WORKOUT_EDITOR_PROFILE_V1);
+
+    expect(result.compatible).toBe(false);
+    expect(result.issues.map(issue => issue.code)).toEqual([
+      'unsupported_sport',
+      'unsupported_ending',
+      'unsupported_target',
+      'unsupported_relative_target',
+    ]);
+  });
+});
+
+describe('planned workout formatting', () => {
+  it('uses Sports Lib unit-aware formatters for canonical endings and targets', () => {
+    expect(formatWorkoutEndingV1({ kind: 'distance', meters: 1000 })).toContain('Km');
+    expect(formatWorkoutEndingV1({ kind: 'kilojoules', kilojoules: 250 })).toContain('kJ');
+    expect(formatWorkoutTargetV1({
+      kind: 'heart-rate',
+      mode: 'absolute',
+      minimumBpm: 140,
+      maximumBpm: 150,
+    })).toBe('140–150 bpm');
+    expect(formatWorkoutTargetV1({
+      kind: 'speed',
+      mode: 'absolute',
+      minimumMetersPerSecond: 1000 / 300,
+      maximumMetersPerSecond: 1000 / 240,
+      presentation: 'pace',
+    })).toBe('04:00–05:00 min/km');
+  });
+
+  it('honors imperial distance and pace preferences without changing storage', () => {
+    const imperial = normalizeUserUnitSettings({
+      distanceUnits: DistanceUnits.Miles,
+      paceUnits: [PaceUnits.MinutesPerMile],
+      speedUnits: [SpeedUnits.MilesPerHour],
+    });
+
+    expect(formatWorkoutEndingV1({ kind: 'distance', meters: 1609.344 }, imperial)).toContain('mi');
+    expect(formatWorkoutTargetV1({
+      kind: 'speed',
+      mode: 'absolute',
+      minimumMetersPerSecond: 1000 / 300,
+      maximumMetersPerSecond: 1000 / 240,
+      presentation: 'pace',
+    }, imperial)).toContain('min/m');
+  });
+});

--- a/src/app/helpers/planned-workout.shared.spec.ts
+++ b/src/app/helpers/planned-workout.shared.spec.ts
@@ -240,6 +240,17 @@ describe('planned workout v1 contract', () => {
       sport: ActivityTypes.Running,
       nodes: [{
         kind: 'repeat',
+        id: 'oversized-repeat',
+        count: 2,
+        steps: nodes,
+      }],
+    }, 'limit_exceeded', '$.nodes[0].steps');
+
+    expectValidationIssue({
+      version: 1,
+      sport: ActivityTypes.Running,
+      nodes: [{
+        kind: 'repeat',
         id: 'too-many',
         count: 101,
         steps: [{

--- a/src/app/helpers/training-plans.shared.spec.ts
+++ b/src/app/helpers/training-plans.shared.spec.ts
@@ -1,0 +1,244 @@
+import { ActivityTypes } from '@sports-alliance/sports-lib';
+import {
+  TRAINING_PLAN_CHECKPOINT_INTERVAL,
+  TRAINING_PLAN_MAX_DAYS,
+  TrainingPlanContractError,
+  addDaysToTrainingLocalDate,
+  countTrainingPlanDays,
+  extendTrainingPlanRangeToDate,
+  isTrainingLocalDateWithinPlan,
+  normalizeTrainingLocalDate,
+  parseDeleteTrainingPlanRequestV1,
+  parseMutateTrainingScheduleRequestV1,
+  parseScheduledWorkoutV1,
+  parseTrainingPlanStateV1,
+  parseTrainingPlanV1,
+  shouldCheckpointTrainingPlanRevision,
+  validateTrainingPlanDateRange,
+  type TrainingPlanV1,
+} from '@shared/training-plans';
+
+const STRUCTURE = {
+  version: 1,
+  sport: ActivityTypes.Running,
+  nodes: [{
+    kind: 'step',
+    id: 'steady',
+    purpose: 'work',
+    ending: { kind: 'time', seconds: 1800 },
+    targets: [],
+  }],
+};
+
+const PLAN: TrainingPlanV1 = {
+  schemaVersion: 1,
+  id: 'plan-1',
+  name: 'Autumn build',
+  lifecycle: 'active',
+  startLocalDate: '2026-09-01',
+  endLocalDate: '2026-09-30',
+  revision: 2,
+  lastCheckpointRevision: 1,
+  workoutCount: 3,
+  createdAtMs: 1,
+  updatedAtMs: 2,
+};
+
+describe('training-plan date contracts', () => {
+  it('accepts real local dates and performs UTC-stable date arithmetic', () => {
+    expect(normalizeTrainingLocalDate('2024-02-29')).toBe('2024-02-29');
+    expect(addDaysToTrainingLocalDate('2024-02-29', 1)).toBe('2024-03-01');
+    expect(addDaysToTrainingLocalDate('2026-01-01', -1)).toBe('2025-12-31');
+    expect(countTrainingPlanDays('2026-09-01', '2026-09-30')).toBe(30);
+  });
+
+  it('rejects impossible, reversed, and overlong ranges', () => {
+    expect(() => normalizeTrainingLocalDate('2026-02-30')).toThrow(TrainingPlanContractError);
+    expect(() => countTrainingPlanDays('2026-09-02', '2026-09-01')).toThrow(TrainingPlanContractError);
+    expect(() => validateTrainingPlanDateRange(
+      '2026-01-01',
+      addDaysToTrainingLocalDate('2026-01-01', TRAINING_PLAN_MAX_DAYS),
+    ))
+      .toThrow(TrainingPlanContractError);
+  });
+
+  it('extends only the required plan boundary and revalidates the maximum', () => {
+    expect(extendTrainingPlanRangeToDate(PLAN, '2026-08-30')).toEqual({
+      startLocalDate: '2026-08-30',
+      endLocalDate: '2026-09-30',
+    });
+    expect(extendTrainingPlanRangeToDate(PLAN, '2026-10-02')).toEqual({
+      startLocalDate: '2026-09-01',
+      endLocalDate: '2026-10-02',
+    });
+    expect(isTrainingLocalDateWithinPlan('2026-09-15', PLAN)).toBe(true);
+    expect(isTrainingLocalDateWithinPlan('2026-10-01', PLAN)).toBe(false);
+  });
+});
+
+describe('training-plan persisted contracts', () => {
+  it('strictly parses state and plans', () => {
+    expect(parseTrainingPlanStateV1({
+      schemaVersion: 1,
+      activePlanId: 'plan-1',
+      revision: 4,
+      currentWorkoutCount: 3,
+      updatedAtMs: 10,
+    })).toEqual({
+      schemaVersion: 1,
+      activePlanId: 'plan-1',
+      revision: 4,
+      currentWorkoutCount: 3,
+      updatedAtMs: 10,
+    });
+    expect(parseTrainingPlanV1(PLAN)).toEqual(PLAN);
+    expect(() => parseTrainingPlanV1({ ...PLAN, providerId: 'garmin' })).toThrow(TrainingPlanContractError);
+  });
+
+  it('keeps standalone workouts first-class and normalizes their structure', () => {
+    const workout = parseScheduledWorkoutV1({
+      schemaVersion: 1,
+      id: 'workout-1',
+      planId: null,
+      localDate: '2026-09-02',
+      lifecycle: 'planned',
+      title: ' Easy run ',
+      structure: { ...STRUCTURE, sport: 'run' },
+      revision: 1,
+      createdAtMs: 5,
+      updatedAtMs: 5,
+    });
+
+    expect(workout.planId).toBeNull();
+    expect(workout.title).toBe('Easy run');
+    expect(workout.structure.sport).toBe(ActivityTypes.Running);
+  });
+
+  it('requires deletedAtMs exactly for soft-deleted workouts', () => {
+    const base = {
+      schemaVersion: 1,
+      id: 'workout-1',
+      planId: null,
+      localDate: '2026-09-02',
+      title: 'Easy run',
+      structure: STRUCTURE,
+      revision: 1,
+      createdAtMs: 5,
+      updatedAtMs: 5,
+    };
+    expect(() => parseScheduledWorkoutV1({ ...base, lifecycle: 'deleted' })).toThrow(TrainingPlanContractError);
+    expect(() => parseScheduledWorkoutV1({ ...base, lifecycle: 'planned', deletedAtMs: 7 })).toThrow(TrainingPlanContractError);
+    expect(parseScheduledWorkoutV1({ ...base, lifecycle: 'deleted', deletedAtMs: 7 }).deletedAtMs).toBe(7);
+  });
+});
+
+describe('training schedule mutation contracts', () => {
+  it('parses standalone workout creation with explicit range-confirmation state', () => {
+    const request = parseMutateTrainingScheduleRequestV1({
+      mutationId: 'client:123',
+      expectedRevisions: [{ scope: 'state', id: 'current', revision: 0 }],
+      operation: {
+        kind: 'create-workout',
+        workoutId: 'workout-1',
+        planId: null,
+        localDate: '2026-09-03',
+        title: 'Steady run',
+        structure: STRUCTURE,
+        confirmPlanRangeExtension: false,
+      },
+    });
+
+    expect(request.operation).toMatchObject({ kind: 'create-workout', planId: null });
+  });
+
+  it('parses standalone-to-plan and plan-to-plan moves without changing workout identity', () => {
+    const request = parseMutateTrainingScheduleRequestV1({
+      mutationId: 'move-1',
+      expectedRevisions: [
+        { scope: 'workout', id: 'workout-1', revision: 2 },
+        { scope: 'plan', id: 'plan-2', revision: 5 },
+      ],
+      operation: {
+        kind: 'move-workout',
+        workoutId: 'workout-1',
+        planId: 'plan-2',
+        localDate: '2026-10-01',
+        confirmPlanRangeExtension: true,
+      },
+    });
+
+    expect(request.operation).toEqual({
+      kind: 'move-workout',
+      workoutId: 'workout-1',
+      planId: 'plan-2',
+      localDate: '2026-10-01',
+      confirmPlanRangeExtension: true,
+    });
+  });
+
+  it('rejects duplicate revision expectations and reused copy IDs', () => {
+    expect(() => parseMutateTrainingScheduleRequestV1({
+      mutationId: 'duplicate-revisions',
+      expectedRevisions: [
+        { scope: 'plan', id: 'plan-1', revision: 1 },
+        { scope: 'plan', id: 'plan-1', revision: 1 },
+      ],
+      operation: { kind: 'rename-plan', planId: 'plan-1', name: 'New name' },
+    })).toThrow(TrainingPlanContractError);
+
+    expect(() => parseMutateTrainingScheduleRequestV1({
+      mutationId: 'bad-copy',
+      expectedRevisions: [],
+      operation: {
+        kind: 'copy-workout',
+        sourceWorkoutId: 'same',
+        workoutId: 'same',
+        planId: null,
+        localDate: '2026-09-03',
+        confirmPlanRangeExtension: false,
+      },
+    })).toThrow(TrainingPlanContractError);
+  });
+
+  it('requires explicit permanent-deletion confirmation', () => {
+    expect(() => parseMutateTrainingScheduleRequestV1({
+      mutationId: 'delete-forever',
+      expectedRevisions: [],
+      operation: {
+        kind: 'permanently-delete-workout',
+        workoutId: 'workout-1',
+        confirmPermanentDeletion: false,
+      },
+    })).toThrow(TrainingPlanContractError);
+  });
+
+  it('parses both explicit plan-deletion dispositions and rejects silent deletion', () => {
+    const base = {
+      mutationId: 'delete-plan-1',
+      planId: 'plan-1',
+      expectedRevisions: [
+        { scope: 'state', id: 'current', revision: 4 },
+        { scope: 'plan', id: 'plan-1', revision: 3 },
+      ],
+      confirmPlanDeletion: true,
+    };
+    expect(parseDeleteTrainingPlanRequestV1({
+      ...base, workoutDisposition: 'convert-to-standalone',
+    }).workoutDisposition).toBe('convert-to-standalone');
+    expect(parseDeleteTrainingPlanRequestV1({
+      ...base, workoutDisposition: 'delete-workouts',
+    }).workoutDisposition).toBe('delete-workouts');
+    expect(() => parseDeleteTrainingPlanRequestV1({
+      ...base, workoutDisposition: 'delete-workouts', confirmPlanDeletion: false,
+    })).toThrow('Explicit plan-deletion confirmation');
+  });
+});
+
+describe('training plan checkpoint policy', () => {
+  it('checkpoints the first, every twentieth, and bulk revisions', () => {
+    expect(shouldCheckpointTrainingPlanRevision(1)).toBe(true);
+    expect(shouldCheckpointTrainingPlanRevision(TRAINING_PLAN_CHECKPOINT_INTERVAL)).toBe(true);
+    expect(shouldCheckpointTrainingPlanRevision(21)).toBe(false);
+    expect(shouldCheckpointTrainingPlanRevision(21, true)).toBe(true);
+  });
+});

--- a/src/app/helpers/training-plans.shared.spec.ts
+++ b/src/app/helpers/training-plans.shared.spec.ts
@@ -1,6 +1,7 @@
 import { ActivityTypes } from '@sports-alliance/sports-lib';
 import {
   TRAINING_PLAN_CHECKPOINT_INTERVAL,
+  TRAINING_PLAN_MAX_CURRENT_WORKOUTS,
   TRAINING_PLAN_MAX_DAYS,
   TrainingPlanContractError,
   addDaysToTrainingLocalDate,
@@ -93,6 +94,20 @@ describe('training-plan persisted contracts', () => {
     });
     expect(parseTrainingPlanV1(PLAN)).toEqual(PLAN);
     expect(() => parseTrainingPlanV1({ ...PLAN, providerId: 'garmin' })).toThrow(TrainingPlanContractError);
+  });
+
+  it('rejects persisted workout counts above the canonical account limit', () => {
+    expect(() => parseTrainingPlanStateV1({
+      schemaVersion: 1,
+      activePlanId: null,
+      revision: 4,
+      currentWorkoutCount: TRAINING_PLAN_MAX_CURRENT_WORKOUTS + 1,
+      updatedAtMs: 10,
+    })).toThrow(TrainingPlanContractError);
+    expect(() => parseTrainingPlanV1({
+      ...PLAN,
+      workoutCount: TRAINING_PLAN_MAX_CURRENT_WORKOUTS + 1,
+    })).toThrow(TrainingPlanContractError);
   });
 
   it('keeps standalone workouts first-class and normalizes their structure', () => {

--- a/src/app/services/training-plans.service.spec.ts
+++ b/src/app/services/training-plans.service.spec.ts
@@ -1,0 +1,90 @@
+import { ActivityTypes } from '@sports-alliance/sports-lib';
+import { describe, expect, it } from 'vitest';
+import type { ScheduledWorkoutV1, TrainingPlanV1 } from '@shared/training-plans';
+import {
+  selectCalendarVisibleScheduledWorkouts,
+  type CurrentTrainingScheduleV1,
+} from './training-plans.service';
+
+const STRUCTURE = {
+  version: 1 as const,
+  sport: ActivityTypes.Running,
+  nodes: [{
+    kind: 'step' as const,
+    id: 'steady',
+    purpose: 'work' as const,
+    ending: { kind: 'time' as const, seconds: 1800 },
+    targets: [],
+  }],
+};
+
+function workout(id: string, overrides: Partial<ScheduledWorkoutV1> = {}): ScheduledWorkoutV1 {
+  return {
+    schemaVersion: 1,
+    id,
+    planId: null,
+    localDate: '2026-09-02',
+    lifecycle: 'planned',
+    title: id,
+    structure: STRUCTURE,
+    revision: 1,
+    createdAtMs: 1,
+    updatedAtMs: 1,
+    ...overrides,
+  };
+}
+
+const PLAN: TrainingPlanV1 = {
+  schemaVersion: 1,
+  id: 'active-plan',
+  name: 'Active',
+  lifecycle: 'active',
+  startLocalDate: '2026-09-01',
+  endLocalDate: '2026-09-30',
+  revision: 1,
+  lastCheckpointRevision: 1,
+  workoutCount: 1,
+  createdAtMs: 1,
+  updatedAtMs: 1,
+};
+
+describe('calendar-visible planned workouts', () => {
+  it('keeps standalone and active-plan workouts separate from inactive and deleted data', () => {
+    const schedule: CurrentTrainingScheduleV1 = {
+      state: {
+        schemaVersion: 1,
+        activePlanId: PLAN.id,
+        revision: 1,
+        currentWorkoutCount: 4,
+        updatedAtMs: 1,
+      },
+      plans: [PLAN, { ...PLAN, id: 'paused-plan', lifecycle: 'paused' }],
+      workouts: [
+        workout('standalone'),
+        workout('active', { planId: PLAN.id }),
+        workout('skipped', { planId: PLAN.id, lifecycle: 'skipped', localDate: '2026-09-03' }),
+        workout('inactive', { planId: 'paused-plan' }),
+        workout('deleted', { lifecycle: 'deleted', deletedAtMs: 2 }),
+      ],
+    };
+
+    expect(selectCalendarVisibleScheduledWorkouts(schedule).map(item => item.id))
+      .toEqual(['active', 'standalone', 'skipped']);
+  });
+
+  it('applies an inclusive local-date range without changing stored order', () => {
+    const schedule: CurrentTrainingScheduleV1 = {
+      state: { schemaVersion: 1, activePlanId: null, revision: 1, currentWorkoutCount: 3, updatedAtMs: 1 },
+      plans: [],
+      workouts: [
+        workout('later', { localDate: '2026-09-04' }),
+        workout('earlier', { localDate: '2026-09-01' }),
+        workout('middle', { localDate: '2026-09-03' }),
+      ],
+    };
+
+    expect(selectCalendarVisibleScheduledWorkouts(schedule, '2026-09-02', '2026-09-04').map(item => item.id))
+      .toEqual(['middle', 'later']);
+    expect(schedule.workouts.map(item => item.id)).toEqual(['later', 'earlier', 'middle']);
+  });
+});

--- a/src/app/services/training-plans.service.ts
+++ b/src/app/services/training-plans.service.ts
@@ -1,0 +1,162 @@
+import { Injectable, inject } from '@angular/core';
+import {
+  Firestore,
+  collection,
+  collectionData,
+  doc,
+  docData,
+} from 'app/firebase/firestore';
+import { combineLatest, map, Observable, of, shareReplay } from 'rxjs';
+import {
+  SCHEDULED_WORKOUTS_COLLECTION_ID,
+  TRAINING_PLAN_SCHEMA_VERSION,
+  TRAINING_PLAN_STATE_COLLECTION_ID,
+  TRAINING_PLAN_STATE_DOCUMENT_ID,
+  TRAINING_PLANS_COLLECTION_ID,
+  parseScheduledWorkoutV1,
+  parseTrainingPlanStateV1,
+  parseTrainingPlanV1,
+  type DeleteTrainingPlanRequestV1,
+  type DeleteTrainingPlanResponseV1,
+  type MutateTrainingScheduleRequestV1,
+  type MutateTrainingScheduleResponseV1,
+  type PreviewTrainingScheduleRestoreRequestV1,
+  type RestoreTrainingScheduleRevisionRequestV1,
+  type RestoreTrainingScheduleRevisionResponseV1,
+  type ScheduledWorkoutV1,
+  type TrainingPlanStateV1,
+  type TrainingPlanV1,
+  type TrainingScheduleHistoryRequestV1,
+  type TrainingScheduleHistoryResponseV1,
+  type TrainingScheduleRestorePreviewV1,
+} from '@shared/training-plans';
+import { AppFunctionsService } from './app.functions.service';
+import { BrowserCompatibilityService } from './browser.compatibility.service';
+
+export interface CurrentTrainingScheduleV1 {
+  state: TrainingPlanStateV1;
+  plans: TrainingPlanV1[];
+  workouts: ScheduledWorkoutV1[];
+}
+
+function emptyTrainingSchedule(): CurrentTrainingScheduleV1 {
+  return {
+    state: {
+      schemaVersion: TRAINING_PLAN_SCHEMA_VERSION,
+      activePlanId: null,
+      revision: 0,
+      currentWorkoutCount: 0,
+      updatedAtMs: 0,
+    },
+    plans: [],
+    workouts: [],
+  };
+}
+
+export function selectCalendarVisibleScheduledWorkouts(
+  schedule: CurrentTrainingScheduleV1,
+  startLocalDate?: string,
+  endLocalDate?: string,
+): ScheduledWorkoutV1[] {
+  return schedule.workouts
+    .filter(workout => (
+      workout.lifecycle !== 'deleted'
+      && (workout.planId === null || workout.planId === schedule.state.activePlanId)
+      && (!startLocalDate || workout.localDate >= startLocalDate)
+      && (!endLocalDate || workout.localDate <= endLocalDate)
+    ))
+    .sort((left, right) => left.localDate.localeCompare(right.localDate) || left.id.localeCompare(right.id));
+}
+
+@Injectable({ providedIn: 'root' })
+export class TrainingPlansService {
+  private readonly firestore = inject(Firestore);
+  private readonly functions = inject(AppFunctionsService);
+  private readonly browserCompatibility = inject(BrowserCompatibilityService);
+  private readonly scheduleStreams = new Map<string, Observable<CurrentTrainingScheduleV1>>();
+
+  watchSchedule(userId: string | null | undefined): Observable<CurrentTrainingScheduleV1> {
+    const uid = `${userId || ''}`.trim();
+    if (!uid) return of(emptyTrainingSchedule());
+    const existing = this.scheduleStreams.get(uid);
+    if (existing) return existing;
+
+    const userPath = ['users', uid] as const;
+    const stateRef = doc(
+      this.firestore,
+      ...userPath,
+      TRAINING_PLAN_STATE_COLLECTION_ID,
+      TRAINING_PLAN_STATE_DOCUMENT_ID,
+    );
+    const plansRef = collection(this.firestore, ...userPath, TRAINING_PLANS_COLLECTION_ID);
+    const workoutsRef = collection(this.firestore, ...userPath, SCHEDULED_WORKOUTS_COLLECTION_ID);
+    const schedule$ = combineLatest([
+      docData(stateRef),
+      collectionData(plansRef, { idField: 'id' }),
+      collectionData(workoutsRef, { idField: 'id' }),
+    ]).pipe(
+      map(([stateValue, planValues, workoutValues]) => {
+        const plans = (planValues as unknown[]).map(parseTrainingPlanV1)
+          .sort((left, right) => left.createdAtMs - right.createdAtMs || left.id.localeCompare(right.id));
+        const workouts = (workoutValues as unknown[]).map(parseScheduledWorkoutV1)
+          .sort((left, right) => left.localDate.localeCompare(right.localDate) || left.id.localeCompare(right.id));
+        const state = stateValue === undefined ? emptyTrainingSchedule().state : parseTrainingPlanStateV1(stateValue);
+        if (state.currentWorkoutCount !== workouts.filter(workout => workout.lifecycle !== 'deleted').length) {
+          throw new Error('The training schedule count is inconsistent. Reload before editing.');
+        }
+        return { state, plans, workouts };
+      }),
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
+    this.scheduleStreams.set(uid, schedule$);
+    return schedule$;
+  }
+
+  watchCalendarWorkouts(userId: string | null | undefined): Observable<ScheduledWorkoutV1[]> {
+    return this.watchSchedule(userId).pipe(map(schedule => selectCalendarVisibleScheduledWorkouts(schedule)));
+  }
+
+  createMutationId(prefix: string): string {
+    const normalizedPrefix = `${prefix || 'training'}`.replace(/[^A-Za-z0-9_-]/g, '-').slice(0, 32) || 'training';
+    const uuid = this.browserCompatibility.createRandomUUID();
+    if (uuid) return `${normalizedPrefix}:${uuid}`;
+    return `${normalizedPrefix}:${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 12)}`;
+  }
+
+  createEntityId(prefix: string): string {
+    const normalizedPrefix = `${prefix || 'item'}`.replace(/[^A-Za-z0-9_-]/g, '-').slice(0, 24) || 'item';
+    const unique = this.browserCompatibility.createRandomUUID()
+      ?? `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 12)}`;
+    return `${normalizedPrefix}-${unique}`.slice(0, 128);
+  }
+
+  async mutate(request: MutateTrainingScheduleRequestV1): Promise<MutateTrainingScheduleResponseV1> {
+    return (await this.functions.call<MutateTrainingScheduleRequestV1, MutateTrainingScheduleResponseV1>(
+      'mutateTrainingSchedule', request,
+    )).data;
+  }
+
+  async getHistory(request: TrainingScheduleHistoryRequestV1): Promise<TrainingScheduleHistoryResponseV1> {
+    return (await this.functions.call<TrainingScheduleHistoryRequestV1, TrainingScheduleHistoryResponseV1>(
+      'getTrainingScheduleHistory', request,
+    )).data;
+  }
+
+  async previewRestore(request: PreviewTrainingScheduleRestoreRequestV1): Promise<TrainingScheduleRestorePreviewV1> {
+    return (await this.functions.call<PreviewTrainingScheduleRestoreRequestV1, TrainingScheduleRestorePreviewV1>(
+      'previewTrainingScheduleRestore', request,
+    )).data;
+  }
+
+  async restore(request: RestoreTrainingScheduleRevisionRequestV1): Promise<RestoreTrainingScheduleRevisionResponseV1> {
+    return (await this.functions.call<RestoreTrainingScheduleRevisionRequestV1, RestoreTrainingScheduleRevisionResponseV1>(
+      'restoreTrainingScheduleRevision', request,
+    )).data;
+  }
+
+  async deletePlan(request: DeleteTrainingPlanRequestV1): Promise<DeleteTrainingPlanResponseV1> {
+    return (await this.functions.call<DeleteTrainingPlanRequestV1, DeleteTrainingPlanResponseV1>(
+      'deleteTrainingPlan', request,
+    )).data;
+  }
+}

--- a/src/app/services/training-plans.service.ts
+++ b/src/app/services/training-plans.service.ts
@@ -101,9 +101,11 @@ export class TrainingPlansService {
         const workouts = (workoutValues as unknown[]).map(parseScheduledWorkoutV1)
           .sort((left, right) => left.localDate.localeCompare(right.localDate) || left.id.localeCompare(right.id));
         const state = stateValue === undefined ? emptyTrainingSchedule().state : parseTrainingPlanStateV1(stateValue);
-        if (state.currentWorkoutCount !== workouts.filter(workout => workout.lifecycle !== 'deleted').length) {
-          throw new Error('The training schedule count is inconsistent. Reload before editing.');
-        }
+        // These are three independent Firestore listeners. A transaction can
+        // therefore reach them in adjacent emissions even though its writes
+        // were atomic. The server validates the authoritative count inside
+        // each mutation; turning a transient client-side mismatch into a
+        // terminal observable error would strand every schedule consumer.
         return { state, plans, workouts };
       }),
       shareReplay({ bufferSize: 1, refCount: true }),

--- a/src/app/shared/help.content.spec.ts
+++ b/src/app/shared/help.content.spec.ts
@@ -60,6 +60,7 @@ describe('help.content', () => {
       'getting-started',
       'supported-activities',
       'activity-calendar',
+      'training-plans',
       'health',
       'training-analysis',
       'ai-insights',
@@ -71,8 +72,8 @@ describe('help.content', () => {
     ]);
   });
 
-  it('should define eleven unique sections with complete content', () => {
-    expect(HELP_SECTIONS).toHaveLength(11);
+  it('should define twelve unique sections with complete content', () => {
+    expect(HELP_SECTIONS).toHaveLength(12);
 
     const uniqueIds = new Set(HELP_SECTIONS.map(section => section.id));
     expect(uniqueIds.size).toBe(HELP_SECTIONS.length);
@@ -403,6 +404,9 @@ describe('help.content', () => {
     expect(calendarSection?.content).toContain('Settings -> Dashboard -> Start of the Week');
     expect(calendarSection?.content).toContain('visible-period activity query');
     expect(calendarSection?.content).toContain('independent from the dashboard event table');
+    expect(calendarSection?.content).toContain('Select any date, including an empty one');
+    expect(calendarSection?.content).toContain('standalone workouts plus workouts from the active plan');
+    expect(calendarSection?.content).toContain('Planned workouts never change recorded period totals');
     expect(calendarSection?.content).toContain('Merge and benchmark records are excluded');
     expect(calendarSection?.content).toContain('action menu to share, reprocess, download, or delete it');
     expect(calendarSection?.links).toContainEqual({
@@ -418,6 +422,27 @@ describe('help.content', () => {
       target: '/help',
       fragment: 'activity-calendar',
     });
+  });
+
+  it('documents standalone manual planning, revision recovery, and truthful provider status', () => {
+    const gettingStartedSection = HELP_SECTIONS.find(section => section.id === 'getting-started');
+    const planningSection = HELP_SECTIONS.find(section => section.id === 'training-plans');
+
+    expect(planningSection?.content).toContain('You do not need to create a plan first');
+    expect(planningSection?.content).toContain('Manual planning is available without a provider connection');
+    expect(planningSection?.content).toContain('Sending planned workouts to Garmin, COROS, Wahoo, or Suunto is not enabled yet');
+    expect(planningSection?.content).toContain('only one can be active');
+    expect(planningSection?.content).toContain('Move a workout between plans or between a plan and **Standalone**');
+    expect(planningSection?.content).toContain('Ordinary deletion is recoverable from history');
+    expect(planningSection?.content).toContain('Every visible date');
+    expect(planningSection?.content).toContain('Planned workouts and completed activities are separate');
+    expect(planningSection?.links).toContainEqual({
+      label: 'Open Plans',
+      icon: 'event_note',
+      kind: 'route',
+      target: '/plans',
+    });
+    expect(gettingStartedSection?.content).toContain('[Training plans guide](/help#training-plans)');
   });
 
   it('should document safe event merge retry and recovery behavior', () => {

--- a/src/app/shared/help.content.ts
+++ b/src/app/shared/help.content.ts
@@ -165,7 +165,7 @@ const TRAINING_PLANS_HELP_CONTENT = `## Plan without a connected service
 - An account can keep multiple plans but only one can be active. Activating a plan pauses the previous active plan. Archived plans remain available without contributing workouts to Calendar overlays.
 - Move a workout between plans or between a plan and **Standalone** without changing its workout identity. Copy creates a new workout. Moving, copying, or attaching outside a plan's current dates asks before extending that range.
 - Shifting a plan moves its start and end dates together with only that plan's current workouts. Skipping keeps a workout visible and marked; it does not turn it into a completed activity.
-- Ordinary deletion is recoverable from history. Permanent deletion has a separate confirmation. Deleting a plan asks whether its current workouts should become standalone or be deleted; archiving is the non-destructive alternative.
+- Ordinary deletion is recoverable from history. Permanent deletion has a separate confirmation and prevents restoration. A standalone workout's revision history is removed with it; a plan-bound workout can remain in its plan's immutable audit until that plan is deleted, and the confirmation identifies this retention. Deleting a plan asks whether its current workouts should become standalone or be deleted; archiving is the non-destructive alternative.
 - History preview shows what a restore would change before you confirm it. A restore creates a new revision, does not silently reclaim a workout moved to another plan or to standalone, and never recreates a permanently deleted workout.
 
 ## Add from Calendar

--- a/src/app/shared/help.content.ts
+++ b/src/app/shared/help.content.ts
@@ -14,6 +14,7 @@ export type HelpSectionId =
   | 'getting-started'
   | 'supported-activities'
   | 'activity-calendar'
+  | 'training-plans'
   | 'health'
   | 'training-analysis'
   | 'ai-insights'
@@ -153,6 +154,27 @@ const TRAINING_ANALYSIS_HELP_CONTENT = `## What Training is for
 - Missing or unreliable inputs remain explicit. Training does not infer LT1/LT2, race readiness, a universal athlete score, or workout-execution scoring.
 - Training power-profile callouts compare the best 90-day curve with the best one-year curve at 5 seconds, 1 minute, 5 minutes, 20 minutes, and 1 hour. They use bounded reciprocal-duration interpolation, never bridge duration brackets wider than 1.25×, show both activity counts, and call out the strongest retained duration and clearest gap. Missing comparable anchors stay explicit.`;
 
+const TRAINING_PLANS_HELP_CONTENT = `## Plan without a connected service
+
+- Open [Plans](/plans) to create a dated workout. You do not need to create a plan first: choose **Standalone** to keep the workout independent, or use the active plan when you want it grouped into a date range.
+- Manual planning is available without a provider connection. Sending planned workouts to Garmin, COROS, Wahoo, or Suunto is not enabled yet; connecting a service does not send anything automatically.
+- The first editor supports Running and Cycling, date-only scheduling, time or distance steps, fixed repeats, and one absolute heart-rate, power, or pace target per step. Unsupported recipe features remain unavailable instead of being approximated.
+
+## Organize plans and standalone workouts
+
+- An account can keep multiple plans but only one can be active. Activating a plan pauses the previous active plan. Archived plans remain available without contributing workouts to Calendar overlays.
+- Move a workout between plans or between a plan and **Standalone** without changing its workout identity. Copy creates a new workout. Moving, copying, or attaching outside a plan's current dates asks before extending that range.
+- Shifting a plan moves its start and end dates together with only that plan's current workouts. Skipping keeps a workout visible and marked; it does not turn it into a completed activity.
+- Ordinary deletion is recoverable from history. Permanent deletion has a separate confirmation. Deleting a plan asks whether its current workouts should become standalone or be deleted; archiving is the non-destructive alternative.
+- History preview shows what a restore would change before you confirm it. A restore creates a new revision, does not silently reclaim a workout moved to another plan or to standalone, and never recreates a permanently deleted workout.
+
+## Add from Calendar
+
+- Every visible date in the full Calendar, dashboard Activity Calendar tile, and Today mini-calendar can be selected, including an empty date.
+- **Add workout** uses the active plan when one exists and otherwise creates a standalone workout. **Add standalone** is always available as the explicit independent option.
+- Calendar overlays show standalone workouts and workouts from the active plan. Inactive-plan workouts remain in [Plans](/plans), while skipped workouts stay visible with a separate mark.
+- Planned workouts and completed activities are separate. Plans never increase completed activity counts, duration, distance, elevation, activity-group bars, the activity table, or Training analysis.`;
+
 const ACTIVITY_CALENDAR_HELP_CONTENT = `## Open and navigate the calendar
 
 - New dashboards start with a 1 x 1 **Activity Calendar** tile showing the current month. Select its open action to move to the full [Calendar](/calendar).
@@ -165,7 +187,8 @@ const ACTIVITY_CALENDAR_HELP_CONTENT = `## Open and navigate the calendar
 
 - A circle's color identifies an activity group and its size reflects recorded duration. Larger circles mean more recorded time, using a bounded scale so unusually long activities do not dominate the grid.
 - Week and Month views separate activity-group circles when space allows. Narrow layouts, the dashboard tile, and Year view place multiple circles concentrically around the same center so a day stays readable in a compact cell.
-- Select a day with activity to open its details sheet. It shows the day's total duration, the same duration bars and available distance/ascent/descent totals by activity group, and individual activities with their available distance and elevation metrics.
+- Select any date, including an empty one, to open its details sheet. Planned workouts appear in their own section with links to edit them and actions to add a workout for that date. Completed totals and activity-group bars remain separate, followed by individual activities with their available distance and elevation metrics.
+- The calendar shows standalone workouts plus workouts from the active plan. Inactive-plan workouts remain in [Plans](/plans), and skipped workouts stay visible with a separate marker.
 - In the full Calendar, a note icon marks days with **Timeline notes**, even when there is no workout. Select the day to see its notes, then select a note to open or edit it. Date ranges include their end day; ongoing notes stop at today in their original time zone and refresh when you return to the tab. Notes never affect activity totals or circle sizes. Use **Timeline notes** in the header to manage them and **Show on charts and calendar** to show or hide them across workspaces. Dashboard calendar tiles and popovers do not show notes.
 - In day details, an activity group containing exactly one activity opens that activity directly, as does its individual activity row. Browser **Back** restores the same day's details sheet. Deleting an activity from its details page returns to the previous in-app page; the day sheet reopens when other activity remains on that day.
 - Calendar dates intentionally have no hover or touch tooltip. This keeps native vertical scrolling responsive on phones; day details remain available by selecting a date.
@@ -173,6 +196,7 @@ const ACTIVITY_CALENDAR_HELP_CONTENT = `## Open and navigate the calendar
 ## Understand period totals and activity bars
 
 - The summary above the full calendar shows recorded **Distance**, **Duration**, and **Ascent** for the selected week, month, or year. Month totals exclude adjacent dates shown only to complete the calendar grid.
+- Planned workouts never change recorded period totals, activity counts, activity-group bars, or the activity table.
 - Below the calendar, **Activities** compares activity groups by recorded duration. Each bar uses the same color as its circles and is scaled against the longest-duration group in the selected period. The info control beside the heading explains this comparison.
 - Available duration, distance, ascent, and descent totals appear with icons beneath each bar. A metric is omitted when no positive recorded value exists, and **--** beside an activity group means duration was not recorded.
 - Lift-served downhill activities such as alpine skiing, snowboarding, and downhill cycling do not add ascent but do contribute descent. Diving, Scuba Diving, Free Diving, Snorkeling, and Mermaiding do not contribute either elevation metric; their vertical movement is recorded as depth. Ascent and descent summary exclusions configured in **Settings** also apply.
@@ -233,6 +257,7 @@ export const HELP_SECTIONS: HelpSection[] = [
 - **Dashboard** is your main activity overview.
 - **Health** compares supported Sleep and Health measurements source by source. Open the [Health guide](/help#health) for metric ranges, source separation, and sync-state guidance.
 - **Calendar** shows activities in Week, Month, and Year views. Open the [Activity Calendar guide](/help#activity-calendar) for display and summary details, or read the public [Activity Calendar overview](/features/activity-calendar).
+- **Plans** lets you create standalone workouts or organize them into dated plans without connecting a provider. Open the [Training plans guide](/help#training-plans).
 - **Supported activity types** lists the activity types Quantified Self recognizes and explains why the details shown depend on data in each activity. Open the [Supported activity types guide](/help#supported-activities) or public [Supported activity types page](/features/supported-activities).
 - **Training** is your fixed workspace for baseline comparisons, current readiness signals, load trajectory, training mix, capacity evidence, durability, sleep, and power interpretation. Open the [Training analysis guide](/help#training-analysis) for the detailed product guide, read the public [Training Analysis overview](/features/training-analysis) for the search-facing summary, or use its **Feedback** action to email support with Training-specific feedback.
 - **My Tracks** maps positional activities and supports date range, custom date, and activity type filters. Its activity filter lists only trackable types in the selected date range, while keeping an active no-match choice visible until you clear it. Detected trips list an inferred **Home** area first when available; use the sort button to choose newest-first or oldest-first, and the choice is saved.
@@ -457,6 +482,8 @@ export const HELP_SECTIONS: HelpSection[] = [
       { label: 'Login', icon: 'login', kind: 'route', target: '/login' },
       { label: 'Dashboard', icon: 'space_dashboard', kind: 'route', target: '/dashboard' },
       { label: 'Calendar', icon: 'calendar_month', kind: 'route', target: '/calendar' },
+      { label: 'Plans', icon: 'event_note', kind: 'route', target: '/plans' },
+      { label: 'Training plans guide', icon: 'school', kind: 'route', target: '/help', fragment: 'training-plans' },
       { label: 'Health guide', icon: 'school', kind: 'route', target: '/help', fragment: 'health' },
       { label: 'Activity Calendar guide', icon: 'school', kind: 'route', target: '/help', fragment: 'activity-calendar' },
       { label: 'Activity Calendar Overview', icon: 'travel_explore', kind: 'route', target: '/features/activity-calendar' },
@@ -506,6 +533,18 @@ export const HELP_SECTIONS: HelpSection[] = [
       { label: 'Open Calendar', icon: 'calendar_month', kind: 'route', target: '/calendar' },
       { label: 'Activity Calendar Overview', icon: 'travel_explore', kind: 'route', target: '/features/activity-calendar' },
       { label: 'Calendar Settings', icon: 'tune', kind: 'route', target: '/settings' },
+    ],
+  },
+  {
+    id: 'training-plans',
+    icon: 'event_note',
+    title: 'Training plans',
+    summary: 'Create standalone workouts or organize dated Running and Cycling workouts into plans.',
+    content: TRAINING_PLANS_HELP_CONTENT,
+    links: [
+      { label: 'Open Plans', icon: 'event_note', kind: 'route', target: '/plans' },
+      { label: 'Open Calendar', icon: 'calendar_month', kind: 'route', target: '/calendar' },
+      { label: 'Training analysis guide', icon: 'monitoring', kind: 'route', target: '/help', fragment: 'training-analysis' },
     ],
   },
   {

--- a/src/app/workspace-layout.spec.ts
+++ b/src/app/workspace-layout.spec.ts
@@ -8,6 +8,7 @@ const workspaceRoots = [
   ['Dashboard', 'src/app/components/dashboard/dashboard.component.html', 'component-container qs-workspace-page'],
   ['Event details', 'src/app/components/event/event.card.component.html', 'event-dashboard-container qs-workspace-page'],
   ['Calendar', 'src/app/components/calendar/calendar-page/calendar-page.component.html', 'calendar-page qs-workspace-page'],
+  ['Plans', 'src/app/components/plans/plans-workspace.component.html', 'plans-workspace qs-workspace-page'],
   ['Training', 'src/app/components/training/training-workspace.component.html', 'training-workspace qs-workspace-page'],
   ['Routes', 'src/app/components/routes/routes-page.component.html', 'routes-page qs-workspace-page'],
   ['Route detail', 'src/app/components/routes/route-detail/route-detail.component.html', 'route-detail-page qs-workspace-page'],

--- a/src/firebase-hosting.config.spec.ts
+++ b/src/firebase-hosting.config.spec.ts
@@ -351,6 +351,7 @@ describe('Firebase Hosting configuration', () => {
     expect(sitemapXml).not.toContain('<loc>https://quantified-self.io/share/comparison/');
     expect(sitemapXml).not.toContain('<loc>https://quantified-self.io/routes</loc>');
     expect(sitemapXml).not.toContain('<loc>https://quantified-self.io/calendar</loc>');
+    expect(sitemapXml).not.toContain('<loc>https://quantified-self.io/plans</loc>');
     expect(sitemapXml).not.toContain('<loc>https://quantified-self.io/training</loc>');
     expect(sitemapXml).not.toContain('<loc>https://quantified-self.io/health</loc>');
     expect(sitemapXml).not.toContain('<loc>https://quantified-self.io/mcp</loc>');

--- a/src/firestore.rules.spec.ts
+++ b/src/firestore.rules.spec.ts
@@ -1504,6 +1504,89 @@ describe('Firestore Security Rules', () => {
             });
         });
 
+        describe('Training plans and scheduled workouts', () => {
+            const seedCurrentTrainingData = async () => {
+                await testEnv.withSecurityRulesDisabled(async context => {
+                    const userRef = context.firestore().collection('users').doc(userId);
+                    await userRef.collection('trainingPlanState').doc('current').set({
+                        schemaVersion: 1,
+                        activePlanId: 'plan-1',
+                        revision: 1,
+                        currentWorkoutCount: 1,
+                        updatedAtMs: 1,
+                    });
+                    await userRef.collection('trainingPlans').doc('plan-1').set({ id: 'plan-1' });
+                    await userRef.collection('scheduledWorkouts').doc('workout-1').set({
+                        id: 'workout-1', planId: 'plan-1', localDate: '2026-09-02', lifecycle: 'planned',
+                    });
+                    await userRef.collection('trainingPlans').doc('plan-1')
+                        .collection('revisions').doc('0000000001').set({ privateDelta: true });
+                    await userRef.collection('trainingPlans').doc('plan-1')
+                        .collection('revisions').doc('0000000001')
+                        .collection('chunks').doc('checkpoint-workouts-0000').set({ privatePayload: true });
+                    await userRef.collection('scheduledWorkouts').doc('workout-1')
+                        .collection('revisions').doc('0000000001').set({ privateSnapshot: true });
+                    await userRef.collection('trainingPlanState').doc('current')
+                        .collection('mutationReceipts').doc('mutation-1').set({ requestHash: 'private' });
+                    await userRef.collection('trainingPlanState').doc('current')
+                        .collection('planDeletionLocks').doc('plan-1').set({ requestHash: 'private' });
+                    await userRef.collection('trainingPlanState').doc('current')
+                        .collection('deletionTombstones').doc('hashed-entity-id').set({ entityIdHash: 'private' });
+                });
+            };
+
+            it('allows owners to read and list current state, plans, and workouts', async () => {
+                await seedCurrentTrainingData();
+                const userRef = testEnv.authenticatedContext(userId).firestore().collection('users').doc(userId);
+
+                await assertSucceeds(userRef.collection('trainingPlanState').doc('current').get());
+                await assertSucceeds(userRef.collection('trainingPlans').doc('plan-1').get());
+                await assertSucceeds(userRef.collection('trainingPlans').get());
+                await assertSucceeds(userRef.collection('scheduledWorkouts').doc('workout-1').get());
+                await assertSucceeds(userRef.collection('scheduledWorkouts').get());
+            });
+
+            it('denies cross-user and unauthenticated reads of current training data', async () => {
+                await seedCurrentTrainingData();
+                const ownerPath = `users/${userId}/scheduledWorkouts/workout-1`;
+                await assertFails(testEnv.authenticatedContext(otherId).firestore().doc(ownerPath).get());
+                await assertFails(testEnv.unauthenticatedContext().firestore().doc(ownerPath).get());
+            });
+
+            it('denies every direct browser create, update, and delete', async () => {
+                await seedCurrentTrainingData();
+                const db = testEnv.authenticatedContext(userId).firestore();
+                const planRef = db.doc(`users/${userId}/trainingPlans/plan-1`);
+                const workoutRef = db.doc(`users/${userId}/scheduledWorkouts/workout-1`);
+                const stateRef = db.doc(`users/${userId}/trainingPlanState/current`);
+
+                await assertFails(db.doc(`users/${userId}/trainingPlans/plan-2`).set({ id: 'plan-2' }));
+                await assertFails(planRef.update({ name: 'Browser edit' }));
+                await assertFails(planRef.delete());
+                await assertFails(db.doc(`users/${userId}/scheduledWorkouts/workout-2`).set({ id: 'workout-2' }));
+                await assertFails(workoutRef.update({ lifecycle: 'skipped' }));
+                await assertFails(workoutRef.delete());
+                await assertFails(stateRef.update({ revision: 99 }));
+            });
+
+            it('keeps revisions, receipts, deletion locks, and tombstones inaccessible to owners', async () => {
+                await seedCurrentTrainingData();
+                const db = testEnv.authenticatedContext(userId).firestore();
+                const internalPaths = [
+                    `users/${userId}/trainingPlans/plan-1/revisions/0000000001`,
+                    `users/${userId}/trainingPlans/plan-1/revisions/0000000001/chunks/checkpoint-workouts-0000`,
+                    `users/${userId}/scheduledWorkouts/workout-1/revisions/0000000001`,
+                    `users/${userId}/trainingPlanState/current/mutationReceipts/mutation-1`,
+                    `users/${userId}/trainingPlanState/current/planDeletionLocks/plan-1`,
+                    `users/${userId}/trainingPlanState/current/deletionTombstones/hashed-entity-id`,
+                ];
+                for (const path of internalPaths) {
+                    await assertFails(db.doc(path).get());
+                    await assertFails(db.doc(path).set({ forged: true }));
+                }
+            });
+        });
+
         describe('Sleep Sessions and Sync State', () => {
             it('should allow owners to read their own sleep session docs', async () => {
                 const db = testEnv.authenticatedContext(userId).firestore();

--- a/src/firestore.rules.spec.ts
+++ b/src/firestore.rules.spec.ts
@@ -1515,6 +1515,9 @@ describe('Firestore Security Rules', () => {
                         currentWorkoutCount: 1,
                         updatedAtMs: 1,
                     });
+                    await userRef.collection('trainingPlanState').doc('internal').set({
+                        privateState: true,
+                    });
                     await userRef.collection('trainingPlans').doc('plan-1').set({ id: 'plan-1' });
                     await userRef.collection('scheduledWorkouts').doc('workout-1').set({
                         id: 'workout-1', planId: 'plan-1', localDate: '2026-09-02', lifecycle: 'planned',
@@ -1544,6 +1547,8 @@ describe('Firestore Security Rules', () => {
                 await assertSucceeds(userRef.collection('trainingPlans').get());
                 await assertSucceeds(userRef.collection('scheduledWorkouts').doc('workout-1').get());
                 await assertSucceeds(userRef.collection('scheduledWorkouts').get());
+                await assertFails(userRef.collection('trainingPlanState').doc('internal').get());
+                await assertFails(userRef.collection('trainingPlanState').get());
             });
 
             it('denies cross-user and unauthenticated reads of current training data', async () => {


### PR DESCRIPTION
## Summary

- Add the Quantified Self-owned v1 structured-workout contract, canonical units, strict parsing, compatibility analysis, and unit-aware formatting.
- Add owner-only Firestore persistence, rules, indexes, callable mutations, optimistic revisions, history, restore, deletion fencing, and plan deletion behavior.
- Add the authenticated noindex `/plans` workspace for standalone workouts and plans, plus distinct planned-workout overlays across Calendar surfaces.
- Silently limit the Plans sidenav entry to the staged Training Planning UID through a presentation-only allowlist.
- Add redacted Garmin, COROS, Wahoo, and Suunto capability mappings and serializer fixtures while keeping provider delivery disabled.
- Update Training, Calendar, provider integration, help, route, and hosting documentation and contracts.

## Tracking

Closes #643
Closes #644

Partially addresses #645, #647, #648, #649, and #650.

Parent epic: #583

Large-schedule transaction, paged-history, and durable-cleanup follow-up: #657

## Explicit boundaries

- The Plans sidenav allowlist is presentation-only. Direct `/plans` navigation and owner-scoped APIs remain available to authenticated, onboarded users.
- No production provider calls, deployment, feature enablement, or certification are included.
- No provider delivery ledger or live transport adapter is enabled.
- No Sports Lib extraction or package publication is included; that remains gated on sandbox evidence.
- Completion reconciliation, AI proposals, reusable templates, and production rollout remain in their dedicated epic subissues.

## Verification

Verified after rebasing the four feature commits onto `origin/develop` at `8b27adf6d037` (PR head `6e4c10bbbdc7`):

- Targeted frontend: 18 test files and 259 tests passed, including Calendar, Timeline notes, Plans, sidenav, routing, shared contracts, and hosting checks.
- Targeted Functions: 14 test files and 172 tests passed.
- Firestore and Storage Rules: 174 emulator-backed tests passed.
- Angular lint and the Functions TypeScript build passed.
- Frontend production build passed, with CSS-budget and CommonJS warnings.
- Service-worker output verified 324 assets; public-output verification passed for 32 prerendered pages.
- Clean worktree, no conflict markers, and `git diff --check` passed.
- Pre-push MCP contract compatibility check and 85 focused MCP tests passed.

The Calendar conflict resolution preserves category-specific Timeline note icons and colors alongside planned workouts, with every visible date clickable. The Plans entry retains its presentation-only UID allowlist.
