### PR TITLE
fix: nest Plans navigation beneath Training

### DIFF
--- a/docs/frontend-ui.md
+++ b/docs/frontend-ui.md
@@ -40,6 +40,13 @@ alongside the route-specific class; do not add another outer width, margin, or p
 Settings intentionally retains its centered 760 px form column, including its aligned fixed save action, rather than
 stretching a form workflow across the workspace width.
 
+## Sidebar navigation
+
+Training remains a direct link to `/training`. Plans is an indented subitem immediately below it in a labelled Training
+group, without an expansion control. Only the Plans entry uses the Training Planning navigation UID allowlist;
+other signed-in users retain the direct Training link. This presentation hierarchy does not change `/plans`, Calendar
+entry points, or owner-scoped planning access. Each link keeps its own active state and existing close/haptic action.
+
 ## Material and accessibility
 
 Use Angular Material controls for header actions: `mat-icon-button` for icon-only navigation, `mat-button` for secondary

--- a/src/app/components/sidenav/sidenav.component.html
+++ b/src/app/components/sidenav/sidenav.component.html
@@ -50,17 +50,19 @@
     <span>Calendar</span>
   </mat-list-item>
 
-  @if (hasTrainingPlanningNavigationAccess()) {
-    <mat-list-item routerLinkActive="active" routerLink="/plans" (click)="closeSideNav()">
-      <mat-icon>event_note</mat-icon>
-      <span>Plans</span>
+  <div role="group" aria-label="Training">
+    <mat-list-item routerLinkActive="active" routerLink="/training" (click)="closeSideNav()">
+      <mat-icon>monitoring</mat-icon>
+      <span>Training</span>
     </mat-list-item>
-  }
 
-  <mat-list-item routerLinkActive="active" routerLink="/training" (click)="closeSideNav()">
-    <mat-icon>monitoring</mat-icon>
-    <span>Training</span>
-  </mat-list-item>
+    @if (hasTrainingPlanningNavigationAccess()) {
+      <mat-list-item class="sidenav-subitem" routerLinkActive="active" routerLink="/plans" (click)="closeSideNav()">
+        <mat-icon>event_note</mat-icon>
+        <span>Plans</span>
+      </mat-list-item>
+    }
+  </div>
 
   <mat-list-item routerLinkActive="active" routerLink="/health" (click)="closeSideNav()">
     <mat-icon>cardiology</mat-icon>

--- a/src/app/components/sidenav/sidenav.component.scss
+++ b/src/app/components/sidenav/sidenav.component.scss
@@ -202,6 +202,10 @@ mat-list-item {
   width: 100%;
 }
 
+mat-list-item.sidenav-subitem {
+  padding-inline-start: 40px;
+}
+
 :host ::ng-deep mat-list-item:not(.theme-toggle-item) .mat-mdc-list-item-unscoped-content {
   display: flex;
   align-items: center;

--- a/src/app/components/sidenav/sidenav.component.spec.ts
+++ b/src/app/components/sidenav/sidenav.component.spec.ts
@@ -312,7 +312,7 @@ describe('SideNavComponent', () => {
         expect(healthItem).toBeUndefined();
     });
 
-    it('shows Plans navigation to the staged Training Planning user', () => {
+    it('shows Plans beneath the direct Training link for the staged user and closes on selection', () => {
         mockUserService.user = vi.fn().mockReturnValue({
             uid: TRAINING_PLANNING_NAVIGATION_ALLOWED_UID,
             displayName: 'Athlete',
@@ -326,6 +326,13 @@ describe('SideNavComponent', () => {
 
         expect(plansItem).toBeTruthy();
         expect(plansItem?.nativeElement.getAttribute('routerlink')).toBe('/plans');
+        const trainingGroup = fixture.nativeElement.querySelector('[role="group"][aria-label="Training"]');
+        expect(plansItem?.nativeElement.parentElement).toBe(trainingGroup);
+        expect(plansItem?.nativeElement.previousElementSibling?.getAttribute('routerlink')).toBe('/training');
+        expect(mockHapticsService.selection).not.toHaveBeenCalled();
+        plansItem!.triggerEventHandler('click');
+        expect(mockSideNavService.close).toHaveBeenCalledOnce();
+        expect(mockHapticsService.selection).toHaveBeenCalledOnce();
     });
 
     it('silently hides Plans navigation from signed-in users outside the staged rollout', () => {
@@ -392,8 +399,8 @@ describe('SideNavComponent', () => {
         expect([
             navigationItems.indexOf(dashboardItem!),
             navigationItems.indexOf(calendarItem!),
-            navigationItems.indexOf(plansItem!),
             navigationItems.indexOf(trainingItem!),
+            navigationItems.indexOf(plansItem!),
             navigationItems.indexOf(healthItem!),
             navigationItems.indexOf(routesItem!),
             navigationItems.indexOf(myTracksItem!),

--- a/src/app/shared/help.content.ts
+++ b/src/app/shared/help.content.ts
@@ -156,7 +156,7 @@ const TRAINING_ANALYSIS_HELP_CONTENT = `## What Training is for
 
 const TRAINING_PLANS_HELP_CONTENT = `## Plan without a connected service
 
-- Open [Plans](/plans) to create a dated workout. You do not need to create a plan first: choose **Standalone** to keep the workout independent, or use the active plan when you want it grouped into a date range.
+- Open [Plans](/plans) to create a dated workout. Its sidebar entry sits beneath **Training**. You do not need to create a plan first: choose **Standalone** to keep the workout independent, or use the active plan when you want it grouped into a date range.
 - Manual planning is available without a provider connection. Sending planned workouts to Garmin, COROS, Wahoo, or Suunto is not enabled yet; connecting a service does not send anything automatically.
 - The first editor supports Running and Cycling, date-only scheduling, time or distance steps, fixed repeats, and one absolute heart-rate, power, or pace target per step. Unsupported recipe features remain unavailable instead of being approximated.
 


### PR DESCRIPTION
Moves Plans from the top-level sidebar into an indented subitem directly beneath Training. Training remains a direct link, and the Plans entry keeps its existing UID visibility rule, route, active state, and selection haptics.

Adds an accessible Training group and updates the sidebar guidance in Help and the frontend documentation.

Follow-up to #658; related to epic #583.

## Verification

- Sidenav and Help suites: 77 tests passed, covering navigation order, UID visibility, grouping, and selection feedback.
- Angular lint passed.
- Pre-push Functions build, MCP compatibility check, and 85 contract tests passed.
- Production build, service-worker asset checks, and prerendered-page verification passed; the build emits CSS-budget and CommonJS warnings.
