### PR TITLE
feat: add selected laps summaries

### DIFF
--- a/src/app/components/event/laps/event.card.laps.component.css
+++ b/src/app/components/event/laps/event.card.laps.component.css
@@ -15,6 +15,13 @@
   max-width: 48px;
 }
 
+.lap-selection-cell {
+  flex: 0 0 48px;
+  justify-content: center;
+  width: 48px;
+  max-width: 48px;
+}
+
 .lap-duration-cell {
   flex: 0 0 104px;
   width: 104px;
@@ -95,6 +102,28 @@
 .lap-average-cell {
   color: var(--mat-sys-on-surface-variant);
   font: var(--mat-sys-label-large);
+}
+
+.lap-selected-summary-row {
+  background: var(--mat-sys-surface-container);
+}
+
+.lap-selected-summary-row mat-footer-cell,
+.lap-selected-summary-row .mat-mdc-footer-cell {
+  color: var(--mat-sys-on-surface);
+  font: var(--mat-sys-label-large);
+}
+
+.lap-selected-summary-label {
+  flex: 0 0 96px;
+  justify-content: flex-start;
+  max-width: 96px;
+  white-space: nowrap;
+  width: 96px;
+}
+
+.lap-selected-summary-index-spacer {
+  display: none;
 }
 
 @media (max-width: 599.98px) {

--- a/src/app/components/event/laps/event.card.laps.component.css
+++ b/src/app/components/event/laps/event.card.laps.component.css
@@ -112,6 +112,7 @@
 .lap-selected-summary-row .mat-mdc-footer-cell {
   color: var(--mat-sys-on-surface);
   font: var(--mat-sys-label-large);
+  font-family: 'Barlow Condensed', 'Inter', sans-serif;
 }
 
 .lap-selected-summary-label {

--- a/src/app/components/event/laps/event.card.laps.component.html
+++ b/src/app/components/event/laps/event.card.laps.component.html
@@ -103,20 +103,50 @@
     <section class="table-container">
       <table mat-table [dataSource]="lapTable.dataSource">
         @for (column of lapTable.columns; track column) {
-        <ng-container [matColumnDef]="column" [sticky]="column === '#'">
-          <mat-header-cell *matHeaderCellDef [class.lap-index-cell]="column === '#'"
+        <ng-container [matColumnDef]="column" [sticky]="column === 'selection' || column === '#'">
+          <mat-header-cell *matHeaderCellDef [class.lap-selection-cell]="column === 'selection'"
+            [class.lap-index-cell]="column === '#'"
             [class.lap-duration-cell]="column === 'Duration'">
-            @if (column !== '#') {
+            @if (column === 'selection') {
+            <mat-checkbox [checked]="lapTable.allLapRowsSelected"
+              [indeterminate]="lapTable.someLapRowsSelected"
+              (change)="toggleAllLapSelections(lapTable)"
+              aria-label="Select all laps in this table">
+            </mat-checkbox>
+            } @else if (column !== '#') {
             <app-data-type-icon [dataType]="column"></app-data-type-icon>
             }
           </mat-header-cell>
-          <mat-cell *matCellDef="let row" [class.lap-index-cell]="column === '#'"
+          <mat-cell *matCellDef="let row" [class.lap-selection-cell]="column === 'selection'"
+            [class.lap-index-cell]="column === '#'"
             [class.lap-duration-cell]="column === 'Duration'"
-            [class.lap-average-cell]="row.isLapAverage">{{ row[column] }}</mat-cell>
+            [class.lap-average-cell]="row.isLapAverage">
+            @if (column === 'selection' && !row.isLapAverage) {
+            <mat-checkbox [checked]="row.isSelected"
+              (change)="toggleLapSelection(lapTable, row)"
+              [attr.aria-label]="'Select lap ' + row['#']">
+            </mat-checkbox>
+            } @else if (column !== 'selection') {
+            {{ row[column] }}
+            }
+          </mat-cell>
+          <mat-footer-cell *matFooterCellDef [class.lap-selection-cell]="column === 'selection'"
+            [class.lap-index-cell]="column === '#'"
+            [class.lap-duration-cell]="column === 'Duration'"
+            [class.lap-selected-summary-label]="column === 'selection'"
+            [class.lap-selected-summary-index-spacer]="column === '#'">
+            @if (column === 'selection') {
+            {{ lapTable.selectedSummaryLabel }}
+            } @else if (column !== '#') {
+            {{ lapTable.selectedSummary[column] }}
+            }
+          </mat-footer-cell>
         </ng-container>
         }
         <mat-header-row *matHeaderRowDef="lapTable.columns"></mat-header-row>
         <mat-row *matRowDef="let row; columns: lapTable.columns;" [class.lap-average-row]="row.isLapAverage"></mat-row>
+        <mat-footer-row *matFooterRowDef="lapTable.columns; sticky: true" class="lap-selected-summary-row"
+          [attr.hidden]="lapTable.selectedCount === 0 ? '' : null"></mat-footer-row>
       </table>
     </section>
   </section>

--- a/src/app/components/event/laps/event.card.laps.component.spec.ts
+++ b/src/app/components/event/laps/event.card.laps.component.spec.ts
@@ -721,6 +721,8 @@ describe('EventCardLapsComponent', () => {
         expect(styles).toContain('.lap-column-search-field');
         expect(styles).toContain('box-sizing: border-box;');
         expect(styles).toContain('width: calc(100% - 32px) !important;');
+        expect(styles).toContain(".lap-selected-summary-row .mat-mdc-footer-cell");
+        expect(styles).toContain("font-family: 'Barlow Condensed', 'Inter', sans-serif;");
     });
 
     it('renders checkbox-only lap selection and a sticky selected-summary footer', () => {

--- a/src/app/components/event/laps/event.card.laps.component.spec.ts
+++ b/src/app/components/event/laps/event.card.laps.component.spec.ts
@@ -1,7 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectorRef, NO_ERRORS_SCHEMA, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatMenuModule } from '@angular/material/menu';
+import { MatTableModule } from '@angular/material/table';
 import { MatSelectionListChange } from '@angular/material/list';
 import {
     ActivityInterface,
@@ -70,7 +72,7 @@ describe('EventCardLapsComponent', () => {
         updateLapTableColumns = vi.fn().mockResolvedValue(undefined);
         snackBar = { open: vi.fn() };
         await TestBed.configureTestingModule({
-            imports: [CommonModule, MatMenuModule],
+            imports: [CommonModule, MatCheckboxModule, MatMenuModule, MatTableModule],
             declarations: [EventCardLapsComponent],
             providers: [
                 { provide: AppEventColorService, useValue: {} },
@@ -316,6 +318,7 @@ describe('EventCardLapsComponent', () => {
         );
 
         expect(component.getColumns(activity, LapTypes.Manual)).toEqual([
+            'selection',
             '#',
             DataSpeedAvg.type,
             DataSpeedMin.type,
@@ -389,6 +392,7 @@ describe('EventCardLapsComponent', () => {
         expect(runningGroup.searchTerm).toBe('maximum heart rate');
         expect(runningGroup.selectedMetricTypes).toEqual([DataHeartRateMax.type]);
         expect(component.getColumns(activity, LapTypes.Manual)).toEqual([
+            'selection',
             '#',
             DataHeartRateMax.type,
         ]);
@@ -608,6 +612,106 @@ describe('EventCardLapsComponent', () => {
         expect(fixture.nativeElement.querySelector('app-event-section-header')).toBeNull();
     });
 
+    it('selects only lap rows, updates the selected footer, and supports select all', () => {
+        const activity = createActivity([120, 180].map((duration, index) => ({
+            ...createRenderableLap(LapTypes.Manual),
+            getDuration: () => new DataDuration(duration),
+            getStat: (type: string) => type === DataHeartRateMax.type
+                ? new DataHeartRateMax(index === 0 ? 160 : 180)
+                : undefined,
+        } as unknown as LapInterface)));
+        component.selectedActivities = [activity];
+        component.ngOnChanges();
+        fixture.detectChanges();
+
+        const table = component.lapTableGroups[0]?.tables[0];
+        if (!table) {
+            throw new Error('Expected a lap table');
+        }
+        const [averageRow, firstLapRow, secondLapRow] = table.dataSource.data;
+        if (!averageRow || !firstLapRow || !secondLapRow) {
+            throw new Error('Expected the average row and two lap rows');
+        }
+
+        component.toggleLapSelection(table, averageRow);
+        expect(table.selectedCount).toBe(0);
+        expect(table.selection.selected).toEqual([]);
+
+        component.toggleLapSelection(table, firstLapRow);
+        fixture.detectChanges();
+
+        expect(table.selectedCount).toBe(1);
+        expect(table.selectedSummaryLabel).toBe('Selected avg · 1');
+        expect(table.selectedSummary[DataDuration.type]).toContain(' · 1/1');
+        expect(table.allLapRowsSelected).toBe(false);
+        expect(table.someLapRowsSelected).toBe(true);
+        expect(fixture.nativeElement.querySelector('.lap-selected-summary-row')).toBeTruthy();
+
+        component.toggleAllLapSelections(table);
+        expect(table.selectedCount).toBe(2);
+        expect(table.allLapRowsSelected).toBe(true);
+        expect(table.someLapRowsSelected).toBe(false);
+
+        component.toggleAllLapSelections(table);
+        fixture.detectChanges();
+        expect(table.selectedCount).toBe(0);
+        expect(fixture.nativeElement.querySelector('.lap-selected-summary-row')?.getAttribute('hidden')).toBe('');
+    });
+
+    it('keeps lap selections isolated per table and preserves them across column refreshes', async () => {
+        const running = createActivity([createRenderableLap(LapTypes.Manual)]);
+        const cycling = {
+            ...createActivity([createRenderableLap(LapTypes.Manual)]),
+            getID: () => 'activity-2',
+            type: 'Cycling',
+        } as ActivityInterface;
+        component.canCustomize = true;
+        component.selectedActivities = [running, cycling];
+        component.ngOnChanges();
+
+        const runningTable = component.lapTableGroups[0]?.tables.find((table) => table.activity === running);
+        const cyclingTable = component.lapTableGroups[0]?.tables.find((table) => table.activity === cycling);
+        const runningLapRow = runningTable?.dataSource.data.find((row) => !row.isLapAverage);
+        if (!runningTable || !cyclingTable || !runningLapRow) {
+            throw new Error('Expected independent running and cycling lap tables');
+        }
+
+        component.toggleLapSelection(runningTable, runningLapRow);
+        expect(runningTable.selectedCount).toBe(1);
+        expect(cyclingTable.selectedCount).toBe(0);
+
+        await component.onLapColumnSelectionChange(
+            'running',
+            createLapColumnSelectionChange([DataHeartRateMax.type]),
+        );
+
+        const refreshedRunningTable = component.lapTableGroups[0]?.tables.find((table) => table.activity === running);
+        const refreshedCyclingTable = component.lapTableGroups[0]?.tables.find((table) => table.activity === cycling);
+        expect(refreshedRunningTable?.selectedCount).toBe(1);
+        expect(refreshedCyclingTable?.selectedCount).toBe(0);
+    });
+
+    it('clears a table selection once that activity or lap type no longer appears', () => {
+        const activity = createActivity([createRenderableLap(LapTypes.Manual)]);
+        component.selectedActivities = [activity];
+        component.ngOnChanges();
+
+        const table = component.lapTableGroups[0]?.tables[0];
+        const lapRow = table?.dataSource.data.find((row) => !row.isLapAverage);
+        if (!table || !lapRow) {
+            throw new Error('Expected a selectable lap row');
+        }
+        component.toggleLapSelection(table, lapRow);
+        expect(table.selectedCount).toBe(1);
+
+        component.selectedActivities = [];
+        component.ngOnChanges();
+        component.selectedActivities = [activity];
+        component.ngOnChanges();
+
+        expect(component.lapTableGroups[0]?.tables[0]?.selectedCount).toBe(0);
+    });
+
     it('should keep the metric search field within the lap column menu', () => {
         const styles = readFileSync(
             resolve(process.cwd(), 'src/app/components/event/laps/event.card.laps.component.css'),
@@ -619,13 +723,21 @@ describe('EventCardLapsComponent', () => {
         expect(styles).toContain('width: calc(100% - 32px) !important;');
     });
 
-    it('should not render the index column header icon', () => {
+    it('renders checkbox-only lap selection and a sticky selected-summary footer', () => {
         const template = readFileSync(
             resolve(process.cwd(), 'src/app/components/event/laps/event.card.laps.component.html'),
             'utf8',
         );
 
-        expect(template).toContain("@if (column !== '#')");
+        expect(template).toContain("column === 'selection' || column === '#'");
+        expect(template).toContain('Select all laps in this table');
+        expect(template).toContain("[attr.aria-label]=\"'Select lap ' + row['#']\"");
+        expect(template).toContain("column === 'selection' && !row.isLapAverage");
+        expect(template).toContain('toggleAllLapSelections(lapTable)');
+        expect(template).toContain('toggleLapSelection(lapTable, row)');
+        expect(template).toContain('lapTable.selectedSummaryLabel');
+        expect(template).toContain('*matFooterRowDef="lapTable.columns; sticky: true"');
+        expect(template).toContain('lap-selected-summary-row');
         expect(template).toContain('<app-data-type-icon [dataType]="column"></app-data-type-icon>');
         expect(template).toContain("[class.lap-index-cell]=\"column === '#'");
         expect(template).toContain("[class.lap-duration-cell]=\"column === 'Duration'");

--- a/src/app/components/event/laps/event.card.laps.component.ts
+++ b/src/app/components/event/laps/event.card.laps.component.ts
@@ -10,9 +10,11 @@ import {
 } from '@angular/core';
 import { MatSelectionListChange } from '@angular/material/list';
 import { MatTableDataSource } from '@angular/material/table';
+import { SelectionModel } from '@angular/cdk/collections';
 import {
   ActivityInterface,
   EventInterface,
+  LapInterface,
   LapTypes,
   UserUnitSettingsInterface,
 } from '@sports-alliance/sports-lib';
@@ -27,6 +29,7 @@ import {
   getEventLapMetricOptionGroups,
   getEventLapSportFamilyPresentation,
   getEventLapMetricStat,
+  getSelectedEventLapSummaryMetrics,
   getSelectedEventLapMetricTypes,
   normalizeEventDetailsSettings,
   resolveEventLapSportFamily,
@@ -36,9 +39,12 @@ import {
   AppEventLapSportFamily,
 } from '../../../models/app-user.interface';
 
-interface LapTableRow extends Record<string, string | number | boolean> {
+interface LapTableRow extends Record<string, string | number | boolean | LapInterface | undefined> {
   '#': string | number;
   isLapAverage?: boolean;
+  isSelected?: boolean;
+  lap?: LapInterface;
+  selectionKey?: string;
 }
 
 interface LapColumnMenuGroup {
@@ -56,12 +62,20 @@ interface LapTableView {
   activity: ActivityInterface;
   dataSource: MatTableDataSource<LapTableRow>;
   columns: string[];
+  selection: SelectionModel<LapTableRow>;
+  selectedCount: number;
+  selectedSummary: Record<string, string>;
+  selectedSummaryLabel: string;
+  allLapRowsSelected: boolean;
+  someLapRowsSelected: boolean;
 }
 
 interface LapTableGroup {
   lapType: LapTypes;
   tables: LapTableView[];
 }
+
+const LAP_TABLE_SELECTION_COLUMN = 'selection';
 
 function filterLapMetricGroups(
   metricGroups: EventLapMetricOptionGroup[],
@@ -149,6 +163,7 @@ export class EventCardLapsComponent extends DataTableAbstractDirective implement
   }
 
   private updateData() {
+    const selectedLapKeysByTable = this.getSelectedLapKeysByTable();
     this.dataSourcesMap.clear();
     this.columnsMap.clear();
     this.lapTableGroups = [];
@@ -160,6 +175,7 @@ export class EventCardLapsComponent extends DataTableAbstractDirective implement
     }
 
     const lapTypesWithData = new Set<LapTypes>();
+    const tablesByKey = new Map<string, LapTableView>();
 
     this.selectedActivities.forEach(activity => {
       this.availableLapTypes.forEach(lapType => {
@@ -170,7 +186,28 @@ export class EventCardLapsComponent extends DataTableAbstractDirective implement
           lapTypesWithData.add(lapType);
           const dataSource = new MatTableDataSource(data);
           this.dataSourcesMap.set(key, dataSource);
-          this.columnsMap.set(key, this.calculateColumns(dataSource, activity.type));
+          const columns = this.calculateColumns(dataSource, activity.type);
+          this.columnsMap.set(key, columns);
+          const selection = new SelectionModel<LapTableRow>(true);
+          const selectedLapKeys = selectedLapKeysByTable.get(key);
+          const selectableRows = data.filter((row) => !row.isLapAverage);
+          if (selectedLapKeys) {
+            selection.select(...selectableRows.filter((row) => selectedLapKeys.has(row.selectionKey || '')));
+          }
+          const table: LapTableView = {
+            key,
+            activity,
+            dataSource,
+            columns,
+            selection,
+            selectedCount: 0,
+            selectedSummary: {},
+            selectedSummaryLabel: '',
+            allLapRowsSelected: false,
+            someLapRowsSelected: false,
+          };
+          this.refreshSelectedSummary(table);
+          tablesByKey.set(key, table);
         }
       });
     });
@@ -186,7 +223,7 @@ export class EventCardLapsComponent extends DataTableAbstractDirective implement
           if (!dataSource || !columns) {
             return null;
           }
-          return { key, activity, dataSource, columns };
+          return tablesByKey.get(key) || null;
         })
         .filter((table): table is LapTableView => !!table),
     })).filter((group) => group.tables.length > 0);
@@ -205,6 +242,15 @@ export class EventCardLapsComponent extends DataTableAbstractDirective implement
       const row: LapTableRow = {
         '#': index + 1,
       };
+      const lapIdentity = Number.isFinite(lap.lapId) ? lap.lapId : index;
+      Object.defineProperties(row, {
+        isSelected: { value: false, writable: true, enumerable: false },
+        lap: { value: lap, enumerable: false },
+        selectionKey: {
+          value: `${this.getKey(activity, lapType)}-${lapIdentity}`,
+          enumerable: false,
+        },
+      });
 
       metricTypes.forEach((metricType) => {
         row[metricType] = formatEventLapMetric(
@@ -235,8 +281,8 @@ export class EventCardLapsComponent extends DataTableAbstractDirective implement
   }
 
   private calculateColumns(dataSource: MatTableDataSource<LapTableRow>, activityType: unknown): string[] {
-    return this.getColumnsToDisplay(activityType).filter(column => {
-      if (column === '#') {
+    return [LAP_TABLE_SELECTION_COLUMN, ...this.getColumnsToDisplay(activityType)].filter(column => {
+      if (column === LAP_TABLE_SELECTION_COLUMN || column === '#') {
         return true;
       }
       return dataSource.data.some(row => {
@@ -266,12 +312,32 @@ export class EventCardLapsComponent extends DataTableAbstractDirective implement
     ];
   }
 
-  isSticky(column: string) {
-    return column === '#'
+  isSticky(column: string): boolean {
+    return column === LAP_TABLE_SELECTION_COLUMN || column === '#';
   }
 
-  isStickyEnd(_column: string) {
+  isStickyEnd(_column: string): boolean {
     return false;
+  }
+
+  public toggleLapSelection(table: LapTableView, row: LapTableRow): void {
+    if (row.isLapAverage) {
+      return;
+    }
+    table.selection.toggle(row);
+    this.refreshSelectedSummary(table);
+    this.changeDetectorRef.markForCheck();
+  }
+
+  public toggleAllLapSelections(table: LapTableView): void {
+    const selectableRows = table.dataSource.data.filter((row) => !row.isLapAverage);
+    if (table.allLapRowsSelected) {
+      table.selection.clear();
+    } else {
+      table.selection.select(...selectableRows);
+    }
+    this.refreshSelectedSummary(table);
+    this.changeDetectorRef.markForCheck();
   }
 
   public async onLapColumnSelectionChange(
@@ -382,6 +448,49 @@ export class EventCardLapsComponent extends DataTableAbstractDirective implement
     this.activeLapColumnMenuGroup = this.lapColumnMenuGroups.find(
       (group) => group.family === activeFamily,
     ) || this.lapColumnMenuGroups[0] || null;
+  }
+
+  private getSelectedLapKeysByTable(): Map<string, Set<string>> {
+    return new Map(this.lapTableGroups.flatMap((group) => group.tables.map((table) => [
+      table.key,
+      new Set(table.selection.selected
+        .map((row) => row.selectionKey)
+        .filter((selectionKey): selectionKey is string => !!selectionKey)),
+    ])));
+  }
+
+  private refreshSelectedSummary(table: LapTableView): void {
+    const selectableRows = table.dataSource.data.filter((row) => !row.isLapAverage);
+    selectableRows.forEach((row) => {
+      row.isSelected = table.selection.isSelected(row);
+    });
+    const selectedRows = selectableRows.filter((row) => row.isSelected && row.lap);
+    const selectedLaps = selectedRows
+      .map((row) => row.lap)
+      .filter((lap): lap is LapInterface => !!lap);
+    const selectedCount = selectedLaps.length;
+    const metricTypes = table.columns.filter((column) => (
+      column !== LAP_TABLE_SELECTION_COLUMN && column !== '#'
+    ));
+    const summary = Object.fromEntries(metricTypes.map((metricType) => [
+      metricType,
+      `— · 0/${selectedCount}`,
+    ]));
+
+    getSelectedEventLapSummaryMetrics(
+      selectedLaps,
+      metricTypes,
+      this.unitSettings,
+      table.activity.type,
+    ).forEach(({ type, display, availableCount }) => {
+      summary[type] = `${display} · ${availableCount}/${selectedCount}`;
+    });
+
+    table.selectedCount = selectedCount;
+    table.selectedSummary = summary;
+    table.selectedSummaryLabel = selectedCount > 0 ? `Selected avg · ${selectedCount}` : '';
+    table.allLapRowsSelected = selectableRows.length > 0 && selectedCount === selectableRows.length;
+    table.someLapRowsSelected = selectedCount > 0 && !table.allLapRowsSelected;
   }
 
   private setLapColumnMetricSearchTerm(group: LapColumnMenuGroup, searchTerm: string): void {

--- a/src/app/helpers/event-lap-table-columns.helper.spec.ts
+++ b/src/app/helpers/event-lap-table-columns.helper.spec.ts
@@ -26,6 +26,9 @@ import {
 } from '@sports-alliance/sports-lib';
 import {
   DataDuration,
+  DataEffortPaceAvg,
+  DataGradeAdjustedPaceAvg,
+  DataGradeAdjustedSpeedAvg,
 } from '@sports-alliance/sports-lib';
 import {
   EVENT_LAP_TABLE_FIXED_COLUMN,
@@ -33,6 +36,7 @@ import {
   getAverageEventLapMetrics,
   getDefaultEventLapMetricTypes,
   getEventLapMetricOptionGroups,
+  getSelectedEventLapSummaryMetrics,
   getSelectedEventLapMetricTypes,
   isEventLapSportFamily,
   normalizeEventDetailsSettings,
@@ -168,6 +172,197 @@ describe('event lap table columns helper', () => {
       'Running',
     )).toEqual([
       { type: DataPaceAvg.type, display: '08:26 min/m' },
+    ]);
+  });
+
+  it('summarizes selected accumulated and ordinary metrics with available coverage', () => {
+    const laps = [
+      { duration: 120, distance: 1000, energy: 300, heartRate: 160 },
+      { duration: 180, distance: 1500, energy: undefined, heartRate: 180 },
+    ].map(({ duration, distance, energy, heartRate }) => ({
+      getDuration: () => new DataDuration(duration),
+      getDistance: () => new DataDistance(distance),
+      getStat: (type: string) => type === DataEnergy.type && energy !== undefined
+        ? new DataEnergy(energy)
+        : type === DataHeartRateMax.type
+          ? new DataHeartRateMax(heartRate)
+          : undefined,
+    } as unknown as LapInterface));
+
+    const summaries = getSelectedEventLapSummaryMetrics(
+      laps,
+      [DataDuration.type, DataDistance.type, DataEnergy.type, DataHeartRateMax.type],
+      unitSettings,
+      'Running',
+    );
+
+    expect(summaries).toEqual([
+      {
+        type: DataDuration.type,
+        display: formatEventLapMetric(new DataDuration(150), DataDuration.type, unitSettings, 'Running'),
+        availableCount: 2,
+        selectedCount: 2,
+      },
+      {
+        type: DataDistance.type,
+        display: formatEventLapMetric(new DataDistance(1250), DataDistance.type, unitSettings, 'Running'),
+        availableCount: 2,
+        selectedCount: 2,
+      },
+      {
+        type: DataEnergy.type,
+        display: formatEventLapMetric(new DataEnergy(300), DataEnergy.type, unitSettings, 'Running'),
+        availableCount: 1,
+        selectedCount: 2,
+      },
+      {
+        type: DataHeartRateMax.type,
+        display: formatEventLapMetric(new DataHeartRateMax(170), DataHeartRateMax.type, unitSettings, 'Running'),
+        availableCount: 2,
+        selectedCount: 2,
+      },
+    ]);
+  });
+
+  it('weights every supported average pace and speed variant by its required metric', () => {
+    const laps = [
+      {
+        duration: 120,
+        distance: 1000,
+        pace: 300,
+        swimPace: 90,
+        gradeAdjustedPace: 310,
+        effortPace: 320,
+        speed: 5,
+        gradeAdjustedSpeed: 4,
+      },
+      {
+        duration: 480,
+        distance: 3000,
+        pace: 400,
+        swimPace: 150,
+        gradeAdjustedPace: 430,
+        effortPace: 440,
+        speed: 10,
+        gradeAdjustedSpeed: 8,
+      },
+    ].map((values) => ({
+      getDuration: () => new DataDuration(values.duration),
+      getDistance: () => new DataDistance(values.distance),
+      getStat: (type: string) => {
+        const stats = new Map<string, number>([
+          [DataPaceAvg.type, values.pace],
+          [DataSwimPaceAvg.type, values.swimPace],
+          [DataGradeAdjustedPaceAvg.type, values.gradeAdjustedPace],
+          [DataEffortPaceAvg.type, values.effortPace],
+          [DataSpeedAvg.type, values.speed],
+          [DataGradeAdjustedSpeedAvg.type, values.gradeAdjustedSpeed],
+          [DataPaceMax.type, values.pace],
+        ]);
+        const value = stats.get(type);
+        if (value === undefined) {
+          return undefined;
+        }
+        if (type === DataPaceAvg.type) return new DataPaceAvg(value);
+        if (type === DataSwimPaceAvg.type) return new DataSwimPaceAvg(value);
+        if (type === DataGradeAdjustedPaceAvg.type) return new DataGradeAdjustedPaceAvg(value);
+        if (type === DataEffortPaceAvg.type) return new DataEffortPaceAvg(value);
+        if (type === DataSpeedAvg.type) return new DataSpeedAvg(value);
+        if (type === DataGradeAdjustedSpeedAvg.type) return new DataGradeAdjustedSpeedAvg(value);
+        return new DataPaceMax(value);
+      },
+    } as unknown as LapInterface));
+    const metricTypes = [
+      DataPaceAvg.type,
+      DataSwimPaceAvg.type,
+      DataGradeAdjustedPaceAvg.type,
+      DataEffortPaceAvg.type,
+      DataSpeedAvg.type,
+      DataGradeAdjustedSpeedAvg.type,
+      DataPaceMax.type,
+    ];
+
+    const summaries = getSelectedEventLapSummaryMetrics(laps, metricTypes, unitSettings, 'Running');
+
+    expect(summaries).toEqual([
+      {
+        type: DataPaceAvg.type,
+        display: formatEventLapMetric(new DataPaceAvg(375), DataPaceAvg.type, unitSettings, 'Running'),
+        availableCount: 2,
+        selectedCount: 2,
+      },
+      {
+        type: DataSwimPaceAvg.type,
+        display: formatEventLapMetric(new DataSwimPaceAvg(135), DataSwimPaceAvg.type, unitSettings, 'Running'),
+        availableCount: 2,
+        selectedCount: 2,
+      },
+      {
+        type: DataGradeAdjustedPaceAvg.type,
+        display: formatEventLapMetric(new DataGradeAdjustedPaceAvg(400), DataGradeAdjustedPaceAvg.type, unitSettings, 'Running'),
+        availableCount: 2,
+        selectedCount: 2,
+      },
+      {
+        type: DataEffortPaceAvg.type,
+        display: formatEventLapMetric(new DataEffortPaceAvg(410), DataEffortPaceAvg.type, unitSettings, 'Running'),
+        availableCount: 2,
+        selectedCount: 2,
+      },
+      {
+        type: DataSpeedAvg.type,
+        display: formatEventLapMetric(new DataSpeedAvg(9), DataSpeedAvg.type, unitSettings, 'Running'),
+        availableCount: 2,
+        selectedCount: 2,
+      },
+      {
+        type: DataGradeAdjustedSpeedAvg.type,
+        display: formatEventLapMetric(new DataGradeAdjustedSpeedAvg(7.2), DataGradeAdjustedSpeedAvg.type, unitSettings, 'Running'),
+        availableCount: 2,
+        selectedCount: 2,
+      },
+      {
+        type: DataPaceMax.type,
+        display: formatEventLapMetric(new DataPaceMax(350), DataPaceMax.type, unitSettings, 'Running'),
+        availableCount: 2,
+        selectedCount: 2,
+      },
+    ]);
+  });
+
+  it('skips invalid weighted contributions instead of treating unavailable weights as zero', () => {
+    const laps = [
+      { distance: 1000, duration: 120, pace: 300, speed: 5 },
+      { distance: 0, duration: 0, pace: 600, speed: 10 },
+      { distance: 1000, duration: 120, pace: Number.NaN, speed: Number.NaN },
+    ].map((values) => ({
+      getDuration: () => new DataDuration(values.duration),
+      getDistance: () => new DataDistance(values.distance),
+      getStat: (type: string) => type === DataPaceAvg.type
+        ? new DataPaceAvg(values.pace)
+        : type === DataSpeedAvg.type
+          ? new DataSpeedAvg(values.speed)
+          : undefined,
+    } as unknown as LapInterface));
+
+    expect(getSelectedEventLapSummaryMetrics(
+      laps,
+      [DataPaceAvg.type, DataSpeedAvg.type],
+      unitSettings,
+      'Running',
+    )).toEqual([
+      {
+        type: DataPaceAvg.type,
+        display: formatEventLapMetric(new DataPaceAvg(300), DataPaceAvg.type, unitSettings, 'Running'),
+        availableCount: 1,
+        selectedCount: 3,
+      },
+      {
+        type: DataSpeedAvg.type,
+        display: formatEventLapMetric(new DataSpeedAvg(5), DataSpeedAvg.type, unitSettings, 'Running'),
+        availableCount: 1,
+        selectedCount: 3,
+      },
     ]);
   });
 

--- a/src/app/helpers/event-lap-table-columns.helper.ts
+++ b/src/app/helpers/event-lap-table-columns.helper.ts
@@ -10,6 +10,7 @@ import {
   DataDistance,
   DataDuration,
   DataEnergy,
+  DataEffortPaceAvg,
   DataEHPE,
   DataEHPEAvg,
   DataEHPEMax,
@@ -22,11 +23,14 @@ import {
   DataHeartRateMax,
   DataInterface,
   DataGNSSDistance,
+  DataGradeAdjustedPaceAvg,
+  DataGradeAdjustedSpeedAvg,
   DataMovingTime,
   DataNumberOfSatellites,
   DataNumberOfSatellitesAvg,
   DataNumberOfSatellitesMax,
   DataNumberOfSatellitesMin,
+  DataPaceAvg,
   DataPaceMax,
   DataPaceMin,
   DataPowerAvg,
@@ -74,6 +78,11 @@ export interface EventLapSportFamilyPresentation {
 export interface EventLapAverageMetric {
   type: string;
   display: string;
+}
+
+export interface EventLapSelectedSummaryMetric extends EventLapAverageMetric {
+  availableCount: number;
+  selectedCount: number;
 }
 
 const SPORT_FAMILY_PRESENTATIONS: EventLapSportFamilyPresentation[] = [
@@ -250,6 +259,18 @@ const ACCUMULATED_LAP_METRIC_TYPES = new Set([
   DataAccumulatedPower.type,
   DataPowerWork.type,
   DataTotalGrit.type,
+]);
+
+const DISTANCE_WEIGHTED_LAP_METRIC_TYPES = new Set([
+  DataPaceAvg.type,
+  DataSwimPaceAvg.type,
+  DataGradeAdjustedPaceAvg.type,
+  DataEffortPaceAvg.type,
+]);
+
+const DURATION_WEIGHTED_LAP_METRIC_TYPES = new Set([
+  DataSpeedAvg.type,
+  DataGradeAdjustedSpeedAvg.type,
 ]);
 
 export const EVENT_LAP_TABLE_FIXED_COLUMN = '#';
@@ -451,5 +472,94 @@ export const getAverageEventLapMetrics = (
     }
 
     return averages;
+  }, [])
+);
+
+const getFiniteEventLapMetricValue = (
+  lap: LapInterface,
+  metricType: string,
+): number | null => {
+  const value = getEventLapMetricStat(lap, metricType)?.getValue?.();
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+};
+
+const getSelectedEventLapSummaryValue = (
+  laps: readonly LapInterface[],
+  metricType: string,
+): { value: number; availableCount: number } | null => {
+  const weightingMetricType = DISTANCE_WEIGHTED_LAP_METRIC_TYPES.has(metricType)
+    ? DataDistance.type
+    : DURATION_WEIGHTED_LAP_METRIC_TYPES.has(metricType)
+      ? DataDuration.type
+      : null;
+
+  if (!weightingMetricType) {
+    const values = laps
+      .map((lap) => getFiniteEventLapMetricValue(lap, metricType))
+      .filter((value): value is number => value !== null);
+    if (values.length === 0) {
+      return null;
+    }
+    return {
+      value: values.reduce((total, value) => total + value, 0) / values.length,
+      availableCount: values.length,
+    };
+  }
+
+  let weightedTotal = 0;
+  let totalWeight = 0;
+  let availableCount = 0;
+  laps.forEach((lap) => {
+    const value = getFiniteEventLapMetricValue(lap, metricType);
+    const weight = getFiniteEventLapMetricValue(lap, weightingMetricType);
+    if (value === null || weight === null || weight <= 0) {
+      return;
+    }
+    weightedTotal += value * weight;
+    totalWeight += weight;
+    availableCount += 1;
+  });
+
+  return totalWeight > 0
+    ? { value: weightedTotal / totalWeight, availableCount }
+    : null;
+};
+
+/**
+ * Summarizes a temporary selection of rows in the Event Details Laps table.
+ * Unlike the persistent all-laps Avg row, accumulated metrics are intentionally
+ * included and every result reports how many selected laps contributed.
+ */
+export const getSelectedEventLapSummaryMetrics = (
+  laps: readonly LapInterface[],
+  metricTypes: readonly string[],
+  unitSettings: UserUnitSettingsInterface | null | undefined,
+  activityType: unknown,
+): EventLapSelectedSummaryMetric[] => (
+  metricTypes.reduce<EventLapSelectedSummaryMetric[]>((summaries, metricType) => {
+    const summaryValue = getSelectedEventLapSummaryValue(laps, metricType);
+    if (!summaryValue) {
+      return summaries;
+    }
+
+    try {
+      const summaryStat = DynamicDataLoader.getDataInstanceFromDataType(
+        metricType,
+        summaryValue.value,
+      );
+      const display = formatEventLapMetric(summaryStat, metricType, unitSettings, activityType);
+      if (display) {
+        summaries.push({
+          type: metricType,
+          display,
+          availableCount: summaryValue.availableCount,
+          selectedCount: laps.length,
+        });
+      }
+    } catch {
+      // A malformed or non-numeric sports-lib metric should not block the Laps table.
+    }
+
+    return summaries;
   }, [])
 );

--- a/src/app/shared/help.content.spec.ts
+++ b/src/app/shared/help.content.spec.ts
@@ -548,8 +548,11 @@ describe('help.content', () => {
     expect(gettingStartedSection?.content).toContain('Running, Cycling, Swimming, or Other activities');
     expect(gettingStartedSection?.content).toContain('separate column list for each of those sport families');
     expect(gettingStartedSection?.content).toContain('Running and trail-running laps use pace');
-    expect(gettingStartedSection?.content).toContain('Each lap table includes an **Avg** row directly below its headers');
+    expect(gettingStartedSection?.content).toContain('Each lap table includes a persistent **Avg** row directly below its headers');
     expect(gettingStartedSection?.content).toContain('Accumulated totals, such as duration, distance, elevation, energy, and work, are not averaged');
+    expect(gettingStartedSection?.content).toContain('checkboxes beside lap rows');
+    expect(gettingStartedSection?.content).toContain('**Selected avg · N** footer');
+    expect(gettingStartedSection?.content).toContain('distance-weighted pace and duration-weighted speed');
     expect(gettingStartedSection?.content).toContain('Satellite diagnostics and EHPE/EVPE position-error metrics');
     expect(gettingStartedSection?.content).toContain('Missing values stay unavailable rather than becoming zero');
   });

--- a/src/app/shared/help.content.ts
+++ b/src/app/shared/help.content.ts
@@ -373,7 +373,8 @@ export const HELP_SECTIONS: HelpSection[] = [
 - To change it, open **Laps -> Columns**, choose Running, Cycling, Swimming, or Other activities, then tick the metrics you want to see. Use the typed metric search to quickly narrow long lists.
 - Quantified Self remembers a separate column list for each of those sport families. A triathlon can therefore keep different running, cycling, and swimming lap layouts.
 - Running and trail-running laps use pace, cycling laps use speed, and swimming laps use swim pace. These values, along with other convertible metrics, follow your unit preferences in **Settings -> Units**.
-- Each lap table includes an **Avg** row directly below its headers, with averageable lap metrics in their matching columns and using those same units. Accumulated totals, such as duration, distance, elevation, energy, and work, are not averaged.
+- Each lap table includes a persistent **Avg** row directly below its headers, with averageable lap metrics in their matching columns and using those same units. Accumulated totals, such as duration, distance, elevation, energy, and work, are not averaged.
+- Use the checkboxes beside lap rows to compare a temporary selection. A sticky **Selected avg · N** footer appears while rows are selected and averages the selected values in the visible columns. It includes how many selected laps contributed to each value, uses distance-weighted pace and duration-weighted speed where appropriate, and disappears when the selection is cleared.
 - Satellite diagnostics and EHPE/EVPE position-error metrics are intentionally left out of the column picker. Related Average, Minimum, and Maximum values are grouped under their shared metric name.
 - The menu includes the Event Summary metric families, but a column appears only when a current lap has a valid value. Missing values stay unavailable rather than becoming zero.
 


### PR DESCRIPTION
## Summary
- add local per-table lap selection controls and a sticky selected-average footer
- calculate arithmetic summaries with coverage, plus weighted pace and speed averages
- preserve selections through column refreshes and document the behavior

## Verification
- npx vitest run src/app/helpers/event-lap-table-columns.helper.spec.ts src/app/components/event/laps/event.card.laps.component.spec.ts src/app/shared/help.content.spec.ts --reporter=verbose
- npm run lint
- npm run build