### PR TITLE
feat: show lap column availability

### DIFF
--- a/src/app/components/event/laps/event.card.laps.component.css
+++ b/src/app/components/event/laps/event.card.laps.component.css
@@ -56,6 +56,13 @@
   padding: 12px 16px 4px;
 }
 
+.lap-column-availability-summary {
+  color: var(--mat-sys-on-surface-variant);
+  font: var(--mat-sys-label-medium);
+  margin: 0;
+  padding: 4px 16px 0;
+}
+
 .lap-column-search-field {
   box-sizing: border-box;
   display: block;
@@ -83,6 +90,16 @@
   align-items: center;
   display: inline-flex;
   gap: 8px;
+}
+
+.lap-column-option-copy {
+  display: grid;
+  gap: 2px;
+}
+
+.lap-column-option-availability {
+  color: var(--mat-sys-on-surface-variant);
+  font: var(--mat-sys-body-small);
 }
 
 .lap-tab-label {

--- a/src/app/components/event/laps/event.card.laps.component.css
+++ b/src/app/components/event/laps/event.card.laps.component.css
@@ -86,22 +86,6 @@
   padding: 8px 16px 0;
 }
 
-.lap-column-option {
-  align-items: center;
-  display: inline-flex;
-  gap: 8px;
-}
-
-.lap-column-option-copy {
-  display: grid;
-  gap: 2px;
-}
-
-.lap-column-option-availability {
-  color: var(--mat-sys-on-surface-variant);
-  font: var(--mat-sys-body-small);
-}
-
 .lap-tab-label {
   align-items: center;
   display: inline-flex;

--- a/src/app/components/event/laps/event.card.laps.component.html
+++ b/src/app/components/event/laps/event.card.laps.component.html
@@ -26,6 +26,11 @@
       }
       @if (activeLapColumnMenuGroup; as group) {
       <p class="lap-column-menu-copy">Choose columns for {{ group.label.toLowerCase() }} laps. Values use your saved units.</p>
+      @if (group.selectedUnavailableMetricCount > 0) {
+      <p class="lap-column-availability-summary" role="status">
+        {{ group.selectedUnavailableMetricCount }} selected {{ group.selectedUnavailableMetricCount === 1 ? 'column is' : 'columns are' }} unavailable in these laps and hidden from the table.
+      </p>
+      }
       <mat-form-field appearance="outline" class="lap-column-search-field" subscriptSizing="dynamic">
         <mat-label>Search metrics</mat-label>
         <input matInput [value]="group.searchTerm" (click)="$event.stopPropagation()"
@@ -56,7 +61,12 @@
         <mat-list-option [selected]="group.selectedMetricTypes.includes(metric.type)" [value]="metric.type">
           <span class="lap-column-option">
             <app-data-type-icon [dataType]="metric.type" size="18px"></app-data-type-icon>
-            <span>{{ metric.label }}</span>
+            <span class="lap-column-option-copy">
+              <span>{{ metric.label }}</span>
+              @if (group.metricAvailability[metric.type]?.label; as availabilityLabel) {
+              <span class="lap-column-option-availability">{{ availabilityLabel }}</span>
+              }
+            </span>
           </span>
         </mat-list-option>
         }

--- a/src/app/components/event/laps/event.card.laps.component.html
+++ b/src/app/components/event/laps/event.card.laps.component.html
@@ -59,15 +59,11 @@
         <div mat-subheader>{{ metricGroup.label }}</div>
         @for (metric of metricGroup.metrics; track metric.type) {
         <mat-list-option [selected]="group.selectedMetricTypes.includes(metric.type)" [value]="metric.type">
-          <span class="lap-column-option">
-            <app-data-type-icon [dataType]="metric.type" size="18px"></app-data-type-icon>
-            <span class="lap-column-option-copy">
-              <span>{{ metric.label }}</span>
-              @if (group.metricAvailability[metric.type]?.label; as availabilityLabel) {
-              <span class="lap-column-option-availability">{{ availabilityLabel }}</span>
-              }
-            </span>
-          </span>
+          <app-data-type-icon matListItemIcon [dataType]="metric.type" size="18px"></app-data-type-icon>
+          <span matListItemTitle>{{ metric.label }}</span>
+          @if (group.metricAvailability[metric.type]?.label; as availabilityLabel) {
+          <span matListItemLine>{{ availabilityLabel }}</span>
+          }
         </mat-list-option>
         }
         }

--- a/src/app/components/event/laps/event.card.laps.component.spec.ts
+++ b/src/app/components/event/laps/event.card.laps.component.spec.ts
@@ -398,6 +398,77 @@ describe('EventCardLapsComponent', () => {
         ]);
     });
 
+    it('keeps saved metrics checked and explains when the current laps have no data', () => {
+        const activityWithHeartRate = createActivity([{
+            ...createRenderableLap(LapTypes.Manual),
+            getStat: (type: string) => type === DataHeartRateMax.type
+                ? new DataHeartRateMax(175)
+                : undefined,
+        } as unknown as LapInterface]);
+        const activityWithoutHeartRate = {
+            ...createActivity([createRenderableLap(LapTypes.Manual)]),
+            getID: () => 'activity-2',
+        } as ActivityInterface;
+        component.canCustomize = true;
+        eventDetailsSettings.set(normalizeEventDetailsSettings({
+            lapTableColumnsBySportFamily: { running: [DataHeartRateMax.type] },
+        }));
+        component.selectedActivities = [activityWithHeartRate];
+        fixture.detectChanges();
+        component.ngOnChanges();
+
+        expect(component.lapColumnMenuGroups.find((group) => group.family === 'running')
+            ?.metricAvailability[DataHeartRateMax.type]?.availableTableCount).toBe(1);
+
+        component.selectedActivities = [activityWithoutHeartRate];
+        component.ngOnChanges();
+
+        const runningGroup = component.lapColumnMenuGroups.find((group) => group.family === 'running');
+        expect(runningGroup?.selectedMetricTypes).toEqual([DataHeartRateMax.type]);
+        expect(runningGroup?.selectedUnavailableMetricCount).toBe(1);
+        expect(runningGroup?.metricAvailability[DataHeartRateMax.type]).toEqual({
+            availableTableCount: 0,
+            tableCount: 1,
+            label: 'No data in current laps — hidden from the table',
+        });
+        expect(runningGroup?.metricAvailability[DataSpeedAvg.type]?.label).toBeNull();
+        expect(component.getColumns(activityWithoutHeartRate, LapTypes.Manual))
+            .not.toContain(DataHeartRateMax.type);
+    });
+
+    it('reports partial availability across the current lap tables without clearing saved metrics', () => {
+        const activityWithHeartRate = createActivity([{
+            ...createRenderableLap(LapTypes.Manual),
+            getStat: (type: string) => type === DataHeartRateMax.type
+                ? new DataHeartRateMax(175)
+                : undefined,
+        } as unknown as LapInterface]);
+        const activityWithoutHeartRate = {
+            ...createActivity([createRenderableLap(LapTypes.Manual)]),
+            getID: () => 'activity-2',
+        } as ActivityInterface;
+        component.canCustomize = true;
+        eventDetailsSettings.set(normalizeEventDetailsSettings({
+            lapTableColumnsBySportFamily: { running: [DataHeartRateMax.type] },
+        }));
+        component.selectedActivities = [activityWithHeartRate, activityWithoutHeartRate];
+        fixture.detectChanges();
+        component.ngOnChanges();
+
+        const runningGroup = component.lapColumnMenuGroups.find((group) => group.family === 'running');
+        expect(runningGroup?.selectedMetricTypes).toEqual([DataHeartRateMax.type]);
+        expect(runningGroup?.selectedUnavailableMetricCount).toBe(0);
+        expect(runningGroup?.metricAvailability[DataHeartRateMax.type]).toEqual({
+            availableTableCount: 1,
+            tableCount: 2,
+            label: 'Available in 1 of 2 lap tables',
+        });
+        expect(component.getColumns(activityWithHeartRate, LapTypes.Manual))
+            .toContain(DataHeartRateMax.type);
+        expect(component.getColumns(activityWithoutHeartRate, LapTypes.Manual))
+            .not.toContain(DataHeartRateMax.type);
+    });
+
     it('retains selected metrics when selecting a metric from a filtered column search', async () => {
         const activity = createActivity([createRenderableLap(LapTypes.Manual)]);
         const initialMetricTypes = [DataDuration.type, DataPaceAvg.type];
@@ -721,6 +792,8 @@ describe('EventCardLapsComponent', () => {
         expect(styles).toContain('.lap-column-search-field');
         expect(styles).toContain('box-sizing: border-box;');
         expect(styles).toContain('width: calc(100% - 32px) !important;');
+        expect(styles).toContain('.lap-column-availability-summary');
+        expect(styles).toContain('.lap-column-option-availability');
         expect(styles).toContain(".lap-selected-summary-row .mat-mdc-footer-cell");
         expect(styles).toContain("font-family: 'Barlow Condensed', 'Inter', sans-serif;");
     });
@@ -751,6 +824,10 @@ describe('EventCardLapsComponent', () => {
         expect(template).toContain('Choose columns for {{ group.label.toLowerCase() }} laps');
         expect(template).toContain('Search metrics');
         expect(template).toContain('group.filteredMetricGroups');
+        expect(template).toContain('group.selectedUnavailableMetricCount');
+        expect(template).toContain('group.metricAvailability[metric.type]?.label');
+        expect(template).toContain('unavailable in these laps and hidden from the table');
+        expect(template).toContain('lap-column-option-availability');
         expect(template).toContain('No matching metrics.');
         expect(template).toContain('row.isLapAverage');
         expect(template).toContain('lap-average-row');

--- a/src/app/components/event/laps/event.card.laps.component.spec.ts
+++ b/src/app/components/event/laps/event.card.laps.component.spec.ts
@@ -793,7 +793,6 @@ describe('EventCardLapsComponent', () => {
         expect(styles).toContain('box-sizing: border-box;');
         expect(styles).toContain('width: calc(100% - 32px) !important;');
         expect(styles).toContain('.lap-column-availability-summary');
-        expect(styles).toContain('.lap-column-option-availability');
         expect(styles).toContain(".lap-selected-summary-row .mat-mdc-footer-cell");
         expect(styles).toContain("font-family: 'Barlow Condensed', 'Inter', sans-serif;");
     });
@@ -827,7 +826,8 @@ describe('EventCardLapsComponent', () => {
         expect(template).toContain('group.selectedUnavailableMetricCount');
         expect(template).toContain('group.metricAvailability[metric.type]?.label');
         expect(template).toContain('unavailable in these laps and hidden from the table');
-        expect(template).toContain('lap-column-option-availability');
+        expect(template).toContain('matListItemTitle');
+        expect(template).toContain('matListItemLine');
         expect(template).toContain('No matching metrics.');
         expect(template).toContain('row.isLapAverage');
         expect(template).toContain('lap-average-row');

--- a/src/app/components/event/laps/event.card.laps.component.ts
+++ b/src/app/components/event/laps/event.card.laps.component.ts
@@ -52,9 +52,17 @@ interface LapColumnMenuGroup {
   label: string;
   icon: string;
   selectedMetricTypes: string[];
+  metricAvailability: Record<string, LapMetricAvailability>;
+  selectedUnavailableMetricCount: number;
   metricGroups: EventLapMetricOptionGroup[];
   filteredMetricGroups: EventLapMetricOptionGroup[];
   searchTerm: string;
+}
+
+interface LapMetricAvailability {
+  availableTableCount: number;
+  tableCount: number;
+  label: string | null;
 }
 
 interface LapTableView {
@@ -420,13 +428,24 @@ export class EventCardLapsComponent extends DataTableAbstractDirective implement
     this.lapColumnMenuGroups = Array.from(sportFamilies).map((family) => {
       const presentation = getEventLapSportFamilyPresentation(family);
       const existingGroup = existingGroupsByFamily.get(family);
+      const selectedMetricTypes = getSelectedEventLapMetricTypes(
+        this.eventDetailsSettings,
+        family,
+      );
+      const metricAvailability = this.getLapMetricAvailability(
+        family,
+        metricGroups,
+        new Set(selectedMetricTypes),
+      );
+      const selectedUnavailableMetricCount = selectedMetricTypes.filter((metricType) => (
+        metricAvailability[metricType]?.availableTableCount === 0
+      )).length;
       if (existingGroup) {
         existingGroup.label = presentation.label;
         existingGroup.icon = presentation.icon;
-        existingGroup.selectedMetricTypes = getSelectedEventLapMetricTypes(
-          this.eventDetailsSettings,
-          family,
-        );
+        existingGroup.selectedMetricTypes = selectedMetricTypes;
+        existingGroup.metricAvailability = metricAvailability;
+        existingGroup.selectedUnavailableMetricCount = selectedUnavailableMetricCount;
         existingGroup.metricGroups = metricGroups;
         existingGroup.filteredMetricGroups = filterLapMetricGroups(
           metricGroups,
@@ -439,7 +458,9 @@ export class EventCardLapsComponent extends DataTableAbstractDirective implement
         family,
         label: presentation.label,
         icon: presentation.icon,
-        selectedMetricTypes: getSelectedEventLapMetricTypes(this.eventDetailsSettings, family),
+        selectedMetricTypes,
+        metricAvailability,
+        selectedUnavailableMetricCount,
         metricGroups,
         filteredMetricGroups: metricGroups,
         searchTerm: '',
@@ -448,6 +469,31 @@ export class EventCardLapsComponent extends DataTableAbstractDirective implement
     this.activeLapColumnMenuGroup = this.lapColumnMenuGroups.find(
       (group) => group.family === activeFamily,
     ) || this.lapColumnMenuGroups[0] || null;
+  }
+
+  private getLapMetricAvailability(
+    family: AppEventLapSportFamily,
+    metricGroups: EventLapMetricOptionGroup[],
+    selectedMetricTypes: ReadonlySet<string>,
+  ): Record<string, LapMetricAvailability> {
+    const tables = this.lapTableGroups
+      .flatMap((lapTableGroup) => lapTableGroup.tables)
+      .filter((table) => resolveEventLapSportFamily(table.activity.type) === family);
+    const tableCount = tables.length;
+
+    return Object.fromEntries(metricGroups
+      .flatMap((metricGroup) => metricGroup.metrics)
+      .map(({ type }) => {
+        const availableTableCount = tables.filter((table) => table.columns.includes(type)).length;
+        const label = !selectedMetricTypes.has(type)
+          ? null
+          : availableTableCount === 0
+          ? 'No data in current laps — hidden from the table'
+          : availableTableCount < tableCount
+            ? `Available in ${availableTableCount} of ${tableCount} lap tables`
+            : null;
+        return [type, { availableTableCount, tableCount, label }];
+      }));
   }
 
   private getSelectedLapKeysByTable(): Map<string, Set<string>> {

--- a/src/app/shared/help.content.spec.ts
+++ b/src/app/shared/help.content.spec.ts
@@ -556,6 +556,8 @@ describe('help.content', () => {
     expect(gettingStartedSection?.content).toContain('checkboxes beside lap rows');
     expect(gettingStartedSection?.content).toContain('**Selected avg · N** footer');
     expect(gettingStartedSection?.content).toContain('distance-weighted pace and duration-weighted speed');
+    expect(gettingStartedSection?.content).toContain('A saved lap column stays selected even when the current laps do not contain that metric');
+    expect(gettingStartedSection?.content).toContain('available in only some of the current lap tables');
     expect(gettingStartedSection?.content).toContain('Satellite diagnostics and EHPE/EVPE position-error metrics');
     expect(gettingStartedSection?.content).toContain('Missing values stay unavailable rather than becoming zero');
   });

--- a/src/app/shared/help.content.ts
+++ b/src/app/shared/help.content.ts
@@ -375,6 +375,7 @@ export const HELP_SECTIONS: HelpSection[] = [
 - Running and trail-running laps use pace, cycling laps use speed, and swimming laps use swim pace. These values, along with other convertible metrics, follow your unit preferences in **Settings -> Units**.
 - Each lap table includes a persistent **Avg** row directly below its headers, with averageable lap metrics in their matching columns and using those same units. Accumulated totals, such as duration, distance, elevation, energy, and work, are not averaged.
 - Use the checkboxes beside lap rows to compare a temporary selection. A sticky **Selected avg · N** footer appears while rows are selected and averages the selected values in the visible columns. It includes how many selected laps contributed to each value, uses distance-weighted pace and duration-weighted speed where appropriate, and disappears when the selection is cleared.
+- A saved lap column stays selected even when the current laps do not contain that metric. The column chooser marks it as unavailable and hidden from the table, or shows when it is available in only some of the current lap tables.
 - Satellite diagnostics and EHPE/EVPE position-error metrics are intentionally left out of the column picker. Related Average, Minimum, and Maximum values are grouped under their shared metric name.
 - The menu includes the Event Summary metric families, but a column appears only when a current lap has a valid value. Missing values stay unavailable rather than becoming zero.
 


### PR DESCRIPTION
## Summary
- retain saved lap columns when a selected activity has no data for them
- mark selected unavailable and partly available metrics in the column picker
- use Material two-line options for readable availability descriptions

## Verification
- `npx vitest run src/app/components/event/laps/event.card.laps.component.spec.ts src/app/shared/help.content.spec.ts --reporter=verbose`
- `npm run lint`
- `npm run build`
- `npm run hooks:mcp:pre-push`